### PR TITLE
hotfix: only use whole directories for volumes, not single files

### DIFF
--- a/terraform/projects/app-ecs-services/prometheus-service.tf
+++ b/terraform/projects/app-ecs-services/prometheus-service.tf
@@ -87,12 +87,7 @@ resource "aws_ecs_task_definition" "prometheus_server" {
 
   volume {
     name      = "prometheus-config"
-    host_path = "/ecs/config-from-s3/prometheus/prometheus.yml"
-  }
-
-  volume {
-    name      = "alert-config"
-    host_path = "/ecs/config-from-s3/prometheus/alerts"
+    host_path = "/ecs/config-from-s3/prometheus"
   }
 }
 

--- a/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json
+++ b/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json
@@ -13,11 +13,7 @@
     "mountPoints": [
       {
         "sourceVolume": "prometheus-config",
-        "containerPath": "/etc/prometheus/prometheus.yml"
-      },
-      {
-        "sourceVolume": "alert-config",
-        "containerPath": "/etc/prometheus/alerts"
+        "containerPath": "/etc/prometheus"
       }
     ],
     "logConfiguration": {


### PR DESCRIPTION
staging is broken, this should fix it hopefully.

We have been seeing issues where the s3-config-grabber task fails with
an error like:

> download failed: s3://$bucketname/etc/prometheus/prometheus.yml to ../configs/prometheus/prometheus.yml [Errno 21] Is a directory

This seems to be related to the fact that the `prometheus-config`
volume maps on to a single file on the host,
/ecs/config-from-s3/prometheus/prometheus.yml.  This commit moves the
volume to the level above, so that `prometheus-config` is the whole
/ecs/config-from-s3/prometheus directory.  (As a result, the
`alert-config` volume goes away.  We might want it, or something
similar, back at some point).

To deploy this fix, we may need to terminate the container instance
and allow the autoscaling group to build a new one, to clean up any
accidentally created /etc/prometheus/prometheus.yml/ directory.