### PR TITLE
Pin prometheus and alertmanager to specific AZs

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -37,6 +37,7 @@ stack_name = "${ENV}"
 dev_environment = "true"
 prometheus_subdomain = "${ENV}"
 targets_s3_bucket="$DEFAULT_DEV_TARGETS_S3_BUCKET"
+prometheis_total=1
 additional_tags = {
   "Environment" = "${ENV}"
 }

--- a/terraform/projects/app-ecs-instances/README.md
+++ b/terraform/projects/app-ecs-instances/README.md
@@ -9,14 +9,18 @@ Create ECS container instances
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | additional_tags | Stack specific tags to apply | map | `<map>` | no |
-| autoscaling_group_desired_capacity | Desired number of ECS container instances | string | `3` | no |
-| autoscaling_group_max_size | Maximum desired number of ECS container instances | string | `3` | no |
-| autoscaling_group_min_size | Minimum desired number of ECS container instances | string | `3` | no |
 | aws_region | AWS region | string | `eu-west-1` | no |
 | ecs_image_id | AMI ID to use for the ECS container instances | string | `ami-2d386654` | no |
 | ecs_instance_root_size | ECS container instance root volume size - in GB | string | `50` | no |
 | ecs_instance_ssh_keyname | SSH keyname for ECS container instances | string | `ecs-monitoring-ssh-test` | no |
 | ecs_instance_type | ECS container instance type | string | `m4.xlarge` | no |
+| prometheis_total | Desired number of prometheus servers.  Maximum 3. | string | `3` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | `ecs-monitoring` | no |
 | stack_name | Unique name for this collection of resources | string | `ecs-monitoring` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| available_azs | AZs available with running container instances |
 

--- a/terraform/projects/app-ecs-instances/README.md
+++ b/terraform/projects/app-ecs-instances/README.md
@@ -20,9 +20,3 @@ Create ECS container instances
 | remote_state_bucket | S3 bucket we store our terraform state in | string | `ecs-monitoring` | no |
 | stack_name | Unique name for this collection of resources | string | `ecs-monitoring` | no |
 
-## Outputs
-
-| Name | Description |
-|------|-------------|
-| ecs_instance_asg_id | ecs-instance ASG ID |
-

--- a/terraform/projects/app-ecs-instances/main.tf
+++ b/terraform/projects/app-ecs-instances/main.tf
@@ -17,22 +17,10 @@ variable "aws_region" {
   default     = "eu-west-1"
 }
 
-variable "autoscaling_group_min_size" {
+variable "prometheis_total" {
   type        = "string"
-  description = "Minimum desired number of ECS container instances"
-  default     = 3
-}
-
-variable "autoscaling_group_max_size" {
-  type        = "string"
-  description = "Maximum desired number of ECS container instances"
-  default     = 3
-}
-
-variable "autoscaling_group_desired_capacity" {
-  type        = "string"
-  description = "Desired number of ECS container instances"
-  default     = 3
+  description = "Desired number of prometheus servers.  Maximum 3."
+  default     = "3"
 }
 
 variable "ecs_image_id" {
@@ -127,8 +115,9 @@ data "terraform_remote_state" "infra_security_groups" {
   }
 }
 
-data "aws_subnet" "private_subnets" {
-  count = "${length(data.terraform_remote_state.infra_networking.private_subnets)}"
+data "aws_subnet" "subnets_for_prometheus" {
+  # only use enough subnets to fit the desired number of prometheus servers
+  count = "${var.prometheis_total}"
   id    = "${data.terraform_remote_state.infra_networking.private_subnets[count.index]}"
 }
 
@@ -174,11 +163,11 @@ module "ecs_instance" {
 
   # Auto scaling group
   asg_name                  = "${var.stack_name}-ecs-instance"
-  vpc_zone_identifier       = ["${data.aws_subnet.private_subnets.*.id}"]
+  vpc_zone_identifier       = ["${data.aws_subnet.subnets_for_prometheus.*.id}"]
   health_check_type         = "EC2"
-  min_size                  = "${var.autoscaling_group_min_size}"
-  max_size                  = "${var.autoscaling_group_max_size}"
-  desired_capacity          = "${var.autoscaling_group_desired_capacity}"
+  min_size                  = "${var.prometheis_total}"
+  max_size                  = "${var.prometheis_total}"
+  desired_capacity          = "${var.prometheis_total}"
   wait_for_capacity_timeout = 0
 
   tags_as_map = "${merge(
@@ -190,9 +179,9 @@ module "ecs_instance" {
 }
 
 resource "aws_ebs_volume" "prometheus_ebs_volume" {
-  count = 3
+  count = "${length(data.aws_subnet.subnets_for_prometheus.*.availability_zone)}"
 
-  availability_zone = "${element(data.aws_subnet.private_subnets.*.availability_zone, count.index)}"
+  availability_zone = "${element(data.aws_subnet.subnets_for_prometheus.*.availability_zone, count.index)}"
   size              = 500
   type              = "gp2"
 
@@ -212,4 +201,11 @@ resource "aws_ebs_volume" "prometheus_ebs_volume" {
     map("Stackname", "${var.stack_name}"),
     map("Name", "${var.stack_name}-prometheus-ebs-volume")
   )}"
+}
+
+## Outputs
+
+output "available_azs" {
+  value       = "${data.aws_subnet.subnets_for_prometheus.*.availability_zone}"
+  description = "AZs available with running container instances"
 }

--- a/terraform/projects/app-ecs-services/alertmanager-service.tf
+++ b/terraform/projects/app-ecs-services/alertmanager-service.tf
@@ -104,6 +104,11 @@ resource "aws_ecs_service" "alertmanager_server" {
     container_name   = "alertmanager"
     container_port   = 9093
   }
+
+  placement_constraints {
+    type       = "memberOf"
+    expression = "attribute:ecs.availability-zone == ${element(data.aws_subnet.private_subnets.*.availability_zone, count.index)}"
+  }
 }
 
 #### alertmanager

--- a/terraform/projects/app-ecs-services/alertmanager-service.tf
+++ b/terraform/projects/app-ecs-services/alertmanager-service.tf
@@ -92,7 +92,7 @@ resource "aws_ecs_task_definition" "alertmanager_server" {
 }
 
 resource "aws_ecs_service" "alertmanager_server" {
-  count = 3
+  count = "${length(data.terraform_remote_state.app_ecs_instances.available_azs)}"
 
   name            = "${var.stack_name}-alertmanager-server-${count.index + 1}"
   cluster         = "${var.stack_name}-ecs-monitoring"
@@ -107,7 +107,7 @@ resource "aws_ecs_service" "alertmanager_server" {
 
   placement_constraints {
     type       = "memberOf"
-    expression = "attribute:ecs.availability-zone == ${element(data.aws_subnet.private_subnets.*.availability_zone, count.index)}"
+    expression = "attribute:ecs.availability-zone == ${data.terraform_remote_state.app_ecs_instances.available_azs[count.index]}"
   }
 }
 

--- a/terraform/projects/app-ecs-services/main.tf
+++ b/terraform/projects/app-ecs-services/main.tf
@@ -98,6 +98,11 @@ data "terraform_remote_state" "app_ecs_albs" {
   }
 }
 
+data "aws_subnet" "private_subnets" {
+  count = "${length(data.terraform_remote_state.infra_networking.private_subnets)}"
+  id    = "${data.terraform_remote_state.infra_networking.private_subnets[count.index]}"
+}
+
 ## Resources
 
 resource "aws_cloudwatch_log_group" "task_logs" {

--- a/terraform/projects/app-ecs-services/main.tf
+++ b/terraform/projects/app-ecs-services/main.tf
@@ -98,9 +98,14 @@ data "terraform_remote_state" "app_ecs_albs" {
   }
 }
 
-data "aws_subnet" "private_subnets" {
-  count = "${length(data.terraform_remote_state.infra_networking.private_subnets)}"
-  id    = "${data.terraform_remote_state.infra_networking.private_subnets[count.index]}"
+data "terraform_remote_state" "app_ecs_instances" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "app-ecs-instances.tfstate"
+    region = "${var.aws_region}"
+  }
 }
 
 ## Resources

