### PR TITLE
Specify --web.external-url when running Prometheus

### DIFF
--- a/terraform/projects/app-ecs-albs/main.tf
+++ b/terraform/projects/app-ecs-albs/main.tf
@@ -450,6 +450,11 @@ output "paas_proxy_tg" {
   description = "Paas proxy target group"
 }
 
+output "prom_public_record_fqdns" {
+  value       = "${aws_route53_record.prom_alias.*.fqdn}"
+  description = "Prometheus public DNS FQDNs"
+}
+
 output "alerts_private_record_fqdns" {
   value       = "${aws_route53_record.alerts_private_record.*.fqdn}"
   description = "Alertmanagers private DNS FQDNs"

--- a/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json
+++ b/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json
@@ -15,6 +15,13 @@
         "containerPath": "/prometheus"
       }
     ],
+    "command": [
+      "--config.file=/etc/prometheus/prometheus.yml",
+      "--storage.tsdb.path=/prometheus",
+      "--web.console.libraries=/usr/share/prometheus/console_libraries",
+      "--web.console.templates=/usr/share/prometheus/consoles",
+      "--web.external-url=${prom_url}"
+    ],
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {


### PR DESCRIPTION
This commit updates our container definitions so that we can specify
the external URL that Prometheus can be accessed by.

This is important, because when Prometheus ships alerts to
Alertmanager, it tags them with a source URL, which by default is a
private non-routable URL.  To make our alerts more useful, we should
have a publicly-routable URL here instead.

Because each prometheus instance has a different public URL, they each
need a separate command-line parameter.  To achieve this I split the
single task definition into one per prometheus.