### PR TITLE
Remove alerts on test applications

### DIFF
--- a/terraform/projects/app-ecs-services/config/alerts/alerts.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/alerts.yml
@@ -1,16 +1,4 @@
 groups:
-- name: HTTP-SVC-BASE-CHECKS
-  rules:
-  - alert: RequestsReponseTimeBelow
-    expr: up{job="tools-test-app"} == 0
-    for: 1m
-    labels:
-        severity: "P3"
-        product: "tools"
-    annotations:
-        summary: "Service is taking longer than 2 seconds to respond"
-        description: "The service name is {{ $labels.job }}. The URL under test is {{ $labels.instance }}"
-
 - name: AlertManager
   rules:
   - alert: AlertManager_Below_Threshold


### PR DESCRIPTION
This is being done as part of https://trello.com/c/WYpdllfH/439-switch-off-alpha-prometheus

This removes alerts on applications that aren't being run in a production environment. We've done this because we now have alerts that work for running applications and no longer need to prove that it can be done