### PR TITLE
simplify prometheus config

### DIFF
--- a/terraform/projects/app-ecs-services/config/prometheus.yml
+++ b/terraform/projects/app-ecs-services/config/prometheus.yml
@@ -10,28 +10,10 @@ scrape_configs:
   - job_name: prometheus
     scrape_interval: 5s
     static_configs:
-      - targets: ['prometheus-server.sd.ecs-monitoring.com:9090']
+      - targets: ['localhost:9090']
   - job_name: paas-targets
     scheme: http
     proxy_url: 'http://metrics-nginx.sd.ecs-monitoring.com:8080'
     file_sd_configs:
       - files: ['/etc/prometheus/targets/*.json']
         refresh_interval: 30s
-  - job_name: 'HTTP-blackbox-check'
-    metrics_path: /probe
-    params:
-      module: [http_2xx]
-    static_configs:
-      - targets:
-        - https://www.unixdaemon.net
-        - https://dropwizard-example.cloudapps.digital
-        - https://mysql-exporter-paas.cloudapps.digital
-        - https://http-simulator.cloudapps.digital/metrics
-        - https://alerter.cloudapps.digital/
-    relabel_configs:
-      - source_labels: [__address__]
-        target_label: __param_target
-      - source_labels: [__param_target]
-        target_label: instance
-      - target_label: __address__
-        replacement: prometheus-blackbox.sd.ecs-monitoring.com:9115


### PR DESCRIPTION
two things:

 - just use `localhost` for scraping ourselves while we haven't agreed
   on a service discovery solution
 - remove the blackbox stuff as we're not planning to use it