### PR TITLE
rejig how we manage paas-proxy and alertmanager private names

### DIFF
--- a/terraform/projects/app-ecs-albs/README.md
+++ b/terraform/projects/app-ecs-albs/README.md
@@ -19,12 +19,12 @@ Create ALBs for the ECS cluster
 |------|-------------|
 | alertmanager_alb_dns | External Alertmanager ALB DNS name |
 | alertmanager_alb_zoneid | External Alertmanager ALB zone id |
-| alerts_private_record_fqdn | Alert Managers private DNS fqdn |
+| alerts_private_record_fqdns | Alertmanagers private DNS FQDNs |
 | monitoring_external_tg | External Monitoring ALB target group |
 | monitoring_internal_tg | External Alertmanager ALB target group |
 | paas_proxy_alb_dns | Internal PaaS ALB DNS name |
 | paas_proxy_alb_zoneid | Internal PaaS ALB target group |
-| paas_proxy_private_record_fqdn | PaaS Proxy private DNS fqdn |
+| paas_proxy_private_record_fqdn | PaaS Proxy private DNS FQDN |
 | paas_proxy_tg | Paas proxy target group |
 | prometheus_alb_dns | External Monitoring ALB DNS name |
 | zone_id | External Monitoring ALB hosted zone ID |

--- a/terraform/projects/app-ecs-albs/main.tf
+++ b/terraform/projects/app-ecs-albs/main.tf
@@ -446,12 +446,12 @@ output "paas_proxy_tg" {
   description = "Paas proxy target group"
 }
 
-output "alerts_private_record_fqdn" {
+output "alerts_private_record_fqdns" {
   value       = "${aws_route53_record.alerts_private_record.*.fqdn}"
-  description = "Alert Managers private DNS fqdn"
+  description = "Alertmanagers private DNS FQDNs"
 }
 
 output "paas_proxy_private_record_fqdn" {
-  value       = "${aws_route53_record.paas_proxy_private_record.*.fqdn}"
-  description = "PaaS Proxy private DNS fqdn"
+  value       = "${aws_route53_record.paas_proxy_private_record.fqdn}"
+  description = "PaaS Proxy private DNS FQDN"
 }

--- a/terraform/projects/app-ecs-services/templates/prometheus.tpl
+++ b/terraform/projects/app-ecs-services/templates/prometheus.tpl
@@ -4,7 +4,7 @@ alerting:
   alertmanagers:
   - scheme: http
     static_configs:
-      - targets: ["${alertmanager_dns_name}"]
+      - targets: ["${alertmanager_dns_names}"]
 rule_files:
   - "/etc/prometheus/alerts/*"
 scrape_configs:
@@ -16,7 +16,7 @@ scrape_configs:
     scheme: http
     scrape_interval: 5s
     static_configs:
-      - targets: ["${alertmanager_dns_name}"]
+      - targets: ["${alertmanager_dns_names}"]
   - job_name: paas-targets
     scheme: http
     proxy_url: 'http://${paas_proxy_dns_name}:8080'


### PR DESCRIPTION
This commit does a couple of things:

 - in the app-ecs-albs outputs, make it clear that
   alerts_private_record_fqdns is a list of FQDNs by giving it a
   plural name, and make it clear that paas_proxy_private_record_fqdn
   is a single FQDN by making a string instead of a list of exactly
   one string

 - in the prometheus configuration templating, restrict the number of
   alertmanagers we scrape and that we send alerts to, to the number
   of available_azs, so we don't try to scrape non-existant
   alertmanagers.