### PR TITLE
Make the autoscaling group build 3 instances across 3 AZ

### DIFF
--- a/terraform/projects/app-ecs-albs/main.tf
+++ b/terraform/projects/app-ecs-albs/main.tf
@@ -105,7 +105,7 @@ resource "aws_lb" "monitoring_internal_alb" {
   load_balancer_type = "application"
   security_groups    = ["${data.terraform_remote_state.infra_security_groups.alertmanager_external_sg_id}"]
 
-  subnets = [ 
+  subnets = [
     "${data.terraform_remote_state.infra_networking.private_subnets}",
   ]
 
@@ -133,7 +133,7 @@ resource "aws_route53_record" "prom_alias" {
 
 resource "aws_route53_record" "alerts_alias" {
   count = "${length(data.terraform_remote_state.infra_networking.public_subnets)}"
-  
+
   zone_id = "${data.terraform_remote_state.infra_networking.public_zone_id}"
   name    = "alerts-${count.index + 1}"
   type    = "A"
@@ -293,7 +293,6 @@ resource "aws_lb_listener" "paas_proxy_internal_listener" {
     type             = "forward"
   }
 }
-
 
 resource "aws_route53_record" "alerts_private_record" {
   count = "${length(data.terraform_remote_state.infra_networking.private_subnets)}"

--- a/terraform/projects/app-ecs-albs/main.tf
+++ b/terraform/projects/app-ecs-albs/main.tf
@@ -81,7 +81,7 @@ data "terraform_remote_state" "infra_security_groups" {
 
 ## Resources
 
-resource "aws_lb" "monitoring_external_alb" {
+resource "aws_lb" "nginx_auth_external_alb" {
   count = "${length(data.terraform_remote_state.infra_networking.public_subnets)}"
 
   name               = "${var.stack_name}-external-alb-${count.index + 1}"
@@ -102,7 +102,9 @@ resource "aws_lb" "monitoring_external_alb" {
 }
 
 resource "aws_lb" "monitoring_internal_alb" {
-  name               = "${var.stack_name}-internal-alb"
+  count = "${length(data.terraform_remote_state.infra_networking.private_subnets)}"
+  
+  name               = "${var.stack_name}-internal-alb-${count.index}"
   internal           = true
   load_balancer_type = "application"
   security_groups    = ["${data.terraform_remote_state.infra_security_groups.alertmanager_external_sg_id}"]
@@ -115,7 +117,7 @@ resource "aws_lb" "monitoring_internal_alb" {
     local.default_tags,
     var.additional_tags,
     map("Stackname", "${var.stack_name}"),
-    map("Name", "${var.stack_name}-monitoring-internal")
+    map("Name", "${var.stack_name}-monitoring-internal-${count.index}")
   )}"
 }
 
@@ -127,25 +129,27 @@ resource "aws_route53_record" "prom_alias" {
   type    = "A"
 
   alias {
-    name                   = "${element(aws_lb.monitoring_external_alb.*.dns_name, count.index)}"
-    zone_id                = "${element(aws_lb.monitoring_external_alb.*.zone_id, count.index)}"
+    name                   = "${element(aws_lb.nginx_auth_external_alb.*.dns_name, count.index)}"
+    zone_id                = "${element(aws_lb.nginx_auth_external_alb.*.zone_id, count.index)}"
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "alerts_alias" {
+  count = "${length(data.terraform_remote_state.infra_networking.public_subnets)}"
+  
   zone_id = "${data.terraform_remote_state.infra_networking.public_zone_id}"
-  name    = "alerts-1"
+  name    = "alerts-${count.index + 1}"
   type    = "A"
 
   alias {
-    name                   = "${aws_lb.monitoring_external_alb.dns_name}"
-    zone_id                = "${aws_lb.monitoring_external_alb.zone_id}"
+    name                   = "${element(aws_lb.nginx_auth_external_alb.*.dns_name, count.index)}"
+    zone_id                = "${element(aws_lb.nginx_auth_external_alb.*.zone_id, count.index)}"
     evaluate_target_health = false
   }
 }
 
-resource "aws_lb_target_group" "monitoring_external_tg" {
+resource "aws_lb_target_group" "nginx_auth_external_endpoint" {
   count = "${length(data.terraform_remote_state.infra_networking.public_subnets)}"
 
   name                 = "${var.stack_name}-ext-tg-${count.index + 1}"
@@ -165,33 +169,24 @@ resource "aws_lb_target_group" "monitoring_external_tg" {
   }
 }
 
-resource "aws_lb_listener" "monitoring_external_listener" {
+resource "aws_lb_listener" "nginx_auth_external_listener" {
   count = "${length(data.terraform_remote_state.infra_networking.public_subnets)}"
 
-  load_balancer_arn = "${element(aws_lb.monitoring_external_alb.*.arn, count.index)}"
+  load_balancer_arn = "${element(aws_lb.nginx_auth_external_alb.*.arn, count.index)}"
   port              = "80"
   protocol          = "HTTP"
 
   default_action {
-    target_group_arn = "${element(aws_lb_target_group.monitoring_external_tg.*.arn, count.index)}"
+    target_group_arn = "${element(aws_lb_target_group.nginx_auth_external_endpoint.*.arn, count.index)}"
     type             = "forward"
   }
 }
 
 
-resource "aws_lb_listener" "alertmanager_listener" {
-  load_balancer_arn = "${aws_lb.monitoring_internal_alb.arn}"
-  port              = "80"
-  protocol          = "HTTP"
+resource "aws_lb_target_group" "alertmanager_internal_endpoint" {
+  count = "${length(data.terraform_remote_state.infra_networking.public_subnets)}"
 
-  default_action {
-    target_group_arn = "${aws_lb_target_group.alertmanager_endpoint.arn}"
-    type             = "forward"
-  }
-}
-
-resource "aws_lb_target_group" "alertmanager_endpoint" {
-  name     = "${var.stack_name}-alertmanager"
+  name     = "${var.stack_name}-alerts-internal-${count.index + 1}"
   port     = "9093"
   protocol = "HTTP"
   vpc_id   = "${data.terraform_remote_state.infra_networking.vpc_id}"
@@ -207,19 +202,23 @@ resource "aws_lb_target_group" "alertmanager_endpoint" {
   }
 }
 
-resource "aws_lb_listener" "paas_proxy_listener" {
-  load_balancer_arn = "${aws_lb.monitoring_internal_alb.arn}"
-  port              = "8080"
+resource "aws_lb_listener" "alertmanager_internal_listener" {
+  count = "${length(data.terraform_remote_state.infra_networking.private_subnets)}"
+
+  load_balancer_arn = "${element(aws_lb.monitoring_internal_alb.*.arn, count.index)}"
+  port              = "80"
   protocol          = "HTTP"
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.paas_proxy_endpoint.arn}"
+    target_group_arn = "${element(aws_lb_target_group.alertmanager_internal_endpoint.*.arn, count.index)}"
     type             = "forward"
   }
 }
 
-resource "aws_lb_target_group" "paas_proxy_endpoint" {
-  name     = "${var.stack_name}-paas-proxy"
+resource "aws_lb_target_group" "paas_proxy_internal_endpoint" {
+  count = "${length(data.terraform_remote_state.infra_networking.private_subnets)}"
+
+  name     = "${var.stack_name}-paas-proxy-${count.index}"
   protocol = "HTTP"
   port     = "8080"
   vpc_id   = "${data.terraform_remote_state.infra_networking.vpc_id}"
@@ -235,49 +234,63 @@ resource "aws_lb_target_group" "paas_proxy_endpoint" {
   }
 }
 
+resource "aws_lb_listener" "paas_proxy_internal_listener" {
+  count = "${length(data.terraform_remote_state.infra_networking.private_subnets)}"
+
+  load_balancer_arn = "${element(aws_lb.monitoring_internal_alb.*.arn, count.index)}"
+  port              = "8080"
+  protocol          = "HTTP"
+
+  default_action {
+    target_group_arn = "${element(aws_lb_target_group.paas_proxy_internal_endpoint.*.arn, count.index)}"
+    type             = "forward"
+  }
+}
+
+
 ## Outputs
 
 output "monitoring_external_tg" {
-  value       = "${aws_lb_target_group.monitoring_external_tg.*.arn}"
+  value       = "${aws_lb_target_group.nginx_auth_external_endpoint.*.arn}"
   description = "External Monitoring ALB target group"
 }
 
 output "prometheus_alb_dns" {
-  value       = "${aws_lb.monitoring_external_alb.*.dns_name}"
+  value       = "${aws_lb.nginx_auth_external_alb.*.dns_name}"
   description = "External Monitoring ALB DNS name"
 }
 
 output "zone_id" {
-  value       = "${aws_lb.monitoring_external_alb.*.zone_id}"
+  value       = "${aws_lb.nginx_auth_external_alb.*.zone_id}"
   description = "External Monitoring ALB hosted zone ID"
 }
 
 output "monitoring_internal_tg" {
-  value       = "${aws_lb_target_group.alertmanager_endpoint.arn}"
+  value       = "${aws_lb_target_group.alertmanager_internal_endpoint.*.arn}"
   description = "External Alertmanager ALB target group"
 }
 
 output "alertmanager_alb_zoneid" {
-  value       = "${aws_lb.monitoring_internal_alb.zone_id}"
+  value       = "${aws_lb.monitoring_internal_alb.*.zone_id}"
   description = "External Alertmanager ALB zone id"
 }
 
 output "alertmanager_alb_dns" {
-  value       = "${aws_lb.monitoring_internal_alb.dns_name}"
+  value       = "${aws_lb.monitoring_internal_alb.*.dns_name}"
   description = "External Alertmanager ALB DNS name"
 }
 
 output "paas_proxy_alb_zoneid" {
-  value       = "${aws_lb.monitoring_internal_alb.zone_id}"
+  value       = "${aws_lb.monitoring_internal_alb.*.zone_id}"
   description = "Internal PaaS ALB target group"
 }
 
 output "paas_proxy_alb_dns" {
-  value       = "${aws_lb.monitoring_internal_alb.dns_name}"
+  value       = "${aws_lb.monitoring_internal_alb.*.dns_name}"
   description = "Internal PaaS ALB DNS name"
 }
 
 output "pass_proxy_tg" {
-  value       = "${aws_lb_target_group.paas_proxy_endpoint.arn}"
+  value       = "${aws_lb_target_group.paas_proxy_internal_endpoint.*.arn}"
   description = "Paas proxy target group"
 }

--- a/terraform/projects/app-ecs-instances/ecs-iam-policy.tf
+++ b/terraform/projects/app-ecs-instances/ecs-iam-policy.tf
@@ -51,13 +51,21 @@ data "aws_iam_policy_document" "ecs_instance_document" {
 
   statement {
     resources = [
-      "${aws_ebs_volume.prometheus_ebs_volume.arn}",
+      "${aws_ebs_volume.prometheus_ebs_volume.*.arn}",
       "arn:aws:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/*",
     ]
 
     actions = [
       "ec2:AttachVolume",
       "ec2:DetachVolume",
+    ]
+  }
+
+  statement {
+    resources = ["*"]
+
+    actions = [
+      "ec2:DescribeVolumes",
     ]
   }
 }

--- a/terraform/projects/app-ecs-instances/instance-user-data.tpl
+++ b/terraform/projects/app-ecs-instances/instance-user-data.tpl
@@ -5,12 +5,16 @@ sudo yum install -y aws-cli wget
 
 REGION="${region}"
 DEVICE="xvdf"
-VOLUME_ID="${volume_id}"
+VOLUME_IDS="${volume_ids}"
 
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] finding current instance ID"
 INSTANCE_ID="`wget -q -O - http://169.254.169.254/latest/meta-data/instance-id`"
 
-echo "[$(date '+%H:%M:%S %d-%m-%Y')] attaching volume"
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] finding volume to attach"
+AZ="$(wget -q -O - http://169.254.169.254/latest/meta-data/placement/availability-zone)"
+VOLUME_ID="$(aws ec2 describe-volumes --filters Name=availability-zone,Values=$AZ --volume-ids $VOLUME_IDS --region $REGION --query Volumes[*].VolumeId --output text)"
+
+echo "[$(date '+%H:%M:%S %d-%m-%Y')] attaching volume: $VOLUME_ID"
 aws ec2 attach-volume --volume-id $VOLUME_ID --instance-id $INSTANCE_ID --device /dev/$DEVICE --region $REGION
 
 # Waiting for volume to finish attaching

--- a/terraform/projects/app-ecs-services/alertmanager-service.tf
+++ b/terraform/projects/app-ecs-services/alertmanager-service.tf
@@ -92,13 +92,15 @@ resource "aws_ecs_task_definition" "alertmanager_server" {
 }
 
 resource "aws_ecs_service" "alertmanager_server" {
-  name            = "${var.stack_name}-alertmanager-server"
+  count = 3
+
+  name            = "${var.stack_name}-alertmanager-server-${count.index + 1}"
   cluster         = "${var.stack_name}-ecs-monitoring"
   task_definition = "${aws_ecs_task_definition.alertmanager_server.arn}"
   desired_count   = 1
 
   load_balancer {
-    target_group_arn = "${data.terraform_remote_state.app_ecs_albs.alertmanager_external_tg}"
+    target_group_arn = "${element(data.terraform_remote_state.app_ecs_albs.monitoring_internal_tg, count.index)}"
     container_name   = "alertmanager"
     container_port   = 9093
   }

--- a/terraform/projects/app-ecs-services/prometheus-service.tf
+++ b/terraform/projects/app-ecs-services/prometheus-service.tf
@@ -81,7 +81,8 @@ data "template_file" "prometheus_config_file" {
   template = "${file("templates/prometheus.tpl")}"
 
   vars {
-    alertmanager_dns_name = "${join("\",\"", data.terraform_remote_state.app_ecs_albs.alertmanager_alb_dns)}"
+    alertmanager_dns_name = "${join("\",\"", data.terraform_remote_state.app_ecs_albs.alerts_private_record_fqdn)}"
+    paas_proxy_dns_name = "${join("\",\"", data.terraform_remote_state.app_ecs_albs.paas_proxy_private_record_fqdn)}"
   }
 }
 
@@ -173,7 +174,7 @@ resource "aws_ecs_service" "paas_proxy_service" {
   desired_count   = 1
 
   load_balancer {
-    target_group_arn = "${element(data.terraform_remote_state.app_ecs_albs.pass_proxy_tg, count.index)}"
+    target_group_arn = "${data.terraform_remote_state.app_ecs_albs.paas_proxy_tg}"
     container_name   = "paas-proxy"
     container_port   = 8080
   }

--- a/terraform/projects/app-ecs-services/prometheus-service.tf
+++ b/terraform/projects/app-ecs-services/prometheus-service.tf
@@ -151,13 +151,15 @@ resource "aws_ecs_task_definition" "paas_proxy" {
 }
 
 resource "aws_ecs_service" "prometheus_server" {
-  name            = "${var.stack_name}-prometheus-server"
+  count = "${length(data.terraform_remote_state.app_ecs_albs.monitoring_external_tg)}"
+
+  name            = "${var.stack_name}-prometheus-server-${count.index}"
   cluster         = "${var.stack_name}-ecs-monitoring"
   task_definition = "${aws_ecs_task_definition.prometheus_server.arn}"
-  desired_count   = 3
+  desired_count   = 1
 
   load_balancer {
-    target_group_arn = "${data.terraform_remote_state.app_ecs_albs.monitoring_external_tg}"
+    target_group_arn = "${element(data.terraform_remote_state.app_ecs_albs.monitoring_external_tg, count.index)}"
     container_name   = "auth-proxy"
     container_port   = 9090
   }

--- a/terraform/projects/app-ecs-services/prometheus-service.tf
+++ b/terraform/projects/app-ecs-services/prometheus-service.tf
@@ -228,7 +228,9 @@ data "template_file" "auth_proxy_config_file" {
   template = "${file("templates/auth-proxy.conf.tpl")}"
 
   vars {
-    alertmanager_dns_name = "${data.terraform_remote_state.app_ecs_albs.alerts_private_record_fqdn.0}"
+    alertmanager_1_dns_name = "${data.terraform_remote_state.app_ecs_albs.alerts_private_record_fqdn.0}"
+    alertmanager_2_dns_name = "${data.terraform_remote_state.app_ecs_albs.alerts_private_record_fqdn.1}"
+    alertmanager_3_dns_name = "${data.terraform_remote_state.app_ecs_albs.alerts_private_record_fqdn.2}"
   }
 }
 

--- a/terraform/projects/app-ecs-services/prometheus-service.tf
+++ b/terraform/projects/app-ecs-services/prometheus-service.tf
@@ -228,7 +228,7 @@ data "template_file" "auth_proxy_config_file" {
   template = "${file("templates/auth-proxy.conf.tpl")}"
 
   vars {
-    alertmanager_dns_name = "${data.terraform_remote_state.app_ecs_albs.alertmanager_alb_dns[0]}"
+    alertmanager_dns_name = "${data.terraform_remote_state.app_ecs_albs.alerts_private_record_fqdn.0}"
   }
 }
 

--- a/terraform/projects/app-ecs-services/prometheus-service.tf
+++ b/terraform/projects/app-ecs-services/prometheus-service.tf
@@ -154,7 +154,7 @@ resource "aws_ecs_service" "prometheus_server" {
   name            = "${var.stack_name}-prometheus-server"
   cluster         = "${var.stack_name}-ecs-monitoring"
   task_definition = "${aws_ecs_task_definition.prometheus_server.arn}"
-  desired_count   = 1
+  desired_count   = 3
 
   load_balancer {
     target_group_arn = "${data.terraform_remote_state.app_ecs_albs.monitoring_external_tg}"
@@ -180,7 +180,7 @@ resource "aws_ecs_service" "config_updater" {
   name            = "${var.stack_name}-targets-grabber"
   cluster         = "${var.stack_name}-ecs-monitoring"
   task_definition = "${aws_ecs_task_definition.config_updater.arn}"
-  desired_count   = 1
+  desired_count   = 3
 }
 
 data "template_file" "config_updater_defn" {

--- a/terraform/projects/app-ecs-services/prometheus-service.tf
+++ b/terraform/projects/app-ecs-services/prometheus-service.tf
@@ -82,7 +82,7 @@ data "template_file" "prometheus_config_file" {
 
   vars {
     alertmanager_dns_name = "${join("\",\"", data.terraform_remote_state.app_ecs_albs.alerts_private_record_fqdn)}"
-    paas_proxy_dns_name = "${join("\",\"", data.terraform_remote_state.app_ecs_albs.paas_proxy_private_record_fqdn)}"
+    paas_proxy_dns_name   = "${join("\",\"", data.terraform_remote_state.app_ecs_albs.paas_proxy_private_record_fqdn)}"
   }
 }
 
@@ -167,7 +167,7 @@ resource "aws_ecs_service" "prometheus_server" {
 }
 
 resource "aws_ecs_service" "paas_proxy_service" {
-  count = 3 
+  count           = 3
   name            = "${var.stack_name}-paas-proxy-${count.index}"
   cluster         = "${var.stack_name}-ecs-monitoring"
   task_definition = "${aws_ecs_task_definition.paas_proxy.arn}"

--- a/terraform/projects/app-ecs-services/templates/auth-proxy.conf.tpl
+++ b/terraform/projects/app-ecs-services/templates/auth-proxy.conf.tpl
@@ -18,7 +18,7 @@ server {
     return 200 "Static health check";
   }
 
-  resolver 8.8.8.8 valid=10s;
+  resolver 10.0.0.2 valid=10s;
 }
 
 server {
@@ -29,13 +29,14 @@ server {
 
   server_name ~(alert*);
 
+  set $alert "${alertmanager_dns_name}";
 
   location / {
-    proxy_pass http://${alertmanager_dns_name}/;
+    proxy_pass  http://$alert;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }
 
-  resolver 8.8.8.8 valid=10s;
+  resolver 10.0.0.2 valid=10s;
 }

--- a/terraform/projects/app-ecs-services/templates/auth-proxy.conf.tpl
+++ b/terraform/projects/app-ecs-services/templates/auth-proxy.conf.tpl
@@ -27,9 +27,49 @@ server {
   auth_basic_user_file /etc/nginx/conf.d/.htpasswd;
 
 
-  server_name ~(alert*);
+  server_name alerts-1.*;
 
-  set $alert "${alertmanager_dns_name}";
+  set $alert "${alertmanager_1_dns_name}";
+
+  location / {
+    proxy_pass  http://$alert;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
+
+  resolver 10.0.0.2 valid=10s;
+}
+
+server {
+  listen 9090;
+  auth_basic "Prometheus";
+  auth_basic_user_file /etc/nginx/conf.d/.htpasswd;
+
+
+  server_name alerts-2.*;
+
+  set $alert "${alertmanager_2_dns_name}";
+
+  location / {
+    proxy_pass  http://$alert;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
+
+  resolver 10.0.0.2 valid=10s;
+}
+
+server {
+  listen 9090;
+  auth_basic "Prometheus";
+  auth_basic_user_file /etc/nginx/conf.d/.htpasswd;
+
+
+  server_name alerts-3.*;
+
+  set $alert "${alertmanager_3_dns_name}";
 
   location / {
     proxy_pass  http://$alert;

--- a/terraform/projects/app-ecs-services/templates/prometheus.tpl
+++ b/terraform/projects/app-ecs-services/templates/prometheus.tpl
@@ -19,7 +19,7 @@ scrape_configs:
       - targets: ["${alertmanager_dns_name}"]
   - job_name: paas-targets
     scheme: http
-    proxy_url: 'http://${alertmanager_dns_name}:8080'
+    proxy_url: 'http://${paas_proxy_dns_name}:8080'
     file_sd_configs:
       - files: ['/etc/prometheus/targets/*.json']
         refresh_interval: 30s


### PR DESCRIPTION
This commit:
- increases the size of the autoscaling group to 3
- it passes all of the subnets to the autoscaling group
- creates 3 EBS volumes, 1 in each availability zone
- alters the cloud init script to query against 3 volume-ids to find the
volume created in the correct AZ