### PR TITLE
use nginx for prometheus basic auth

### DIFF
--- a/terraform/projects/app-ecs-albs/main.tf
+++ b/terraform/projects/app-ecs-albs/main.tf
@@ -108,7 +108,7 @@ resource "aws_lb_target_group" "monitoring_external_tg" {
 
   health_check {
     interval            = "10"
-    path                = "/graph" # path chosen that 200s as '/' does not return 200
+    path                = "/health" # static health check on nginx auth proxy
     matcher             = "200"
     protocol            = "HTTP"
     healthy_threshold   = 2

--- a/terraform/projects/app-ecs-services/config/prometheus.yml
+++ b/terraform/projects/app-ecs-services/config/prometheus.yml
@@ -13,7 +13,7 @@ scrape_configs:
       - targets: ['localhost:9090']
   - job_name: paas-targets
     scheme: http
-    proxy_url: 'http://metrics-nginx.sd.ecs-monitoring.com:8080'
+    proxy_url: 'http://paas-proxy:8080'
     file_sd_configs:
       - files: ['/etc/prometheus/targets/*.json']
         refresh_interval: 30s

--- a/terraform/projects/app-ecs-services/config/vhosts/.htpasswd
+++ b/terraform/projects/app-ecs-services/config/vhosts/.htpasswd
@@ -1,0 +1,1 @@
+grafana:$2y$05$KtkeBzc53efo5u10r3A1gexcml34YiMNVtKd8CqaXPEac4hELCERK

--- a/terraform/projects/app-ecs-services/config/vhosts/auth-proxy.conf
+++ b/terraform/projects/app-ecs-services/config/vhosts/auth-proxy.conf
@@ -1,0 +1,16 @@
+server {
+  listen 9090 default_server;
+  auth_basic "Prometheus";
+  auth_basic_user_file /etc/nginx/conf.d/.htpasswd;
+
+  location / {
+    proxy_pass  http://prometheus:9090;
+  }
+  location /status {
+    auth_basic off;
+    proxy_pass http://prometheus:9090/status;
+  }
+  location /health {
+    return 200 "Static health check";
+  }
+}

--- a/terraform/projects/app-ecs-services/config/vhosts/paas-proxy.conf
+++ b/terraform/projects/app-ecs-services/config/vhosts/paas-proxy.conf
@@ -1,0 +1,10 @@
+server {
+  listen 8080;
+
+  location / {
+    proxy_pass https://$host$uri;
+    proxy_ssl_server_name on;
+    proxy_set_header X-CF-APP-INSTANCE $arg_cf_app_guid:$arg_cf_app_instance_index;
+    proxy_set_header Authorization "Bearer $arg_cf_app_guid";
+  }
+}

--- a/terraform/projects/app-ecs-services/prometheus-service.tf
+++ b/terraform/projects/app-ecs-services/prometheus-service.tf
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "prometheus_policy_doc" {
   statement {
     sid = "GetPrometheusFiles"
 
-    resources = ["arn:aws:s3:::${aws_s3_bucket.config_bucket.id}/etc/prometheus/*"]
+    resources = ["arn:aws:s3:::${aws_s3_bucket.config_bucket.id}/prometheus/*"]
 
     actions = [
       "s3:Get*",
@@ -90,6 +90,11 @@ resource "aws_ecs_task_definition" "prometheus_server" {
     host_path = "/ecs/config-from-s3/prometheus"
   }
 
+  volume {
+    name      = "nginx-vhosts"
+    host_path = "/ecs/config-from-s3/nginx/conf.d"
+  }
+
   # We mount this at /prometheus which is the expected location for the prom/prometheus docker image
   volume {
     name      = "prometheus-timeseries-storage"
@@ -105,14 +110,33 @@ resource "aws_ecs_service" "prometheus_server" {
 
   load_balancer {
     target_group_arn = "${data.terraform_remote_state.app_ecs_albs.monitoring_external_tg}"
-    container_name   = "prometheus"
+    container_name   = "nginx"
     container_port   = 9090
   }
 }
 
 resource "aws_s3_bucket_object" "prometheus-config" {
   bucket = "${aws_s3_bucket.config_bucket.id}"
-  key    = "etc/prometheus/prometheus.yml"
+  key    = "prometheus/prometheus/prometheus.yml"
   source = "config/prometheus.yml"
   etag   = "${md5(file("config/prometheus.yml"))}"
+}
+
+#### nginx reverse proxy
+
+resource "aws_s3_bucket_object" "nginx-reverse-proxy" {
+  bucket = "${aws_s3_bucket.config_bucket.id}"
+  key    = "prometheus/nginx/conf.d/prometheus-auth-proxy.conf"
+  source = "config/vhosts/auth-proxy.conf"
+  etag   = "${md5(file("config/vhosts/auth-proxy.conf"))}"
+}
+
+# The htpasswd file is in bcrypt format, which is only supported
+# by the nginx:alpine image, not the plain nginx image
+# https://github.com/nginxinc/docker-nginx/issues/29
+resource "aws_s3_bucket_object" "nginx-htpasswd" {
+  bucket = "${aws_s3_bucket.config_bucket.id}"
+  key    = "prometheus/nginx/conf.d/.htpasswd"
+  source = "config/vhosts/.htpasswd"
+  etag   = "${md5(file("config/vhosts/.htpasswd"))}"
 }

--- a/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json
+++ b/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json
@@ -15,6 +15,9 @@
         "containerPath": "/prometheus"
       }
     ],
+    "links": [
+      "paas-proxy"
+    ],
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {
@@ -27,8 +30,8 @@
   {
     "name": "s3-config-grabber",
     "image": "mesosphere/aws-cli",
-    "cpu": 256,
-    "memory": 256,
+    "cpu": 128,
+    "memory": 128,
     "essential": false,
     "mountPoints": [
       {
@@ -47,10 +50,10 @@
     }
   },
   {
-    "name": "nginx",
+    "name": "auth-proxy",
     "image": "nginx:alpine",
-    "cpu": 256,
-    "memory": 256,
+    "cpu": 128,
+    "memory": 128,
     "essential": true,
     "portMappings": [
       {
@@ -59,13 +62,40 @@
     ],
     "mountPoints": [
       {
-        "sourceVolume": "nginx-vhosts",
+        "sourceVolume": "auth-proxy",
         "containerPath": "/etc/nginx/conf.d",
         "readOnly": true
       }
     ],
     "links": [
       "prometheus"
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${log_group}",
+        "awslogs-region": "${region}",
+        "awslogs-stream-prefix": "prometheus"
+      }
+    }
+  },
+  {
+    "name": "paas-proxy",
+    "image": "nginx:alpine",
+    "cpu": 128,
+    "memory": 128,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 8080
+      }
+    ],
+    "mountPoints": [
+      {
+        "sourceVolume": "paas-proxy",
+        "containerPath": "/etc/nginx/conf.d",
+        "readOnly": true
+      }
     ],
     "logConfiguration": {
       "logDriver": "awslogs",

--- a/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json
+++ b/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json
@@ -2,14 +2,9 @@
   {
     "name": "prometheus",
     "image": "prom/prometheus",
+    "cpu": 1024,
     "memoryReservation": 4096,
     "essential": true,
-    "portMappings": [
-      {
-        "containerPort": 9090,
-        "hostPort": 9090
-      }
-    ],
     "mountPoints": [
       {
         "sourceVolume": "prometheus-config",
@@ -32,6 +27,7 @@
   {
     "name": "s3-config-grabber",
     "image": "mesosphere/aws-cli",
+    "cpu": 256,
     "memory": 256,
     "essential": false,
     "mountPoints": [
@@ -40,7 +36,37 @@
         "containerPath": "/configs"
       }
     ],
-    "command": ["s3", "sync", "s3://${config_bucket}/etc/prometheus", "/configs/prometheus"],
+    "command": ["s3", "sync", "s3://${config_bucket}/prometheus", "/configs"],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${log_group}",
+        "awslogs-region": "${region}",
+        "awslogs-stream-prefix": "prometheus"
+      }
+    }
+  },
+  {
+    "name": "nginx",
+    "image": "nginx:alpine",
+    "cpu": 256,
+    "memory": 256,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 9090
+      }
+    ],
+    "mountPoints": [
+      {
+        "sourceVolume": "nginx-vhosts",
+        "containerPath": "/etc/nginx/conf.d",
+        "readOnly": true
+      }
+    ],
+    "links": [
+      "prometheus"
+    ],
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {


### PR DESCRIPTION
Apologies for the one-massive-commit.  The main thing this does is
adds an nginx authenticating proxy in front of prometheus, that puts
basic auth in place.

This is done by adding an nginx container into the task definition for
prometheus, and using a `link` to allow nginx to access prometheus.

The password is in the credential store.  The password hash is publicly viewable
in this commit; we should probably replace this with a better secret management
policy at some point.

Other things done in this commit:

 - we no longer specify `hostPort` values; we allow ECS to
   automatically assign host ports.  The load balancer can still find
   our container, but we no longer have port conflicts when two
   concurrent versions of the service are deployed

 - reintroduce cpu quotas.  because our instance has a total of 4096
   cpu units available, and the default value is 1024, once we added
   nginx we had 3 containers and therefore couldn't run a new version
   of our service without killing the old version.  Instead we set
   prometheus=1024, s3-config-grabber=256, nginx=256.

 - we use the nginx:alpine image rather than the plain `nginx` image.
   This is for two reasons: 1) it's smaller, and 2) the alpine image
   supports bcrypt:
   https://github.com/docker-library/official-images/issues/860