### PR TITLE
Add product alert label to registers and test alerts

### DIFF
--- a/terraform/projects/app-ecs-services/config/alerts/alerts.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/alerts.yml
@@ -6,6 +6,7 @@ groups:
     for: 1m
     labels:
         severity: "P3"
+        product: "tools"
     annotations:
         summary: "Service is taking longer than 2 seconds to respond"
         description: "The service name is {{ $labels.job }}. The URL under test is {{ $labels.instance }}"

--- a/terraform/projects/app-ecs-services/config/alerts/registers.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/registers.yml
@@ -4,6 +4,8 @@ groups:
   - alert: RequestsExcess5xx
     expr: sum(increase(requests{job="openregister-metric-exporter",status_range="5xx"}[5m])) by (app) >= 3
     for: 15s
+    labels:
+        product: "registers"
     annotations:
         summary: "Service has too many 5xx errors"
         description: "Service {{ $labels.app }} has had too many 5xx errors."


### PR DESCRIPTION
In order to filter between different products on grafana a `product` label has been added, so that on the grafana dashboard we can see alerts by product using a query similar to this- 

`ALERTS{product="tools"}`