### PR TITLE
WIP: Deploy container instances in separate ASGs

### DIFF
--- a/terraform/projects/app-ecs-albs/README.md
+++ b/terraform/projects/app-ecs-albs/README.md
@@ -19,11 +19,13 @@ Create ALBs for the ECS cluster
 |------|-------------|
 | alertmanager_alb_dns | External Alertmanager ALB DNS name |
 | alertmanager_alb_zoneid | External Alertmanager ALB zone id |
-| alertmanager_external_tg | External Alertmanager ALB target group |
+| alerts_private_record_fqdn | Alert Managers private DNS fqdn |
 | monitoring_external_tg | External Monitoring ALB target group |
+| monitoring_internal_tg | External Alertmanager ALB target group |
 | paas_proxy_alb_dns | Internal PaaS ALB DNS name |
 | paas_proxy_alb_zoneid | Internal PaaS ALB target group |
-| pass_proxy_tg | Paas proxy target group |
+| paas_proxy_private_record_fqdn | PaaS Proxy private DNS fqdn |
+| paas_proxy_tg | Paas proxy target group |
 | prometheus_alb_dns | External Monitoring ALB DNS name |
 | zone_id | External Monitoring ALB hosted zone ID |
 

--- a/terraform/projects/app-ecs-instances/README.md
+++ b/terraform/projects/app-ecs-instances/README.md
@@ -9,9 +9,6 @@ Create ECS container instances
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | additional_tags | Stack specific tags to apply | map | `<map>` | no |
-| autoscaling_group_desired_capacity | Desired number of ECS container instances | string | `1` | no |
-| autoscaling_group_max_size | Maximum desired number of ECS container instances | string | `1` | no |
-| autoscaling_group_min_size | Minimum desired number of ECS container instances | string | `1` | no |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | ecs_image_id | AMI ID to use for the ECS container instances | string | `ami-2d386654` | no |
 | ecs_instance_root_size | ECS container instance root volume size - in GB | string | `50` | no |
@@ -19,10 +16,4 @@ Create ECS container instances
 | ecs_instance_type | ECS container instance type | string | `m4.xlarge` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | `ecs-monitoring` | no |
 | stack_name | Unique name for this collection of resources | string | `ecs-monitoring` | no |
-
-## Outputs
-
-| Name | Description |
-|------|-------------|
-| ecs_instance_asg_id | ecs-instance ASG ID |
 

--- a/terraform/projects/app-ecs-instances/ecs-iam-policy.tf
+++ b/terraform/projects/app-ecs-instances/ecs-iam-policy.tf
@@ -60,14 +60,6 @@ data "aws_iam_policy_document" "ecs_instance_document" {
       "ec2:DetachVolume",
     ]
   }
-
-  statement {
-    resources = ["*"]
-
-    actions = [
-      "ec2:DescribeVolumes",
-    ]
-  }
 }
 
 resource "aws_iam_policy" "ecs_instance_policy" {

--- a/terraform/projects/infra-networking/README.md
+++ b/terraform/projects/infra-networking/README.md
@@ -19,10 +19,10 @@ related services. You will often have multiple VPCs in an account
 
 | Name | Description |
 |------|-------------|
-| az_names | Names of available availability zones |
 | nat_gateway | List of nat gateway IP |
 | private_subnets | List of private subnet IDs |
 | private_subnets_ips | List of public subnet IDs |
+| private_zone_id | Route 53 Zone ID for the internal zone |
 | public_subnets | List of public subnet IDs |
 | public_zone_id | Route 53 Zone ID for publicly visible zone |
 | vpc_id | VPC ID where the stack resources are created |

--- a/terraform/projects/infra-networking/main.tf
+++ b/terraform/projects/infra-networking/main.tf
@@ -135,11 +135,6 @@ resource "aws_route53_record" "shared_dev_ns" {
 
 ## Outputs
 
-output "az_names" {
-  value       = "${data.aws_availability_zones.available.names}"
-  description = "Names of available availability zones"
-}
-
 output "vpc_id" {
   value       = "${module.vpc.vpc_id}"
   description = "VPC ID where the stack resources are created"


### PR DESCRIPTION
This commit splits the one-ASG-with-three-instances into
three-ASGs-with-one-instance-each.

The goal I am going for with this commit is: we need to be able to
tell each separate prometheus service
aws_ecs_service.prometheus_server to run on a separate instance.  I
would also like to make our code flexible enough that dev environments
can run one single instance, and staging and production could scale
down to 2, or up to 4 (with two prometheis in a single AZ), if desired.

I had considered telling the services to run with [placement contraints][1]
pinning each prometheus service to a specific availability zone.
However, if there are only 1 or 2 instances, then some of the AZs will
be empty, and pinning a service to that AZ will mean it can never run
at all.  Moreover, there's no clean way to know which AZs are
available.  Finally: if an instance in an ASG dies, will the instance
that replaces it be in the same AZ, or could it come back in a
different one?

I thought a better way of doing this would be to set an explicit
placement attribute in the ECS agent for each instance.  In order to
do this, each instance needs to be created by a separate ASG (because
an ASG has a single user data script, and the user data script sets up
the ECS agent settings).  Now we can pin prometheus services to
specific instances using the custom `prometheus-instance` attribute,
and have confidence that those specific instances exist.

Unfortunately, [terraform modules don't currently support the count attribute][2],
so the only way to have multiple ASGs using this module
is to copy/paste the module multiple times.  This feels like the
least-worst option to me.  (In future, to scale up we would need to
copy/paste more.  To make the number of instances configurable, we can
make each ASG conditional based on the desired number of instances.
For details, see the [module docs][3].)

This has a side benefit that we can now specify the exact volume id in
user data again, rather than doing the trick where we grab a list of
volumes from the API and select the one that's in the same AZ as
us.  (This also enables us to deploy multiple instances in the same AZ
in future if we want.)

In order to be certain that we're pairing up availability zones,
private subnets, ASGs and volume ids correctly, I introduced a
data.aws_subnet.private_subnets data source, and pull availability
zone config from there to configure the aws_ebs_volumes.  This means
we can be confident that the EBS volume is in the same AZ as the ASG
it's paired with.

Note that the number 3 is still hardcoded throughout
app-ecs-instances/main.tf; actually making things configurable will
come in future commits.

I'm issuing this as a PR on its own, even though it isn't the whole multi-AZ story, for a number of reasons:

 - it's big enough by itself and worth making visible
 - I want to deploy this change and ensure that the ECS attributes are present on the instances before deploying any changes that rely on those attributes

[1]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html
[2]: https://github.com/hashicorp/terraform/issues/953
[3]: https://registry.terraform.io/modules/terraform-aws-modules/autoscaling/aws/2.6.0