### PR TITLE
Fix updating bucket objects bug

### DIFF
--- a/terraform/projects/app-ecs-services/alertmanager-service.tf
+++ b/terraform/projects/app-ecs-services/alertmanager-service.tf
@@ -123,8 +123,8 @@ data "template_file" "alertmanager_dev_config_file" {
 }
 
 resource "aws_s3_bucket_object" "alertmanager" {
-  bucket                 = "${aws_s3_bucket.config_bucket.id}"
-  key                    = "alertmanager/alertmanager.yml"
-  content                = "${var.dev_environment == "true" ? data.template_file.alertmanager_dev_config_file.rendered : data.template_file.alertmanager_config_file.rendered}"
-  server_side_encryption = "AES256"
+  bucket  = "${aws_s3_bucket.config_bucket.id}"
+  key     = "alertmanager/alertmanager.yml"
+  content = "${var.dev_environment == "true" ? data.template_file.alertmanager_dev_config_file.rendered : data.template_file.alertmanager_config_file.rendered}"
+  etag    = "${md5(var.dev_environment == "true" ? data.template_file.alertmanager_dev_config_file.rendered : data.template_file.alertmanager_config_file.rendered)}"
 }

--- a/terraform/projects/app-ecs-services/main.tf
+++ b/terraform/projects/app-ecs-services/main.tf
@@ -109,49 +109,17 @@ resource "aws_s3_bucket" "config_bucket" {
   bucket_prefix = "ecs-monitoring-${var.stack_name}-config"
   acl           = "private"
 
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
   versioning {
     enabled = true
   }
-}
-
-resource "aws_s3_bucket_policy" "config_bucket_policy" {
-  /* As suggested by https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html
-  to ensure all objects in our config bucket are encrypted */
-
-  bucket = "${aws_s3_bucket.config_bucket.id}"
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Id": "PutObjPolicy",
-  "Statement": [
-    {
-      "Sid": "DenyIncorrectEncryptionHeader",
-      "Effect": "Deny",
-      "Principal": "*",
-      "Action": "s3:PutObject",
-      "Resource": "arn:aws:s3:::${aws_s3_bucket.config_bucket.id}/*",
-      "Condition": {
-        "StringNotEquals": {
-          "s3:x-amz-server-side-encryption": "AES256"
-        }
-      }
-    },
-    {
-      "Sid": "DenyUnEncryptedObjectUploads",
-      "Effect": "Deny",
-      "Principal": "*",
-      "Action": "s3:PutObject",
-      "Resource": "arn:aws:s3:::${aws_s3_bucket.config_bucket.id}/*",
-      "Condition": {
-        "Null": {
-          "s3:x-amz-server-side-encryption": "true"
-        }
-      }
-    }
-  ]
-}
-POLICY
 }
 
 ## Outputs

--- a/terraform/projects/app-ecs-services/prometheus-service.tf
+++ b/terraform/projects/app-ecs-services/prometheus-service.tf
@@ -206,17 +206,17 @@ resource "aws_ecs_task_definition" "config_updater" {
 }
 
 resource "aws_s3_bucket_object" "prometheus-config" {
-  bucket                 = "${aws_s3_bucket.config_bucket.id}"
-  key                    = "prometheus/prometheus.yml"
-  content                = "${data.template_file.prometheus_config_file.rendered}"
-  server_side_encryption = "AES256"
+  bucket  = "${aws_s3_bucket.config_bucket.id}"
+  key     = "prometheus/prometheus.yml"
+  content = "${data.template_file.prometheus_config_file.rendered}"
+  etag    = "${md5(data.template_file.prometheus_config_file.rendered)}"
 }
 
 resource "aws_s3_bucket_object" "alerts-config" {
-  bucket                 = "${aws_s3_bucket.config_bucket.id}"
-  key                    = "prometheus/alerts/alerts.yml"
-  source                 = "config/alerts.yml"
-  server_side_encryption = "AES256"
+  bucket = "${aws_s3_bucket.config_bucket.id}"
+  key    = "prometheus/alerts/alerts.yml"
+  source = "config/alerts.yml"
+  etag   = "${md5(file("config/alerts.yml"))}"
 }
 
 #### nginx reverse proxy
@@ -230,27 +230,27 @@ data "template_file" "auth_proxy_config_file" {
 }
 
 resource "aws_s3_bucket_object" "nginx-reverse-proxy" {
-  bucket                 = "${aws_s3_bucket.config_bucket.id}"
-  key                    = "prometheus/auth-proxy/conf.d/prometheus-auth-proxy.conf"
-  content                = "${data.template_file.auth_proxy_config_file.rendered}"
-  server_side_encryption = "AES256"
+  bucket  = "${aws_s3_bucket.config_bucket.id}"
+  key     = "prometheus/auth-proxy/conf.d/prometheus-auth-proxy.conf"
+  content = "${data.template_file.auth_proxy_config_file.rendered}"
+  etag    = "${md5(data.template_file.auth_proxy_config_file.rendered)}"
 }
 
 # The htpasswd file is in bcrypt format, which is only supported
 # by the nginx:alpine image, not the plain nginx image
 # https://github.com/nginxinc/docker-nginx/issues/29
 resource "aws_s3_bucket_object" "nginx-htpasswd" {
-  bucket                 = "${aws_s3_bucket.config_bucket.id}"
-  key                    = "prometheus/auth-proxy/conf.d/.htpasswd"
-  source                 = "config/vhosts/.htpasswd"
-  server_side_encryption = "AES256"
+  bucket = "${aws_s3_bucket.config_bucket.id}"
+  key    = "prometheus/auth-proxy/conf.d/.htpasswd"
+  source = "config/vhosts/.htpasswd"
+  etag   = "${md5(file("config/vhosts/.htpasswd"))}"
 }
 
 #### paas proxy
 
 resource "aws_s3_bucket_object" "nginx-paas-proxy" {
-  bucket                 = "${aws_s3_bucket.config_bucket.id}"
-  key                    = "prometheus/paas-proxy/conf.d/prometheus-paas-proxy.conf"
-  source                 = "config/vhosts/paas-proxy.conf"
-  server_side_encryption = "AES256"
+  bucket = "${aws_s3_bucket.config_bucket.id}"
+  key    = "prometheus/paas-proxy/conf.d/prometheus-paas-proxy.conf"
+  source = "config/vhosts/paas-proxy.conf"
+  etag   = "${md5(file("config/vhosts/paas-proxy.conf"))}"
 }


### PR DESCRIPTION
This commit fixes a bug introduced in https://trello.com/c/dljFeMNm/426-integrate-alertmanger-with-pagerduty-to-enable-alerts-to-become-pages

- Removes previous bucket policy
- Adds automatic encryption to the bucket
- Readds etags to our bucket objects

This fixes a bug whereby changing an object, such as alerts.yml,
would not be picked up by Terraform and would therefore not be
updated when running a Terraform apply.

It also ends up being a nicer solution with less lines of code
to ensure all objects in our config bucket are encrypted at rest.