### PR TITLE
capture logs from ECS tasks into CloudWatch

### DIFF
--- a/terraform/projects/app-ecs-services/git-puller.tf
+++ b/terraform/projects/app-ecs-services/git-puller.tf
@@ -3,9 +3,18 @@
 *
 */
 
+data "template_file" "git_puller_container_defn" {
+  template = "${file("task-definitions/git-puller.json")}"
+
+  vars {
+    log_group = "${aws_cloudwatch_log_group.task_logs.name}"
+    region    = "${var.aws_region}"
+  }
+}
+
 resource "aws_ecs_task_definition" "git_puller" {
   family                = "git-puller"
-  container_definitions = "${file("task-definitions/git-puller.json")}"
+  container_definitions = "${data.template_file.git_puller_container_defn.rendered}"
 
   volume {
     name      = "pulled-config"

--- a/terraform/projects/app-ecs-services/main.tf
+++ b/terraform/projects/app-ecs-services/main.tf
@@ -82,9 +82,6 @@ data "terraform_remote_state" "app_ecs_albs" {
 resource "aws_cloudwatch_log_group" "task_logs" {
   name = "${var.stack_name}"
   retention_in_days = 7
-  tags = {
-    Environment = "${var.stack_name}"
-  }
 }
 
 ## Outputs

--- a/terraform/projects/app-ecs-services/main.tf
+++ b/terraform/projects/app-ecs-services/main.tf
@@ -41,6 +41,10 @@ provider "aws" {
   region  = "${var.aws_region}"
 }
 
+provider "template" {
+  version = "~> 1.0.0"
+}
+
 ## Data sources
 
 data "terraform_remote_state" "infra_networking" {
@@ -75,6 +79,13 @@ data "terraform_remote_state" "app_ecs_albs" {
 
 ## Resources
 
+resource "aws_cloudwatch_log_group" "task_logs" {
+  name = "${var.stack_name}"
+  retention_in_days = 7
+  tags = {
+    Environment = "${var.stack_name}"
+  }
+}
 
 ## Outputs
 

--- a/terraform/projects/app-ecs-services/prometheus-service.tf
+++ b/terraform/projects/app-ecs-services/prometheus-service.tf
@@ -3,9 +3,18 @@
 *
 */
 
+data "template_file" "prometheus_container_defn" {
+  template = "${file("task-definitions/prometheus-server.json")}"
+
+  vars {
+    log_group = "${aws_cloudwatch_log_group.task_logs.name}"
+    region    = "${var.aws_region}"
+  }
+}
+
 resource "aws_ecs_task_definition" "prometheus_server" {
   family                = "${var.stack_name}-prometheus-server"
-  container_definitions = "${file("task-definitions/prometheus-server.json")}"
+  container_definitions = "${data.template_file.prometheus_container_defn.rendered}"
 
   volume {
     name      = "prometheus-config"

--- a/terraform/projects/app-ecs-services/task-definitions/git-puller.json
+++ b/terraform/projects/app-ecs-services/task-definitions/git-puller.json
@@ -16,7 +16,8 @@
       "logDriver": "awslogs",
       "options": {
         "awslogs-group": "${log_group}",
-        "awslogs-region": "${region}"
+        "awslogs-region": "${region}",
+        "awslogs-stream-prefix": "git-puller"
       }
     }
   }

--- a/terraform/projects/app-ecs-services/task-definitions/git-puller.json
+++ b/terraform/projects/app-ecs-services/task-definitions/git-puller.json
@@ -16,8 +16,7 @@
       "logDriver": "awslogs",
       "options": {
         "awslogs-group": "${log_group}",
-        "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "git-puller"
+        "awslogs-region": "${region}"
       }
     }
   }

--- a/terraform/projects/app-ecs-services/task-definitions/git-puller.json
+++ b/terraform/projects/app-ecs-services/task-definitions/git-puller.json
@@ -11,6 +11,14 @@
         "containerPath": "/configs"
       }
     ],
-    "command": ["clone", "https://github.com/alphagov/prometheus-config.git", "/configs"]
+    "command": ["clone", "https://github.com/alphagov/prometheus-config.git", "/configs"],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${log_group}",
+        "awslogs-region": "${region}",
+        "awslogs-stream-prefix": "git-puller"
+      }
+    }
   }
 ]

--- a/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json
+++ b/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json
@@ -20,6 +20,14 @@
         "sourceVolume": "alert-config",
         "containerPath": "/etc/prometheus/alerts/alerts.default"
       }
-    ]
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${log_group}",
+        "awslogs-region": "${region}",
+        "awslogs-stream-prefix": "prometheus"
+      }
+    }
   }
 ]

--- a/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json
+++ b/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json
@@ -25,7 +25,8 @@
       "logDriver": "awslogs",
       "options": {
         "awslogs-group": "${log_group}",
-        "awslogs-region": "${region}"
+        "awslogs-region": "${region}",
+        "awslogs-stream-prefix": "prometheus"
       }
     }
   }

--- a/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json
+++ b/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json
@@ -25,8 +25,7 @@
       "logDriver": "awslogs",
       "options": {
         "awslogs-group": "${log_group}",
-        "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "prometheus"
+        "awslogs-region": "${region}"
       }
     }
   }


### PR DESCRIPTION
this creates a cloudwatch logs group for the stack, and ships logs
from each of our ECS tasks into CloudWatch.  This means that when a
task fails, we can get the output from the command and see what
exactly went wrong!