### PR TITLE
Add a Jumpbox to dev stacks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,10 @@ destroy-list: ## Destroy terraform for a list of projects, make destroy-list lis
 taint: ## Taint a resource, make taint project=<project name> resource=<resource name>
 	. ./setup.sh -t ${project} ${resource}
 
+.PHONY: jump
+jump: ## Jump onto the first instance on a dev environment
+	. ./setup.sh -j
+
 .PHONY: docs
 docs: ## Update all terraform docs
 	. ./tools/update-docs.sh

--- a/README.md
+++ b/README.md
@@ -120,6 +120,26 @@ To apply terraform for a list of projects:
 `. ./setup.sh -a list "<1st project>,<2nd project>,<3rd project>"`
 </details>
 
+### How to connect to your dev EC2 instance
+
+If you are experiencing problems after creating the stack, you may want to connect to the EC2 instance:
+
+Before using the jump box:
+  - Ensure you have `jq` installed: `brew install jq`
+  - Enable ssh forwarding of your private key: `ssh-add ~/.ssh/id_rsa`
+
+Run one of the following commands to connect to the instance:
+
+```shell
+# using the Makefile
+make jump
+
+# or using the shell script
+. ./setup.sh -j
+```
+
+### Viewing the Prometheus dashboard
+
 Once you have deployed your development stack you should be able to reach the prometheus dashboard using this url pattern:
 
 `https://prom-1.<your test environment specified in the ENV environment variable>.dev.gds-reliability.engineering`
@@ -135,8 +155,7 @@ If you want to make a change to our Prometheus infrastructure you should:
 - Create a new branch
 - Create a new stack for testing purposes in the gds-tech-ops AWS account by following the above set up instructions
 - Once you are happy with your code, put in a pull request and get it reviewed by another team member
-- Once your PR is merged, manually deploy to the staging stack in the staging AWS account using Terraform
-- If staging is fine then manually deploy to the production stack in the production AWS account using Terraform
+- Once your PR is merged, follow the team checklist for deployment (available from other team members) and record your deployment time for staging and production.
 
 
 ## Creating documentation

--- a/terraform/modules/common/ami/main.tf
+++ b/terraform/modules/common/ami/main.tf
@@ -1,0 +1,29 @@
+## Variables
+
+variable "amazon_release" {
+  description = "The amazon release used to generate the encrypted ami"
+}
+
+## Data sources
+
+data "aws_ami" "source" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["amzn-ami-${var.amazon_release}-amazon-ecs-optimized"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  owners = ["amazon"]
+}
+
+## Outputs
+
+output "ami_id" {
+  value = "${data.aws_ami.source.id}"
+}

--- a/terraform/modules/jumpbox/README.md
+++ b/terraform/modules/jumpbox/README.md
@@ -1,0 +1,20 @@
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| allowed_cidrs | List of CIDRs which are able to access the jumpbox, default are GDS ips | list | `<list>` | no |
+| aws_region | The region which the jump box will be built within | string | - | yes |
+| ecs_optimised_ami_version |  | string | `2018.03.a` | no |
+| security_groups | A list of security groups to extend | list | `<list>` | no |
+| stack_name | The name of the stack the jumpbox belongs to | string | - | yes |
+| subnet_id | The subnet which the jumpbox will be added to | string | - | yes |
+| vpc_id | The VPC ID to use on this service | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| jumpbox_ip |  |
+| key_name |  |
+

