### PR TITLE
Add HTTPS to prometheus and alertmanager

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,11 +110,11 @@ To apply terraform for a particular project:
 
 Once you have deployed your development stack you should be able to reach the prometheus dashboard using this url pattern:
 
-`http://prom-1.<your test environment specified in the ENV environment variable>.dev.reliability.engineering`
+`https://prom-1.<your test environment specified in the ENV environment variable>.dev.gds-reliability.engineering`
 
 e.g.
 
-`http://prom-1.your-test-stack.dev.reliability.engineering`
+`https://prom-1.your-test-stack.dev.gds-reliability.engineering`
 
 ## Development process
 

--- a/terraform/projects/app-ecs-albs/README.md
+++ b/terraform/projects/app-ecs-albs/README.md
@@ -19,11 +19,13 @@ Create ALBs for the ECS cluster
 |------|-------------|
 | alertmanager_alb_dns | External Alertmanager ALB DNS name |
 | alertmanager_alb_zoneid | External Alertmanager ALB zone id |
-| alertmanager_external_tg | External Alertmanager ALB target group |
+| alerts_private_record_fqdn | Alert Managers private DNS fqdn |
 | monitoring_external_tg | External Monitoring ALB target group |
+| monitoring_internal_tg | External Alertmanager ALB target group |
 | paas_proxy_alb_dns | Internal PaaS ALB DNS name |
 | paas_proxy_alb_zoneid | Internal PaaS ALB target group |
-| pass_proxy_tg | Paas proxy target group |
+| paas_proxy_private_record_fqdn | PaaS Proxy private DNS fqdn |
+| paas_proxy_tg | Paas proxy target group |
 | prometheus_alb_dns | External Monitoring ALB DNS name |
 | zone_id | External Monitoring ALB hosted zone ID |
 

