### PR TITLE
Make alert manager alert when there is 2 or less instances

### DIFF
--- a/terraform/projects/app-ecs-services/config/alerts/alerts.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/alerts.yml
@@ -10,3 +10,17 @@ groups:
     annotations:
         summary: "Service is taking longer than 2 seconds to respond"
         description: "The service name is {{ $labels.job }}. The URL under test is {{ $labels.instance }}"
+
+- name: AlertManager
+  rules:
+  - alert: AlertManager_Below_Threshold
+    expr: sum(up{job="alertmanager"}) by (job, instance) <= 2 and up{job="alertmanager"} == 0
+    for: 10s
+    labels:
+        severity: "P2"
+        product: "tools"
+    annotations:
+        summary: "Service is below the expected instance Threshold"
+        description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}"
+
+# this can be improved however maybe this is something we need to focus on in Q2 when working on the support plan

--- a/terraform/projects/app-ecs-services/config/alerts/alerts.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/alerts.yml
@@ -14,7 +14,7 @@ groups:
 - name: AlertManager
   rules:
   - alert: AlertManager_Below_Threshold
-    expr: sum(up{job="alertmanager"}) by (job, instance) <= 2 and up{job="alertmanager"} == 0
+    expr: sum(up{job="alertmanager"}) by (job, instance) <= 1 and up{job="alertmanager"} == 0
     for: 10s
     labels:
         severity: "P2"


### PR DESCRIPTION
This is an alert that will trigger when there is two or
less instances available on cluster.

I have tested and ensured functionality, I believe this will be routed to us based on the label tools.