### PR TITLE
Allow "make apply-single" for staging and prod

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -159,11 +159,11 @@ else
                 cd ${ROOTPROJ}
         ;;
         -a) echo "Apply terraform plan to environment: ${ENV}"
-                if [ "${ENV}" = 'staging' -o "${ENV}" = 'production' ] ; then
-                        echo "Cannot run terraform apply all on ${ENV}"
+                if [ $2 ] ; then
+                        apply $2
                 else
-                        if [ $2 ] ; then
-                                apply $2
+                        if [ "${ENV}" = 'staging' -o "${ENV}" = 'production' ] ; then
+                                echo "Cannot run terraform apply all on ${ENV}"
                         else
                                 for folder in ${COMPONENTS[@]}
                                 do 


### PR DESCRIPTION
We don't want people to run `make apply` on staging or prod because of
the higher risks around messing with the lower level networking/vpc
stuff.

However, we should be able to run `make apply-single` in these
environments.