### PR TITLE
shorten deregistration delay to 30 seconds

### DIFF
--- a/terraform/projects/app-ecs-albs/main.tf
+++ b/terraform/projects/app-ecs-albs/main.tf
@@ -101,10 +101,11 @@ resource "aws_lb" "monitoring_external_alb" {
 }
 
 resource "aws_lb_target_group" "monitoring_external_tg" {
-  name     = "${var.stack_name}-ext-tg"
-  port     = 80
-  protocol = "HTTP"
-  vpc_id   = "${data.terraform_remote_state.infra_networking.vpc_id}"
+  name                 = "${var.stack_name}-ext-tg"
+  port                 = 80
+  protocol             = "HTTP"
+  vpc_id               = "${data.terraform_remote_state.infra_networking.vpc_id}"
+  deregistration_delay = 30
 
   health_check {
     interval            = "10"


### PR DESCRIPTION
By default, ALB target groups have a deregistration delay of 300
seconds.  This means that when you kill a task in ECS, it waits for 5
minutes before starting a new task :(

This commit shortens the delay to 30 seconds.  It's a pretty arbitrary
number, which is:

 - short enough to make things less annoying
 - long enough to work with all reasonable-timed requests