--- a/terraform/projects/app-ecs-albs/main.tf
+++ b/terraform/projects/app-ecs-albs/main.tf
@@ -206,7 +206,7 @@ resource "aws_lb_listener" "nginx_auth_external_listener_https" {
   load_balancer_arn = "${aws_lb.nginx_auth_external_alb.arn}"
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
   certificate_arn   = "${aws_acm_certificate.monitoring_cert.arn}"
 
   default_action {

--- a/terraform/projects/app-ecs-albs/main.tf
+++ b/terraform/projects/app-ecs-albs/main.tf
@@ -127,10 +127,8 @@ resource "aws_acm_certificate" "monitoring_cert" {
 }
 
 resource "aws_route53_record" "monitoring_cert_validation" {
-  # Count is hardcoded due to https://github.com/hashicorp/terraform/issues/10857 meaning that we can
-  # not have a count based on a computed value on the first deploy. `7` represents one record for the
-  # aws_acm_certificate.monitoring_cert domain and six for it's subject_alternative_names (our prometheis and alertmanagers)
-  count = 7
+  # Count matches the domain_name plus each `subject_alternative_domain`
+  count = "${1 + length(concat(aws_route53_record.prom_alias.*.fqdn, aws_route53_record.alerts_alias.*.fqdn))}"
 
   name       = "${lookup(aws_acm_certificate.monitoring_cert.domain_validation_options[count.index], "resource_record_name")}"
   type       = "${lookup(aws_acm_certificate.monitoring_cert.domain_validation_options[count.index], "resource_record_type")}"

--- a/terraform/projects/app-ecs-albs/main.tf
+++ b/terraform/projects/app-ecs-albs/main.tf
@@ -121,8 +121,8 @@ resource "aws_lb" "monitoring_internal_alb" {
 # https://docs.aws.amazon.com/acm/latest/userguide/managed-renewal.html
 # If this fails, AWS will email associated with the AWS account
 resource "aws_acm_certificate" "monitoring_cert" {
-  domain_name       = "${data.terraform_remote_state.infra_networking.public_subdomain}"
-  validation_method = "DNS"
+  domain_name               = "${data.terraform_remote_state.infra_networking.public_subdomain}"
+  validation_method         = "DNS"
   subject_alternative_names = ["${aws_route53_record.prom_alias.*.fqdn}", "${aws_route53_record.alerts_alias.*.fqdn}"]
 }
 

--- a/terraform/projects/app-ecs-instances/README.md
+++ b/terraform/projects/app-ecs-instances/README.md
@@ -9,9 +9,9 @@ Create ECS container instances
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | additional_tags | Stack specific tags to apply | map | `<map>` | no |
-| autoscaling_group_desired_capacity | Desired number of ECS container instances | string | `1` | no |
-| autoscaling_group_max_size | Maximum desired number of ECS container instances | string | `1` | no |
-| autoscaling_group_min_size | Minimum desired number of ECS container instances | string | `1` | no |
+| autoscaling_group_desired_capacity | Desired number of ECS container instances | string | `3` | no |
+| autoscaling_group_max_size | Maximum desired number of ECS container instances | string | `3` | no |
+| autoscaling_group_min_size | Minimum desired number of ECS container instances | string | `3` | no |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | ecs_image_id | AMI ID to use for the ECS container instances | string | `ami-2d386654` | no |
 | ecs_instance_root_size | ECS container instance root volume size - in GB | string | `50` | no |

--- a/terraform/projects/infra-networking/README.md
+++ b/terraform/projects/infra-networking/README.md
@@ -23,6 +23,8 @@ related services. You will often have multiple VPCs in an account
 | nat_gateway | List of nat gateway IP |
 | private_subnets | List of private subnet IDs |
 | private_subnets_ips | List of public subnet IDs |
+| private_zone_id | Route 53 Zone ID for the internal zone |
+| public_subdomain | This is the subdomain for root zone |
 | public_subnets | List of public subnet IDs |
 | public_zone_id | Route 53 Zone ID for publicly visible zone |
 | vpc_id | VPC ID where the stack resources are created |

--- a/terraform/projects/infra-networking/main.tf
+++ b/terraform/projects/infra-networking/main.tf
@@ -160,6 +160,11 @@ output "public_zone_id" {
   description = "Route 53 Zone ID for publicly visible zone"
 }
 
+output "public_subdomain" {
+  value       = "${aws_route53_zone.subdomain.name}"
+  description = "This is the subdomain for root zone"
+}
+
 output "private_zone_id" {
   value       = "${aws_route53_zone.private.zone_id}"
   description = "Route 53 Zone ID for the internal zone"

--- a/terraform/projects/infra-security-groups/main.tf
+++ b/terraform/projects/infra-security-groups/main.tf
@@ -145,6 +145,15 @@ resource "aws_security_group_rule" "monitoring_external_sg_ingress_any_http" {
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
+resource "aws_security_group_rule" "monitoring_external_sg_ingress_any_https" {
+  type              = "ingress"
+  to_port           = 443
+  from_port         = 443
+  protocol          = "tcp"
+  security_group_id = "${aws_security_group.monitoring_external_sg.id}"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
 resource "aws_security_group_rule" "allow_prometheus_access_alertmanager" {
   type              = "ingress"
   to_port           = 80


### PR DESCRIPTION
https://trello.com/c/PQNsTTaX/436-https-for-prometheus-and-alertmanager

The changes here enable SSL encryption for your service endpoints.
A certificate is issued & stored in AWS certificate manager. The
ALB can then make use of the certificate. All incoming requests
to the ALB to port 443 will be served HTTPS traffic. It is still
possible to use the HTTP endpoint, however we can drop that
support later on when we are happy with HTTPS is working fine.

Validation of the certificate is done using DNS validation. Note,
that as DNS validation can take a little while (anywhere from a
couple of minutes up to half an hour) there is a chance that dev
stacks will take much longer to create. It is likely suggested that
devs don't tear down their stack fully and instead keep a dev stack
for themselves which they make changes to.

Certificate renewal is handled by AWS automatically and if this
fails then we will get an email sent to the address associated
with the AWS account.