### PR TITLE
Set nice dev urls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,12 +46,16 @@ apply-single: ## Apply terraform for a project, make apply-single project=<proje
 	. ./setup.sh -a ${project}
 
 .PHONY: destroy-single
-destroy-single: ## Destroy terraform to a project, make destroy-single project=<project name>
+destroy-single: ## Destroy terraform for a project, make destroy-single project=<project name>
 	. ./setup.sh -d ${project}
 
 .PHONY: destroy
 destroy: ## Destroy stack
 	. ./setup.sh -d
+
+.PHONY: taint
+taint: ## Taint a resource, make taint project=<project name> resource=<resource name>
+	. ./setup.sh -t ${project} ${resource}
 
 .PHONY: docs
 docs: ## Update all terraform docs

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,10 @@ plan-single: ## Plan terraform for a project, make plan-single project=<project 
 apply-single: ## Apply terraform for a project, make apply-single project=<project name>
 	. ./setup.sh -a ${project}
 
+.PHONY: destroy-single
+destroy-single: ## Destroy terraform to a project, make destroy-single project=<project name>
+	. ./setup.sh -d ${project}
+
 .PHONY: destroy
 destroy: ## Destroy stack
 	. ./setup.sh -d

--- a/Makefile
+++ b/Makefile
@@ -30,19 +30,19 @@ apply: ## Apply all terraform, auto approves
 	. ./setup.sh -a
 
 .PHONY: clean-single
-clean-single: ## Init terraform to a project, make init-single project=<project name>
+clean-single: ## Clean terraform state for a project, make clean-single project=<project name>
 	. ./setup.sh -c ${project}
 
 .PHONY: init-single
-init-single: ## Init terraform to a project, make init-single project=<project name>
+init-single: ## Init terraform for a project, make init-single project=<project name>
 	. ./setup.sh -i ${project}
 
 .PHONY: plan-single
-plan-single: ## Plan terraform to a project, make plan-single project=<project name>
+plan-single: ## Plan terraform for a project, make plan-single project=<project name>
 	. ./setup.sh -p ${project}
 
 .PHONY: apply-single
-apply-single: ## Apply terraform to a project, make apply-single project=<project name>
+apply-single: ## Apply terraform for a project, make apply-single project=<project name>
 	. ./setup.sh -a ${project}
 
 .PHONY: destroy

--- a/README.md
+++ b/README.md
@@ -46,12 +46,11 @@ Executing `make` on the command line will give you a list of possible commands t
 In order to create a new stack you can run these make commands in order:
 
 ```shell
-# ensure that you have set up and sourced your environment variables in `environment.sh`
+# ensure that you have set up and sourced your environment variables using `source environment.sh`
 
 make create-stack   # Create the terraform stack env vars
 make create-bucket  # Create the terraform state bucket
 make init           # Initialise terraform
-make plan           # Plan all terraform
 make apply          # Apply all terraform, auto approves
 ```
 
@@ -76,12 +75,11 @@ How to use the setup.sh shell script
 In order to create a new stack run the following commands in order:
 
 ```shell
-# ensure that you have set up and sourced your environment variables in `environment.sh`
+# ensure that you have set up and sourced your environment variables using `source environment.sh`
 
-. ./setup.sh -s     # create stack config files `backend` and `tfvars` 
+. ./setup.sh -s     # create stack config files `backend` and `tfvars`
 . ./setup.sh -b     # create the terraform bucket for holding the state
 . ./setup.sh -i     # initialise the terraform state
-. ./setup.sh -p     # plan terraform to see what will change in the stack
 . ./setup.sh -a     # apply terraform
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ Before using the Makefile or shell script you will need to make a copy of the `e
 
 ```shell
 export TERRAFORM_BUCKET=<terraform state bucket name, should be unique or match `remote_state_bucket` in `tfvars` file for staging / production>
-export PROFILE_NAME=<if you are using `aws-vault` your profile name in `~/.aws/config` to access RE AWS>
-export USE_AWS_VAULT=<`true` if you are using `aws-vault`>
+export PROFILE_NAME=<your profile name in `~/.aws/config` to access RE AWS>
 export ENV=<your test environment, or `staging` / `production`>
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ export PROFILE_NAME=<your profile name in `~/.aws/config` to access RE AWS>
 export ENV=<your test environment, or `staging` / `production`>
 ```
 