--- a/terraform/modules/jumpbox/main.tf
+++ b/terraform/modules/jumpbox/main.tf
@@ -1,0 +1,125 @@
+## Variables
+
+variable "subnet_id" {
+  description = "The subnet which the jumpbox will be added to"
+}
+
+variable "vpc_id" {
+  description = "The VPC ID to use on this service"
+}
+
+variable "ecs_optimised_ami_version" {
+  default = "2018.03.a"
+}
+
+variable "stack_name" {
+  description = "The name of the stack the jumpbox belongs to"
+}
+
+variable "aws_region" {
+  description = "The region which the jump box will be built within"
+}
+
+variable "security_groups" {
+  type        = "list"
+  description = "A list of security groups to extend"
+  default     = []
+}
+
+variable "allowed_cidrs" {
+  type        = "list"
+  description = "List of CIDRs which are able to access the jumpbox, default are GDS ips"
+
+  default = [
+    "213.86.153.212/32",
+    "213.86.153.213/32",
+    "213.86.153.214/32",
+    "213.86.153.235/32",
+    "213.86.153.236/32",
+    "213.86.153.237/32",
+    "85.133.67.244/32",
+  ]
+}
+
+## Resources
+
+resource "aws_key_pair" "ssh_key" {
+  key_name   = "${var.stack_name}-jumpbox-key"
+  public_key = "${file("~/.ssh/id_rsa.pub")}"
+}
+
+module "ami" {
+  source         = "../common/ami"
+  amazon_release = "${var.ecs_optimised_ami_version}"
+}
+
+resource "aws_security_group" "bastion_security_group" {
+  name        = "${var.stack_name}-bastion-sg"
+  vpc_id      = "${var.vpc_id}"
+  description = "Controls access to & from the bastion"
+}
+
+resource "aws_security_group_rule" "allow_ssh" {
+  security_group_id = "${aws_security_group.bastion_security_group.id}"
+
+  type        = "ingress"
+  from_port   = 22
+  to_port     = 22
+  protocol    = "tcp"
+  cidr_blocks = ["${var.allowed_cidrs}"]
+}
+
+resource "aws_security_group_rule" "allow_all_egress" {
+  security_group_id = "${aws_security_group.bastion_security_group.id}"
+
+  type        = "egress"
+  from_port   = 0
+  to_port     = 0
+  protocol    = "-1"
+  cidr_blocks = ["${var.allowed_cidrs}"]
+}
+
+resource "aws_instance" "instance" {
+  ami           = "${module.ami.ami_id}"
+  subnet_id     = "${var.subnet_id}"
+  instance_type = "t2.small"
+
+  lifecycle {
+    # Changes to security_groups were ignored as it would cause the jumpbox instance to be destroyed
+    # because it wasn't picking up the list of security groups from the terraform state file
+    # Running terraform plan would show that 0 security groups had been assigned which is different from 2 assigned here.
+    # This also means that if the security groups should change the `infra-jump-instance` project will need to be 
+    # tainted to pick up udpates.
+    ignore_changes = ["ami", "security_groups"]
+  }
+
+  root_block_device {
+    volume_size           = "10"
+    delete_on_termination = "true"
+  }
+
+  key_name = "${aws_key_pair.ssh_key.key_name}"
+
+  security_groups = [
+    "${var.security_groups}",
+    "${aws_security_group.bastion_security_group.id}",
+  ]
+
+  associate_public_ip_address = "true"
+
+  tags {
+    Name      = "jumpbox.${var.stack_name}.dmz"
+    Stack     = "${var.stack_name}"
+    Terraform = "true"
+  }
+}
+
+## Outputs
+
+output "jumpbox_ip" {
+  value = "${aws_instance.instance.public_ip}"
+}
+
+output "key_name" {
+  value = "${aws_key_pair.ssh_key.key_name}"
+}

--- a/terraform/projects/app-ecs-instances/README.md
+++ b/terraform/projects/app-ecs-instances/README.md
@@ -10,10 +10,10 @@ Create ECS container instances
 |------|-------------|:----:|:-----:|:-----:|
 | additional_tags | Stack specific tags to apply | map | `<map>` | no |
 | aws_region | AWS region | string | `eu-west-1` | no |
-| ecs_image_id | AMI ID to use for the ECS container instances | string | `ami-2d386654` | no |
 | ecs_instance_root_size | ECS container instance root volume size - in GB | string | `50` | no |
 | ecs_instance_ssh_keyname | SSH keyname for ECS container instances | string | `ecs-monitoring-ssh-test` | no |
 | ecs_instance_type | ECS container instance type | string | `m4.xlarge` | no |
