### PR TITLE
Set nice urls for staging and prod prometheus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,18 @@ plan:  ## Plan all terraform
 apply: ## Apply all terraform, auto approves
 	. ./setup.sh -a
 
+.PHONY: clean-single
+clean-single: ## Init terraform to a project, make init-single project=<project name>
+	. ./setup.sh -c ${project}
+
+.PHONY: init-single
+init-single: ## Init terraform to a project, make init-single project=<project name>
+	. ./setup.sh -i ${project}
+
+.PHONY: plan-single
+plan-single: ## Plan terraform to a project, make plan-single project=<project name>
+	. ./setup.sh -p ${project}
+
 .PHONY: apply-single
 apply-single: ## Apply terraform to a project, make apply-single project=<project name>
 	. ./setup.sh -a ${project}

--- a/stacks/production.tfvars
+++ b/stacks/production.tfvars
@@ -1,5 +1,6 @@
 remote_state_bucket = "prometheus-production"
 stack_name = "production"
+prometheus_subdomain = "monitoring"
 additional_tags = {
   "Environment" = "production"
 }

--- a/stacks/staging.tfvars
+++ b/stacks/staging.tfvars
@@ -1,5 +1,6 @@
 remote_state_bucket = "prometheus-staging"
 stack_name = "staging"
+prometheus_subdomain = "monitoring-staging"
 additional_tags = {
   "Environment" = "staging"
 }

--- a/terraform/projects/app-ecs-albs/main.tf
+++ b/terraform/projects/app-ecs-albs/main.tf
@@ -135,3 +135,13 @@ output "monitoring_external_tg" {
   value       = "${aws_lb_target_group.monitoring_external_tg.arn}"
   description = "External Monitoring ALB target group"
 }
+
+output "dns_name" {
+  value       = "${aws_lb.monitoring_external_alb.dns_name}"
+  description = "External Monitoring ALB dns_name"
+}
+
+output "zone_id" {
+  value       = "${aws_lb.monitoring_external_alb.zone_id}"
+  description = "External Monitoring ALB hosted zone ID"
+}

--- a/terraform/projects/infra-networking-route53/main.tf
+++ b/terraform/projects/infra-networking-route53/main.tf
@@ -1,0 +1,78 @@
+/**
+* ## Project: infra-networking-route53
+*
+* Terraform project to setup route53
+*
+*/
+
+variable "aws_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-1"
+}
+
+variable "prometheus_subdomain" {
+  type        = "string"
+  description = "Subdomain for prometheus"
+  default     = "monitoring"
+}
+
+variable "remote_state_bucket" {
+  type        = "string"
+  description = "S3 bucket we store our terraform state in"
+  default     = "ecs-monitoring"
+}
+
+# locals
+# --------------------------------------------------------------
+
+# Resources
+# --------------------------------------------------------------
+
+## Providers
+
+terraform {
+  required_version = "= 0.11.7"
+
+  backend "s3" {
+    key = "infra-networking-route53.tfstate"
+  }
+}
+
+provider "aws" {
+  version = "~> 1.14.1"
+  region  = "${var.aws_region}"
+}
+
+## Data sources
+
+data "terraform_remote_state" "app-ecs-albs" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "app-ecs-albs.tfstate"
+    region = "${var.aws_region}"
+  }
+}
+
+## Resources
+
+resource "aws_route53_zone" "subdomain" {
+  name = "${var.prometheus_subdomain}.gds-reliability.engineering"
+}
+
+resource "aws_route53_record" "prom-alias" {
+  zone_id = "${aws_route53_zone.subdomain.zone_id}"
+  name    = "prom-1"
+  type    = "A"
+
+  alias {
+    name                   = "${data.terraform_remote_state.app-ecs-albs.dns_name}"
+    zone_id                = "${data.terraform_remote_state.app-ecs-albs.zone_id}"
+    evaluate_target_health = false
+  }
+}
+
+## Outputs
+


### PR DESCRIPTION
## What

To make it easier to go to the prometheus url for staging and prod, route53 is used to set up the subdomains based on `prometheus_subdomain` values in `tfvars`.

After deploying to staging / prod, you need to make a note of the name servers and set `monitoring` and `monitoring-staging` values in `gds-tech-ops` role for the `gds-reliability.engineering` zone in route53.

It is possible to also deploy development stacks using this PR as it should create the hosted zone but you will need to add the name servers to the `gds-reliability.engineering` zone manually and eventually for dev stacks we are proposing the use of `your_stack.dev.gds-reliability.engineering` rather than `your_stack.gds-reliability.engineering`.

You will need to make sure that you have added `prometheus_subdomain` to your dev stack `tfvars` and that you avoid other subdomains already listed in the `gds-reliability.engineering` zone.