-Applying or destroying the stack on the staging and production environments has been blocked but is possible on other development environments.
+Applying or destroying the entire stack on the staging and production environments has been blocked but is possible on other development environments.
 
 <details>
 <summary>
@@ -95,6 +95,14 @@ To apply terraform for a particular project:
 `. ./setup.sh -a <project name in terraform/projects>`
 
 </details>
+
+Once you have deployed your development stack you should be able to reach the prometheus dashboard using this url pattern:
+
+`http://prom-1.<your test environment specified in the ENV environment variable>.dev.reliability.engineering`
+
+e.g.
+
+`http://prom-1.your-test-stack.dev.reliability.engineering`
 
 ## Development process
 

--- a/environment_sample.sh
+++ b/environment_sample.sh
@@ -1,4 +1,3 @@
 export TERRAFORM_BUCKET=
 export PROFILE_NAME=
-export USE_AWS_VAULT=
 export ENV=

--- a/setup.sh
+++ b/setup.sh
@@ -5,13 +5,15 @@ TERRAFORMBACKVARS=$(pwd)/stacks/${ENV}.backend
 TERRAFORMTFVARS=$(pwd)/stacks/${ENV}.tfvars
 ROOTPROJ=$(pwd)
 TERRAFORMPROJ=$(pwd)/terraform/projects/
+SHARED_DEV_DNS_ZONE=Z3702PZTSCDWPA  # this is the dev.gds-reliability.engineering DNS hosted zone ID
 declare -a COMPONENTS=("infra-networking" "infra-security-groups" "app-ecs-instances" "app-ecs-albs" "infra-networking-route53"  "app-ecs-services")
 declare -a COMPONENTSDESTROY=("app-ecs-services" "infra-networking-route53" "app-ecs-albs" "app-ecs-instances" "infra-security-groups" "infra-networking")
 
-#Bucket name and stackname
+
 ############ Actions #################
 
 create_stack_configs() {
+# Creates .backend and .tfvars files for this stack in the stacks directory
 
 if [ -e "${ROOTPROJ}/stacks/${ENV}.backend" ] ; then
         echo "${ENV}.backend exists"
@@ -41,13 +43,24 @@ fi
 }
 
 create_bucket() {
+# Creates versioned AWS bucket to store remote terraform state
         aws-vault exec ${PROFILE_NAME} -- aws s3 mb "s3://${TERRAFORM_BUCKET}"
         aws-vault exec ${PROFILE_NAME} -- aws s3api put-bucket-versioning  \
         --bucket ${TERRAFORM_BUCKET} \
         --versioning-configuration Status=Enabled
+}
 