+| ecs_optimised_ami_version |  | string | `2018.03.a` | no |
 | prometheis_total | Desired number of prometheus servers.  Maximum 3. | string | `3` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | `ecs-monitoring` | no |
 | stack_name | Unique name for this collection of resources | string | `ecs-monitoring` | no |

--- a/terraform/projects/infra-jump-instance/README.md
+++ b/terraform/projects/infra-jump-instance/README.md
@@ -1,0 +1,18 @@
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| additional_tags | Stack specific tags to apply | map | `<map>` | no |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| jumpbox_cidrs | List of CIDRs which are able to access the jumpbox | list | `<list>` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | `ecs-monitoring` | no |
+| stack_name | Unique name for this collection of resources | string | `ecs-monitoring` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| jump_box_key_name |  |
+| jumpbox_ip |  |
+

--- a/terraform/projects/infra-jump-instance/main.tf
+++ b/terraform/projects/infra-jump-instance/main.tf
@@ -1,0 +1,103 @@
+## Variables
+
+variable "additional_tags" {
+  type        = "map"
+  description = "Stack specific tags to apply"
+  default     = {}
+}
+
+variable "aws_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-1"
+}
+
+variable "remote_state_bucket" {
+  type        = "string"
+  description = "S3 bucket we store our terraform state in"
+  default     = "ecs-monitoring"
+}
+
+variable "stack_name" {
+  type        = "string"
+  description = "Unique name for this collection of resources"
+  default     = "ecs-monitoring"
+}
+
+variable "jumpbox_cidrs" {
+  type        = "list"
+  description = "List of CIDRs which are able to access the jumpbox"
+  default     = ["0.0.0.0/0"]
+}
+
+## Providers
+
+terraform {
+  required_version = "= 0.11.7"
+
+  backend "s3" {
+    key = "infra-jump-instance.tfstate"
+  }
+}
+
+provider "aws" {
+  version = "~> 1.14.1"
+  region  = "${var.aws_region}"
+}
+
+provider "template" {
+  version = "~> 1.0.0"
+}
+
+## Data sources
+
+data "terraform_remote_state" "infra_networking" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "infra-networking.tfstate"
+    region = "${var.aws_region}"
+  }
+}
+
+data "terraform_remote_state" "infra_security_groups" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "infra-security-groups.tfstate"
+    region = "${var.aws_region}"
+  }
+}
+
+## Resources
+
+module "jumpbox" {
+  source          = "../../modules/jumpbox"
+  aws_region      = "${var.aws_region}"
+  subnet_id       = "${element(data.terraform_remote_state.infra_networking.public_subnets, 0)}"
+  stack_name      = "${var.stack_name}"
+  vpc_id          = "${data.terraform_remote_state.infra_networking.vpc_id}"
+  security_groups = ["${data.terraform_remote_state.infra_security_groups.monitoring_external_sg_id}"]
+  allowed_cidrs   = "${var.jumpbox_cidrs}"
+}
+
+resource "aws_route53_record" "jump_alias" {
+  zone_id = "${data.terraform_remote_state.infra_networking.public_zone_id}"
+  name    = "jump"
+  type    = "A"
+  ttl     = 60
+
+  records = ["${module.jumpbox.jumpbox_ip}"]
+}
+
+## Outputs
+
+output "jumpbox_ip" {
+  value = "${module.jumpbox.jumpbox_ip}"
+}
+
+output "jump_box_key_name" {
+  value = "${module.jumpbox.key_name}"
+}


### PR DESCRIPTION
An ssh key is created based on the users public key (it assumes the
users public key is available as `~/.ssh/id_rsa.pub`), so at the moment connecting to the instance is only available for the user who is applying the jumpbox project.

In order to get the jumpbox to work you will need to ensure that you have `jq` installed and you allow your ssh key to be forwarded, details of which can be found in the README.

It's be a good idea to start with a fresh stack in order to ensure that your ssh key is being forwarded to the EC2 instance, so if you have an existing stack to destroy it and then apply the terraform to build it again.

To connect to the EC2 instance, rather than jumping onto the jumpbox and then ssh-ing on the the instance the `make jump` task will do both steps for you.