### PR TITLE
Reduce size of dev EC2 instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ make apply          # Apply all terraform, auto approves
 
 If you are changing stacks or have a problem with the terraform state:
 
-`make clean`
+`make clean create-stack init`
 
 To delete a stack:
 

--- a/terraform/projects/app-ecs-albs/README.md
+++ b/terraform/projects/app-ecs-albs/README.md
@@ -26,6 +26,7 @@ Create ALBs for the ECS cluster
 | paas_proxy_alb_zoneid | Internal PaaS ALB target group |
 | paas_proxy_private_record_fqdn | PaaS Proxy private DNS FQDN |
 | paas_proxy_tg | Paas proxy target group |
+| prom_public_record_fqdns | Prometheus public DNS FQDNs |
 | prometheus_alb_dns | External Monitoring ALB DNS name |
 | zone_id | External Monitoring ALB hosted zone ID |
 

--- a/terraform/projects/app-ecs-instances/README.md
+++ b/terraform/projects/app-ecs-instances/README.md
@@ -9,7 +9,9 @@ Create ECS container instances
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | additional_tags | Stack specific tags to apply | map | `<map>` | no |
+| asg_dev_scaledown_schedules | Schedules for scaling down dev EC2 instances | list | `<list>` | no |
 | aws_region | AWS region | string | `eu-west-1` | no |
+| dev_environment | Boolean flag for development environments | string | `false` | no |
 | ecs_instance_root_size | ECS container instance root volume size - in GB | string | `50` | no |
 | ecs_instance_ssh_keyname | SSH keyname for ECS container instances | string | `ecs-monitoring-ssh-test` | no |
 | ecs_instance_type | ECS container instance type | string | `m4.xlarge` | no |
@@ -22,5 +24,6 @@ Create ECS container instances
 
 | Name | Description |
 |------|-------------|
+| asg_dev_scaledown_schedules | Cron schedule for scaling down dev EC2 instances |
 | available_azs | AZs available with running container instances |
 

--- a/terraform/projects/app-ecs-services/README.md
+++ b/terraform/projects/app-ecs-services/README.md
@@ -10,6 +10,8 @@ Create services and task definitions for the ECS cluster
 |------|-------------|:----:|:-----:|:-----:|
 | aws_region | AWS region | string | `eu-west-1` | no |
 | dev_environment | Boolean flag for development environments | string | `false` | no |
+| prom_cpu | CPU requirement for prometheus | string | `1024` | no |
+| prom_memoryReservation | memory reservation requirement for prometheus | string | `4096` | no |
 | remote_state_bucket | S3 bucket we store our terraform state in | string | `ecs-monitoring` | no |
 | stack_name | Unique name for this collection of resources | string | `ecs-monitoring` | no |
 | targets_s3_bucket | The default s3 bucket to grab targets | string | `gds-prometheus-targets` | no |

--- a/terraform/projects/app-ecs-services/prometheus-service.tf
+++ b/terraform/projects/app-ecs-services/prometheus-service.tf
@@ -7,6 +7,21 @@
 *
 */
 
+variable "prom_cpu" {
+  type        = "string"
+  description = "CPU requirement for prometheus"
+  default     = "1024"
+}
+
+variable "prom_memoryReservation" {
+  type        = "string"
+  description = "memory reservation requirement for prometheus"
+  default     = "4096"
+}
+
+# locals
+# --------------------------------------------------------------
+
 locals {
   num_azs = "${length(data.terraform_remote_state.app_ecs_instances.available_azs)}"
 
@@ -101,10 +116,12 @@ data "template_file" "prometheus_container_defn" {
   template = "${file("task-definitions/prometheus-server.json")}"
 
   vars {
-    prom_url      = "https://${local.prometheus_public_fqdns[count.index]}"
-    log_group     = "${aws_cloudwatch_log_group.task_logs.name}"
-    region        = "${var.aws_region}"
-    config_bucket = "${aws_s3_bucket.config_bucket.id}"
+    prom_cpu               = "${var.prom_cpu}"
+    prom_memoryReservation = "${var.prom_memoryReservation}"
+    prom_url               = "https://${local.prometheus_public_fqdns[count.index]}"
+    log_group              = "${aws_cloudwatch_log_group.task_logs.name}"
+    region                 = "${var.aws_region}"
+    config_bucket          = "${aws_s3_bucket.config_bucket.id}"
   }
 }
 

--- a/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json
+++ b/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json
@@ -2,8 +2,8 @@
   {
     "name": "prometheus",
     "image": "prom/prometheus",
-    "cpu": 1024,
-    "memoryReservation": 4096,
+    "cpu": ${prom_cpu},
+    "memoryReservation": ${prom_memoryReservation},
     "essential": true,
     "mountPoints": [
       {


### PR DESCRIPTION
## What

Aim of this PR is to reduce the size of the instances as in dev environments it's not necessary to run instances of `m4.xlarge`.

Updated setup.sh to remove the tfvars file when doing a clean of the stack, this is to ensure that when creating new dev stacks it uses the latest variables, previously devs were able to continue using the tfvars without any new vars being added resulting in default values for vars being used. 

In this case rather than using m4.xlarge use t2.small, and to pick up lower prometheus cpu and memoryReservation values for dev stacks.

The default dev stack `tfvars`, which is created by function `create_stack_configs` in the shell script, has been updated with default dev values which can be overridden by devs.

The prometheus task definition was changed in order to use the variables from tfvars for your stack if they exist otherwise default values will be used which are the default values for production and staging.

## Reference 

https://trello.com/c/Gn0fdyOr/447-destroy-our-dev-stacks-overnight-to-reduce-costs