+does_stack_config_exist() {
+        if [ -e "${ROOTPROJ}/stacks/${ENV}.backend" ] ; then
+                return "1"
+        else
+                echo "stacks/${ENV}.backend doesn't exist"
+                return "0"
+        fi
+}
 
 clean() {
+# Removes .terraform files to avoid state clashes
         echo $1
 
         if [ -d "$TERRAFORMPROJ$1/.terraform" ] ; then
@@ -58,7 +71,21 @@ clean() {
         fi
 }
 
+import_shared_dev_route53 () {
+# Imports into terraform the shared development route 53 zone that had not been set up
+# using Terraform
+        echo "import shared dev route53"
+        aws-vault exec ${PROFILE_NAME} -- $TERRAFORMPATH import aws_route53_zone.shared_dev_subdomain $SHARED_DEV_DNS_ZONE
+}
+
+remove_shared_dev_route53 () {
+# Remove the shared development route 53 zone from the state file
+        echo "import shared dev route53"
+        aws-vault exec ${PROFILE_NAME} -- $TERRAFORMPATH state rm aws_route53_zone.shared_dev_subdomain
+}
+
 init () {
+# Init a terraform project
         echo $1
 
         cd $TERRAFORMPROJ$1
@@ -66,6 +93,7 @@ init () {
 }
 
 plan () {
+# Plan a terraform project
         echo $1
 
         cd $TERRAFORMPROJ$1
@@ -73,17 +101,37 @@ plan () {
 }
 
 apply () {
+# Apply a terraform project
         echo $1
 
         cd $TERRAFORMPROJ$1
+
+        # For development stacks, for the `infra-networking-route53` project, ensure that
+        # the shared_dev_route53 resource has been imported into terraform before applying
+        if [ $ENV != 'production' -a $ENV != 'staging' -a "$1" = 'infra-networking-route53' ] ; then
+                import_shared_dev_route53
+        fi
+
         aws-vault exec ${PROFILE_NAME} -- $TERRAFORMPATH apply --var-file=$TERRAFORMTFVARS --auto-approve
 }
 
 destroy () {
+# Destroy a terraform project
         echo $1
 
         cd $TERRAFORMPROJ$1
+
+        # For development stacks, for the `infra-networking-route53` project,
+        # remove the shared_dev_subdomain route53 state file
+        if [ $ENV != 'production' -a $ENV != 'staging' -a "$1" = 'infra-networking-route53' ] ; then
+                remove_shared_dev_route53
+        fi
+
         aws-vault exec ${PROFILE_NAME} -- $TERRAFORMPATH destroy --var-file=$TERRAFORMTFVARS --auto-approve
+
+        if [ $? != 0 ]; then
+                exit
+        fi
 }
 
 #################################
@@ -125,50 +173,69 @@ else
                 fi
         ;;
         -i) echo "Initialize terraform dir: ${ENV}"
-                if [ $2 ] ; then
-                        init $2
-                else
-                        for folder in ${COMPONENTS[@]}
-                        do
-                                init $folder
-                        done
-                fi
-        ;;
-        -p) echo "Create terraform plan: ${ENV}"
-                if [ $2 ] ; then
-                        plan $2
-                else
-                        for folder in ${COMPONENTS[@]}
-                        do
-                                plan $folder
-                        done
-                fi
-        ;;
-        -a) echo "Apply terraform plan to environment: ${ENV}"
-                if [ $2 ] ; then
-                        apply $2
-                else
-                        if [ "${ENV}" = 'staging' -o "${ENV}" = 'production' ] ; then
-                                echo "Cannot run terraform apply all on ${ENV}"
+                does_stack_config_exist
+                if [ $? = 1 ] ; then
+                        if [ $2 ] ; then
+                                init $2
                         else
                                 for folder in ${COMPONENTS[@]}
                                 do
-                                        apply $folder
+                                        init $folder
                                 done
                         fi
                 fi
         ;;
-        -d) echo "Destroy terraform plan to environment: ${ENV}"
-                if [ "${ENV}" = 'staging' -o "${ENV}" = 'production' ] ; then
-                        echo "Cannot run terraform apply all on ${ENV}"
-                else
-                        read -p 'Are you sure? (y)' answer
-
-                        if [ "${answer}" = 'y' ] ; then
-                                for folder in ${COMPONENTSDESTROY[@]}
+        -p) echo "Create terraform plan: ${ENV}"
+                does_stack_config_exist
+                if [ $? = 1 ] ; then
+                        if [ $2 ] ; then
+                                plan $2
+                        else
+                                for folder in ${COMPONENTS[@]}
                                 do
-                                        destroy $folder
+                                        plan $folder
                                 done
