### PR TITLE
Change registers alert

### DIFF
--- a/terraform/projects/app-ecs-services/config/alerts/registers.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/registers.yml
@@ -2,10 +2,10 @@ groups:
 - name: Registers
   rules:
   - alert: RequestsExcess5xx
-    expr: sum(increase(requests{job="openregister-metric-exporter",status_range="5xx"}[5m])) by (app) >= 3
-    for: 15s
+    expr: sum by(app) (rate(requests{job="openregister-metric-exporter",status_range="5xx"}[5m])) / sum by(app) (rate(requests{job="openregister-metric-exporter"}[5m])) >= 0.25
+    for: 120s
     labels:
         product: "registers"
     annotations:
-        summary: "Service has too many 5xx errors"
-        description: "Service {{ $labels.app }} has had too many 5xx errors."
+        summary: "App {{ $labels.app }} has too many 5xx errors"
+        description: "App {{ $labels.app }} has 5xx errors in excess of 25% of total requests"


### PR DESCRIPTION
The previous alert was really quite spammy.  We sat down and talked
about what might be a better measure of failure.

For context:

 - a lot of 5xx errors on the registers app are caused by bots making
   weird requests; they therefore don't really result in real users
   being impacted and the alert isn't actionable
 - the failure modes we are interested in are things like "we broke
   the app and now basically every request fails (except maybe things
   like /favicon.ico)

As a result, we decided to change the alert to be "some really high
percentage of all requests are erroring".

This alert says "if the total requests over a 5 minute rolling window
has more than 25% 5xx errors, and continues to do so for 2 minutes
solidly, raise an alert".

cc @michaelabenyohai @gidsg