--- a/terraform/projects/app-ecs-services/prometheus-service.tf
+++ b/terraform/projects/app-ecs-services/prometheus-service.tf
@@ -149,7 +149,7 @@ resource "aws_ecs_task_definition" "paas_proxy" {
 resource "aws_ecs_service" "prometheus_server" {
   count = "${length(data.terraform_remote_state.app_ecs_albs.monitoring_external_tg)}"
 
-  name            = "${var.stack_name}-prometheus-server-${count.index}"
+  name            = "${var.stack_name}-prometheus-server-${count.index + 1}"
   cluster         = "${var.stack_name}-ecs-monitoring"
   task_definition = "${aws_ecs_task_definition.prometheus_server.arn}"
   desired_count   = 1

--- a/terraform/projects/app-ecs-services/prometheus-service.tf
+++ b/terraform/projects/app-ecs-services/prometheus-service.tf
@@ -159,6 +159,11 @@ resource "aws_ecs_service" "prometheus_server" {
     container_name   = "auth-proxy"
     container_port   = 9090
   }
+
+  placement_constraints {
+    type       = "memberOf"
+    expression = "attribute:ecs.availability-zone == ${element(data.aws_subnet.private_subnets.*.availability_zone, count.index)}"
+  }
 }
 
 resource "aws_ecs_service" "paas_proxy_service" {

--- a/terraform/projects/infra-networking/README.md
+++ b/terraform/projects/infra-networking/README.md
@@ -19,7 +19,6 @@ related services. You will often have multiple VPCs in an account
 
 | Name | Description |
 |------|-------------|
-| az_names | Names of available availability zones |
 | nat_gateway | List of nat gateway IP |
 | private_subnets | List of private subnet IDs |
 | private_subnets_ips | List of public subnet IDs |

--- a/terraform/projects/infra-networking/main.tf
+++ b/terraform/projects/infra-networking/main.tf
@@ -135,11 +135,6 @@ resource "aws_route53_record" "shared_dev_ns" {
 
 ## Outputs
 
-output "az_names" {
-  value       = "${data.aws_availability_zones.available.names}"
-  description = "Names of available availability zones"
-}
-
 output "vpc_id" {
   value       = "${module.vpc.vpc_id}"
   description = "VPC ID where the stack resources are created"


### PR DESCRIPTION
This supersedes #38, which can now be closed.

This PR pins prometheus and alertmanager to specific AZs, and makes the number of instances configurable via a tfvar `prometheis_total`.  It can have any value from 0 to 3.  It
will control the number of instances created in the autoscaling group,
and in turn the number of prometheus/alertmanager servers created.

The tricky part here is ensuring that we assign services to
availability zones which actually have instances in them.  If we just
let the autoscaling group have all subnets (and hence all availability
zones), I don't know what guarantees there are about which AZs it will
choose to use.

In this PR, we ensure that the ASG only has access to a subset of
subnets, that the EBS volumes are created in AZs corresponding to
those subnets, and that the services are assigned to those AZs.
This way, we avoid a possible situation where an instance is created
in an AZ which has no EBS volumes (and vice versa).

After this PR, you can add

```
prometheis_total = 1
```

to your stacks/foo.tfvars file in order to reduce the number of
instances you provision.  Newly-created dev environments
(created via `make create-stack` will default to 1 instance.)