+                        fi
+                fi
+        ;;
+        -a) echo "Apply terraform plan to environment: ${ENV}"
+                does_stack_config_exist
+                if [ $? = 1 ]    ; then
+                        if [ $2 ] ; then
+                                apply $2
+                        else
+                                if [ "${ENV}" = 'staging' -o "${ENV}" = 'production' ] ; then
+                                        echo "Cannot run terraform apply all on ${ENV}"
+                                else
+                                        for folder in ${COMPONENTS[@]}
+                                        do
+                                                apply $folder
+                                        done
+                                fi
+                        fi
+                fi
+        ;;
+        -d) echo "Destroy terraform plan to environment: ${ENV}"
+                does_stack_config_exist
+                if [ $? = 1 ] ; then
+                        if [ $2 ] ; then
+                                destroy $2
+                        else
+                                if [ "${ENV}" = 'staging' -o "${ENV}" = 'production' ] ; then
+                                        echo "Cannot run terraform destroy all on ${ENV}"
+                                else
+                                        read -p 'Are you sure? (yN)' answer
+
+                                        if [ "${answer}" = 'y' ] ; then
+                                                for folder in ${COMPONENTSDESTROY[@]}
+                                                do
+                                                        destroy $folder
+                                                        if [ $? != 0 ] ; then
+                                                                exit
+                                                        fi
+                                                done
+                                        fi
+                                fi
                         fi
                 fi
         ;;
@@ -176,3 +243,5 @@ else
         ;;
         esac
 fi
+
+cd $ROOTPROJ

--- a/setup.sh
+++ b/setup.sh
@@ -7,8 +7,8 @@ ROOTPROJ=$(pwd)
 TERRAFORMPROJ=$(pwd)/terraform/projects/
 SHARED_DEV_SUBDOMAIN_RESOURCE=aws_route53_zone.shared_dev_subdomain
 SHARED_DEV_DNS_ZONE=Z3702PZTSCDWPA  # this is the dev.gds-reliability.engineering DNS hosted zone ID
-declare -a COMPONENTS=("infra-networking" "infra-security-groups" "app-ecs-instances" "app-ecs-albs" "infra-networking-route53"  "app-ecs-services")
-declare -a COMPONENTSDESTROY=("app-ecs-services" "infra-networking-route53" "app-ecs-albs" "app-ecs-instances" "infra-security-groups" "infra-networking")
+declare -a COMPONENTS=("infra-networking" "infra-security-groups" "app-ecs-instances" "app-ecs-albs" "app-ecs-services")
+declare -a COMPONENTSDESTROY=("app-ecs-services" "app-ecs-albs" "app-ecs-instances" "infra-security-groups" "infra-networking")
 
 
 ############ Actions #################
@@ -114,9 +114,9 @@ apply () {
 
         cd $TERRAFORMPROJ$1
 
-        # For development stacks, for the `infra-networking-route53` project, ensure that
+        # For development stacks, for the `infra-networking` project, ensure that
         # the shared_dev_route53 resource has been imported into terraform before applying
-        if [ $ENV != 'production' -a $ENV != 'staging' -a "$1" = 'infra-networking-route53' ] ; then
+        if [ $ENV != 'production' -a $ENV != 'staging' -a "$1" = 'infra-networking' ] ; then
                 import_shared_dev_route53
         fi
 
@@ -129,9 +129,9 @@ destroy () {
 
         cd $TERRAFORMPROJ$1
 
-        # For development stacks, for the `infra-networking-route53` project,
+        # For development stacks, for the `infra-networking` project,
         # remove the shared_dev_subdomain route53 state file
-        if [ $ENV != 'production' -a $ENV != 'staging' -a "$1" = 'infra-networking-route53' ] ; then
+        if [ $ENV != 'production' -a $ENV != 'staging' -a "$1" = 'infra-networking' ] ; then
                 remove_shared_dev_route53
         fi
 

--- a/terraform/projects/app-ecs-albs/main.tf
+++ b/terraform/projects/app-ecs-albs/main.tf
@@ -100,6 +100,18 @@ resource "aws_lb" "monitoring_external_alb" {
   )}"
 }
 
+resource "aws_route53_record" "prom_alias" {
+  zone_id = "${data.terraform_remote_state.infra_networking.public_zone_id}"
+  name    = "prom-1"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_lb.monitoring_external_alb.dns_name}"
+    zone_id                = "${aws_lb.monitoring_external_alb.zone_id}"
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_lb_target_group" "monitoring_external_tg" {
   name                 = "${var.stack_name}-ext-tg"
   port                 = 80
