### PR TITLE
Persistent storage

### DIFF
--- a/terraform/projects/app-ecs-instances/ecs-iam-policy.tf
+++ b/terraform/projects/app-ecs-instances/ecs-iam-policy.tf
@@ -31,6 +31,12 @@ data "aws_iam_policy_document" "ecs_instance_document" {
     resources = ["*"]
 
     actions = [
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:AttachNetworkInterface",
+      "ec2:AttachVolume",
+      "ec2:DetachVolume",
+      "ec2:DescribeVolumeStatus",
+      "ec2:DescribeVolumes",
       "ecs:CreateCluster",
       "ecs:DeregisterContainerInstance",
       "ecs:DiscoverPollEndpoint",

--- a/terraform/projects/app-ecs-instances/ecs-iam-policy.tf
+++ b/terraform/projects/app-ecs-instances/ecs-iam-policy.tf
@@ -48,8 +48,14 @@ data "aws_iam_policy_document" "ecs_instance_document" {
       "logs:createlogstream",
       "logs:putlogevents",
     ]
+  }
 
-    resources = ["arn:aws:ec2:${var.aws_region}:${var.account_id}:volume/${aws_ebs_volume.prometheus_ebs_volume.id}"]
+  statement {
+    resources = [
+      "arn:aws:ec2:${var.aws_region}:${var.account_id}:volume/${aws_ebs_volume.prometheus_ebs_volume.id}",
+      "arn:aws:ec2:${var.aws_region}:${var.account_id}:instance/*"
+    ]
+
 
     actions = [
       "ec2:AttachVolume",

--- a/terraform/projects/app-ecs-instances/ecs-iam-policy.tf
+++ b/terraform/projects/app-ecs-instances/ecs-iam-policy.tf
@@ -26,36 +26,36 @@ EOF
 
 data "aws_iam_policy_document" "ecs_instance_document" {
   statement {
-    sid       = "ECSInstancePolicy"
+    sid = "ECSInstancePolicy"
+
     resources = ["*"]
 
     actions = [
-      "ec2:describenetworkinterfaces",
-      "ec2:attachnetworkinterface",
-      "ec2:describevolumestatus",
-      "ec2:describevolumes",
-      "ecs:createcluster",
-      "ecs:deregistercontainerinstance",
-      "ecs:discoverpollendpoint",
-      "ecs:poll",
-      "ecs:registercontainerinstance",
-      "ecs:starttelemetrysession",
-      "ecs:submit*",
-      "ecr:getauthorizationtoken",
-      "ecr:batchchecklayeravailability",
-      "ecr:getdownloadurlforlayer",
-      "ecr:batchgetimage",
-      "logs:createlogstream",
-      "logs:putlogevents",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:AttachNetworkInterface",
+      "ec2:DescribeVolumeStatus",
+      "ec2:DescribeVolumes",
+      "ecs:CreateCluster",
+      "ecs:DeregisterContainerInstance",
+      "ecs:DiscoverPollEndpoint",
+      "ecs:Poll",
+      "ecs:RegisterContainerInstance",
+      "ecs:StartTelemetrySession",
+      "ecs:Submit*",
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
     ]
   }
 
   statement {
     resources = [
       "arn:aws:ec2:${var.aws_region}:${var.account_id}:volume/${aws_ebs_volume.prometheus_ebs_volume.id}",
-      "arn:aws:ec2:${var.aws_region}:${var.account_id}:instance/*"
+      "arn:aws:ec2:${var.aws_region}:${var.account_id}:instance/*",
     ]
-
 
     actions = [
       "ec2:AttachVolume",

--- a/terraform/projects/app-ecs-instances/ecs-iam-policy.tf
+++ b/terraform/projects/app-ecs-instances/ecs-iam-policy.tf
@@ -26,30 +26,34 @@ EOF
 
 data "aws_iam_policy_document" "ecs_instance_document" {
   statement {
-    sid = "ECSInstancePolicy"
-
+    sid       = "ECSInstancePolicy"
     resources = ["*"]
 
     actions = [
-      "ec2:DescribeNetworkInterfaces",
-      "ec2:AttachNetworkInterface",
+      "ec2:describenetworkinterfaces",
+      "ec2:attachnetworkinterface",
+      "ec2:describevolumestatus",
+      "ec2:describevolumes",
+      "ecs:createcluster",
+      "ecs:deregistercontainerinstance",
+      "ecs:discoverpollendpoint",
+      "ecs:poll",
+      "ecs:registercontainerinstance",
+      "ecs:starttelemetrysession",
+      "ecs:submit*",
+      "ecr:getauthorizationtoken",
+      "ecr:batchchecklayeravailability",
+      "ecr:getdownloadurlforlayer",
+      "ecr:batchgetimage",
+      "logs:createlogstream",
+      "logs:putlogevents",
+    ]
+
+    resources = ["arn:aws:ec2:${var.aws_region}:${var.account_id}:volume/${aws_ebs_volume.prometheus_ebs_volume.id}"]
+
+    actions = [
       "ec2:AttachVolume",
       "ec2:DetachVolume",
-      "ec2:DescribeVolumeStatus",
-      "ec2:DescribeVolumes",
-      "ecs:CreateCluster",
-      "ecs:DeregisterContainerInstance",
-      "ecs:DiscoverPollEndpoint",
-      "ecs:Poll",
-      "ecs:RegisterContainerInstance",
-      "ecs:StartTelemetrySession",
-      "ecs:Submit*",
-      "ecr:GetAuthorizationToken",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
     ]
   }
 }

--- a/terraform/projects/app-ecs-instances/ecs-iam-policy.tf
+++ b/terraform/projects/app-ecs-instances/ecs-iam-policy.tf
@@ -24,6 +24,8 @@ resource "aws_iam_role" "instance_iam_role" {
 EOF
 }
 
+data "aws_caller_identity" "current" {}
+
 data "aws_iam_policy_document" "ecs_instance_document" {
   statement {
     sid = "ECSInstancePolicy"
@@ -53,8 +55,8 @@ data "aws_iam_policy_document" "ecs_instance_document" {
 
   statement {
     resources = [
-      "arn:aws:ec2:${var.aws_region}:${var.account_id}:volume/${aws_ebs_volume.prometheus_ebs_volume.id}",
-      "arn:aws:ec2:${var.aws_region}:${var.account_id}:instance/*",
+      "${aws_ebs_volume.prometheus_ebs_volume.arn}",
+      "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*",
     ]
 
     actions = [

--- a/terraform/projects/app-ecs-instances/ecs-iam-policy.tf
+++ b/terraform/projects/app-ecs-instances/ecs-iam-policy.tf
@@ -33,10 +33,6 @@ data "aws_iam_policy_document" "ecs_instance_document" {
     resources = ["*"]
 
     actions = [
-      "ec2:DescribeNetworkInterfaces",
-      "ec2:AttachNetworkInterface",
-      "ec2:DescribeVolumeStatus",
-      "ec2:DescribeVolumes",
       "ecs:CreateCluster",
       "ecs:DeregisterContainerInstance",
       "ecs:DiscoverPollEndpoint",

--- a/terraform/projects/app-ecs-instances/instance-user-data.tpl
+++ b/terraform/projects/app-ecs-instances/instance-user-data.tpl
@@ -25,17 +25,17 @@ while [[ $x -lt 15 ]]; do
 done
 
 # Format and mount volume
-if sudo file -s /dev/$DEVICE | grep -q "/dev/$DEVICE: data"; then
+if file -s /dev/$DEVICE | grep -q "/dev/$DEVICE: data"; then
   echo "[$(date '+%H:%M:%S %d-%m-%Y')] attach-volume: /dev/$DEVICE does not contain any partition, beginning to format disk"
-  sudo mkfs -t ext4 /dev/$DEVICE
+  mkfs -t ext4 /dev/$DEVICE
 else
   echo "[$(date '+%H:%M:%S %d-%m-%Y')] attach-volume: /dev/$DEVICE is already formatted: $(file -s /dev/$DEVICE)"
 fi
 
 # Allow prometheus container user access to read/write/execute within container
-sudo mkdir -p /ecs/prometheus_data
-sudo mount /dev/$DEVICE /ecs/prometheus_data
-sudo chmod 777 /ecs/prometheus_data
+mkdir -p /ecs/prometheus_data
+mount /dev/$DEVICE /ecs/prometheus_data
+chmod 777 /ecs/prometheus_data
 
 # Set any ECS agent configuration options
 echo 'ECS_CLUSTER=${cluster_name}' >> /etc/ecs/ecs.config

--- a/terraform/projects/app-ecs-instances/instance-user-data.tpl
+++ b/terraform/projects/app-ecs-instances/instance-user-data.tpl
@@ -1,6 +1,29 @@
 #!/bin/bash
+# Attach EBS volume to instance
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] installing dependencies for volume attaching"
+sudo yum install -y aws-cli wget
 
-echo 'ECS_CLUSTER=${cluster_name}' >> /etc/ecs/ecs.config
+REGION="${region}"
+DEVICE="xvdf"
+VOLUME_ID="${volume_id}"
+
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] finding current instance ID"
+INSTANCE_ID="`wget -q -O - http://169.254.169.254/latest/meta-data/instance-id`"
+
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] attaching volume"
+aws ec2 attach-volume --volume-id $VOLUME_ID --instance-id $INSTANCE_ID --device /dev/$DEVICE --region $REGION
+
+# Waiting for volume to finish attaching
+x=0
+while [[ $x -lt 15 ]]; do
+  if ! [[ -e /dev/$DEVICE ]] ; then
+    sleep 1
+  else
+    break
+  fi
+  x=$((x+1))
+done
+
 
 # Set any ECS agent configuration options
 yum install -y ecs-init

--- a/terraform/projects/app-ecs-instances/instance-user-data.tpl
+++ b/terraform/projects/app-ecs-instances/instance-user-data.tpl
@@ -24,8 +24,21 @@ while [[ $x -lt 15 ]]; do
   x=$((x+1))
 done
 
+# Format and mount volume
+if sudo file -s /dev/$DEVICE | grep -q "/dev/$DEVICE: data"; then
+  echo "[$(date '+%H:%M:%S %d-%m-%Y')] attach-volume: /dev/$DEVICE does not contain any partition, beginning to format disk"
+  sudo mkfs -t ext4 /dev/$DEVICE
+else
+  echo "[$(date '+%H:%M:%S %d-%m-%Y')] attach-volume: /dev/$DEVICE is already formatted: $(file -s /dev/$DEVICE)"
+fi
+
+# Allow prometheus container user access to read/write/execute within container
+sudo mkdir -p /ecs/prometheus_data
+sudo mount /dev/$DEVICE /ecs/prometheus_data
+sudo chmod 777 /ecs/prometheus_data
 
 # Set any ECS agent configuration options
+echo 'ECS_CLUSTER=${cluster_name}' >> /etc/ecs/ecs.config
 yum install -y ecs-init
 start ecs
 service docker start

--- a/terraform/projects/app-ecs-instances/main.tf
+++ b/terraform/projects/app-ecs-instances/main.tf
@@ -5,6 +5,12 @@
 *
 */
 
+variable "account_id" {
+  type        = "string"
+  description = "Our AWS account ID"
+  default     = "0"
+}
+
 variable "additional_tags" {
   type        = "map"
   description = "Stack specific tags to apply"
@@ -190,7 +196,7 @@ resource "aws_ebs_volume" "prometheus_ebs_volume" {
   type              = "gp2"
 
   lifecycle {
-    prevent_destroy = true
+    prevent_destroy = false
   }
 
   tags = "${merge(

--- a/terraform/projects/app-ecs-instances/main.tf
+++ b/terraform/projects/app-ecs-instances/main.tf
@@ -196,7 +196,7 @@ resource "aws_ebs_volume" "prometheus_ebs_volume" {
   type              = "gp2"
 
   lifecycle {
-    prevent_destroy = false
+    prevent_destroy = true
   }
 
   tags = "${merge(

--- a/terraform/projects/app-ecs-instances/main.tf
+++ b/terraform/projects/app-ecs-instances/main.tf
@@ -5,12 +5,6 @@
 *
 */
 
-variable "account_id" {
-  type        = "string"
-  description = "Our AWS account ID"
-  default     = "0"
-}
-
 variable "additional_tags" {
   type        = "map"
   description = "Stack specific tags to apply"

--- a/terraform/projects/app-ecs-instances/main.tf
+++ b/terraform/projects/app-ecs-instances/main.tf
@@ -138,6 +138,8 @@ data "template_file" "instance_user_data" {
 
   vars {
     cluster_name = "${local.cluster_name}"
+    volume_id    = "${aws_ebs_volume.prometheus_ebs_volume.id}"
+    region       = "${var.aws_region}"
   }
 }
 
@@ -179,6 +181,23 @@ module "ecs_instance" {
     var.additional_tags,
     map("Stackname", "${var.stack_name}"),
     map("Name", "${var.stack_name}-ecs-instance")
+  )}"
+}
+
+resource "aws_ebs_volume" "prometheus_ebs_volume" {
+  availability_zone = "${element(data.terraform_remote_state.infra_networking.az_names, 0)}"
+  size              = 500
+  type              = "gp2"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = "${merge(
+    local.default_tags,
+    var.additional_tags,
+    map("Stackname", "${var.stack_name}"),
+    map("Name", "${var.stack_name}-prometheus-ebs-volume")
   )}"
 }
 

--- a/terraform/projects/app-ecs-services/prometheus-service.tf
+++ b/terraform/projects/app-ecs-services/prometheus-service.tf
@@ -90,6 +90,7 @@ resource "aws_ecs_task_definition" "prometheus_server" {
     host_path = "/ecs/config-from-s3/prometheus"
   }
 
+  # We mount this at /prometheus which is the expected location for the prom/prometheus docker image
   volume {
     name      = "prometheus-timeseries-storage"
     host_path = "/ecs/prometheus_data"

--- a/terraform/projects/app-ecs-services/prometheus-service.tf
+++ b/terraform/projects/app-ecs-services/prometheus-service.tf
@@ -89,6 +89,11 @@ resource "aws_ecs_task_definition" "prometheus_server" {
     name      = "prometheus-config"
     host_path = "/ecs/config-from-s3/prometheus"
   }
+
+  volume {
+    name      = "prometheus-timeseries-storage"
+    host_path = "/ecs/prometheus_data"
+  }
 }
 
 resource "aws_ecs_service" "prometheus_server" {

--- a/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json
+++ b/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json
@@ -16,6 +16,7 @@
         "containerPath": "/etc/prometheus"
       },
       {
+        "__comment": "/prometheus is the default path that prometheus uses to store timeseries",
         "sourceVolume": "prometheus-timeseries-storage",
         "containerPath": "/prometheus"
       }

--- a/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json
+++ b/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json
@@ -14,6 +14,10 @@
       {
         "sourceVolume": "prometheus-config",
         "containerPath": "/etc/prometheus"
+      },
+      {
+        "sourceVolume": "prometheus-timeseries-storage",
+        "containerPath": "/prometheus"
       }
     ],
     "logConfiguration": {

--- a/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json
+++ b/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json
@@ -16,7 +16,6 @@
         "containerPath": "/etc/prometheus"
       },
       {
-        "__comment": "/prometheus is the default path that prometheus uses to store timeseries",
         "sourceVolume": "prometheus-timeseries-storage",
         "containerPath": "/prometheus"
       }

--- a/terraform/projects/infra-networking/README.md
+++ b/terraform/projects/infra-networking/README.md
@@ -17,6 +17,7 @@ related services. You will often have multiple VPCs in an account
 
 | Name | Description |
 |------|-------------|
+| az_names | Names of available availability zones |
 | private_subnets | List of private subnet IDs |
 | public_subnets | List of public subnet IDs |
 | vpc_id | VPC ID where the stack resources are created |

--- a/terraform/projects/infra-networking/main.tf
+++ b/terraform/projects/infra-networking/main.tf
@@ -82,6 +82,11 @@ module "vpc" {
 
 ## Outputs
 
+output "az_names" {
+  value       = "${data.aws_availability_zones.available.names}"
+  description = "Names of available availability zones"
+}
+
 output "vpc_id" {
   value       = "${module.vpc.vpc_id}"
   description = "VPC ID where the stack resources are created"


### PR DESCRIPTION
https://trello.com/c/ak0GUE0i/386-add-persistent-storage-for-prometheus

This adds the necessary terraform to initialise and format an EBS volume to be used for the persistent storage for our Prometheis. This means that in the event that an EC2 instance goes down we will retain metrics that have been gathered on it. 