@@ -134,14 +146,4 @@ resource "aws_lb_listener" "monitoring_external_listener" {
 output "monitoring_external_tg" {
   value       = "${aws_lb_target_group.monitoring_external_tg.arn}"
   description = "External Monitoring ALB target group"
-}
-
-output "dns_name" {
-  value       = "${aws_lb.monitoring_external_alb.dns_name}"
-  description = "External Monitoring ALB dns_name"
-}
-
-output "zone_id" {
-  value       = "${aws_lb.monitoring_external_alb.zone_id}"
-  description = "External Monitoring ALB hosted zone ID"
 }

--- a/terraform/projects/app-ecs-instances/main.tf
+++ b/terraform/projects/app-ecs-instances/main.tf
@@ -190,7 +190,13 @@ resource "aws_ebs_volume" "prometheus_ebs_volume" {
   type              = "gp2"
 
   lifecycle {
-    prevent_destroy = true
+    # This allows our EBS volumes to be destroyed, which is allowed behaviour
+    # for dev stacks but behaviour we want to avoid for staging or production.
+    # Therefore, we manually created a new policy in the staging and production
+    # account - `Prevent_delete_EC2_volume`, which has been attached to the
+    # AWS roles used by terraform to help prevent accidental EBS volume deletion
+    # https://github.com/hashicorp/terraform/issues/3116
+    prevent_destroy = false
   }
 
   tags = "${merge(

--- a/terraform/projects/infra-networking-route53/README.md
+++ b/terraform/projects/infra-networking-route53/README.md
@@ -1,6 +1,14 @@
 ## Project: infra-networking-route53
 
-Terraform project to setup route53
+Terraform project to setup route53 with alias records to our ALBs.
+
+When running for `staging` and `production` environments, this will set up a
+new DNS hosted zone, for example `monitoring-staging.gds-reliability.engineering` using the
+`prometheus_subdomain` variable from the `tfvars` file.
+
+When running for development environments, this will create a new zone and
+delegate it to our shared `dev.gds-reliability.engineering` zone
+for example `your-stack.dev.gds-reliability.engineering`.
 
 
 
@@ -11,4 +19,5 @@ Terraform project to setup route53
 | aws_region | AWS region | string | `eu-west-1` | no |
 | prometheus_subdomain | Subdomain for prometheus | string | `monitoring` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | `ecs-monitoring` | no |
+| stack_name | Unique name for this collection of resources | string | `ecs-monitoring` | no |
 

--- a/terraform/projects/infra-networking-route53/main.tf
+++ b/terraform/projects/infra-networking-route53/main.tf
@@ -19,31 +19,10 @@ variable "aws_region" {
   default     = "eu-west-1"
 }
 
-variable "prometheus_subdomain" {
-  type        = "string"
-  description = "Subdomain for prometheus"
-  default     = "monitoring"
-}
-
-variable "remote_state_bucket" {
-  type        = "string"
-  description = "S3 bucket we store our terraform state in"
-  default     = "ecs-monitoring"
-}
-
-variable "stack_name" {
-  type        = "string"
-  description = "Unique name for this collection of resources"
-  default     = "ecs-monitoring"
-}
-
 # locals
 # --------------------------------------------------------------
 
-locals {
-  create_dev_count = "${(var.stack_name == "production" || var.stack_name == "staging") ? 0 : 1}"
-  subdomain_name   = "${(var.stack_name == "production" || var.stack_name == "staging") ? "${var.prometheus_subdomain}.gds-reliability.engineering" : "${var.prometheus_subdomain}.${aws_route53_zone.shared_dev_subdomain.name}"}"
-}
+locals {}
 
 ## Providers
 
@@ -60,65 +39,15 @@ provider "aws" {
   region  = "${var.aws_region}"
 }
 
-## Data sources
-
-data "terraform_remote_state" "app-ecs-albs" {
-  backend = "s3"
-
-  config {
-    bucket = "${var.remote_state_bucket}"
-    key    = "app-ecs-albs.tfstate"
-    region = "${var.aws_region}"
-  }
-}
-
 ## Resources
 # --------------------------------------------------------------
 # These resources are only created for staging or production environments (not dev)
 
-resource "aws_route53_zone" "subdomain" {
-  name = "${local.subdomain_name}"
-}
-
-resource "aws_route53_record" "prom_alias" {
-  zone_id = "${aws_route53_zone.subdomain.zone_id}"
-  name    = "prom-1"
-  type    = "A"
-
-  alias {
-    name                   = "${data.terraform_remote_state.app-ecs-albs.dns_name}"
-    zone_id                = "${data.terraform_remote_state.app-ecs-albs.zone_id}"
-    evaluate_target_health = false
-  }
-}
 
 ## Development resources
 # --------------------------------------------------------------
 # These resources are only created for development environments (not staging or prod)
 
-resource "aws_route53_zone" "shared_dev_subdomain" {
-  count = "${local.create_dev_count}"
-  name  = "dev.gds-reliability.engineering"
-}
-
-resource "aws_route53_record" "shared_dev_ns" {
-  count   = "${local.create_dev_count}"
-  zone_id = "${aws_route53_zone.shared_dev_subdomain.zone_id}"
-  name    = "${var.stack_name}.${aws_route53_zone.shared_dev_subdomain.name}"
-  type    = "NS"
-  ttl     = "30"
-
-  records = [
-    "${aws_route53_zone.subdomain.name_servers.0}",
-    "${aws_route53_zone.subdomain.name_servers.1}",
-    "${aws_route53_zone.subdomain.name_servers.2}",
-    "${aws_route53_zone.subdomain.name_servers.3}",
-  ]
-}
 
 ## Outputs
 
-output "public_zone_id" {
-  value       = "${aws_route53_zone.subdomain.zone_id}"
-  description = "Route 53 Zone ID for publicly visible zone"
-}

--- a/terraform/projects/infra-networking/README.md
+++ b/terraform/projects/infra-networking/README.md
@@ -11,6 +11,7 @@ related services. You will often have multiple VPCs in an account
 |------|-------------|:----:|:-----:|:-----:|
 | additional_tags | Stack specific tags to apply | map | `<map>` | no |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| prometheus_subdomain | Subdomain for prometheus | string | `monitoring` | no |
 | stack_name | Unique name for this collection of resources | string | `ecs-monitoring` | no |
 
 ## Outputs
@@ -20,5 +21,6 @@ related services. You will often have multiple VPCs in an account
 | az_names | Names of available availability zones |
 | private_subnets | List of private subnet IDs |
 | public_subnets | List of public subnet IDs |
+| public_zone_id | Route 53 Zone ID for publicly visible zone |
 | vpc_id | VPC ID where the stack resources are created |
 


### PR DESCRIPTION
https://trello.com/c/addX1GVK/413-nice-urls-for-prometheus (Bonus part of this ticket, staging/prod URLs already merged separately)

## What

Enabled the creation of nice urls for developers to be automatically created when creating a dev stack. 

- To enable nice urls we had to manually create the `dev.gds-reliability.engineering` DNS hosted zone and then import this as a resource in the `infra-networking-route53` project. 
- The dev stack doesn't get deployed on the staging and production environments and the staging and production hosted zones don't get deployed on the `gds-tech-ops` dev environment.
- In order to be able to add the new dev stack to `dev.gds-reliability.engineering` hosted zone we had to import it via `terraform import`, the shared dev DNS zone is hardcoded in the `setup.sh`.
- A decision was made to split out the `route53` resources into it's own project because it depended on outputs from the `app-ecs-albs` project.

Also fixed an issue around tearing down a dev stack as there was a `prevent_destroy` on the EBS volumes which we want for staging and production but not for a dev environment.

- in order to do this we had to manually introduce a policy `Prevent_delete_EC2_volume` for the Administrator roles in staging and production accounts as the Administrator account is not currently managed by terraform. We will need to revisit IAM roles and policies in the future to have this all managed within terraform.
- In order to ensure that we can destroy the `infra-networking-route53` project we had to use `terraform state rm` to remove the `shared_dev_subdomain` resource from the remote state bucket.

Refactored the setup.sh file to remove `USE_AWS_VAULT` flag as everyone in the RE Observation team is using `aws-vault` now.

In the `Makefile` and `setup.sh` more single actions were added to speed up the development cycle, and added a check to ensure that the stack backend is available before running terraform.
