### PR TITLE
Only trigger registers alert in production PaaS space

### DIFF
--- a/terraform/projects/app-ecs-services/config/alerts/registers.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/registers.yml
@@ -2,7 +2,7 @@ groups:
 - name: Registers
   rules:
   - alert: RequestsExcess5xx
-    expr: sum by(app) (rate(requests{job="openregister-metric-exporter",status_range="5xx"}[5m])) / sum by(app) (rate(requests{job="openregister-metric-exporter"}[5m])) >= 0.25
+    expr: sum by(app) (rate(requests{job="openregister-metric-exporter", exported_space="prod", status_range="5xx"}[5m])) / sum by(app) (rate(requests{job="openregister-metric-exporter", exported_space="prod"}[5m])) >= 0.25
     for: 120s
     labels:
         product: "registers"


### PR DESCRIPTION
https://trello.com/c/WGqLV0hX/498-registers-alert-on-staging-should-not-alert

CC: @alphagov/gov-uk-registers 

Registers saw an alert trigger yesterday but it turned out
they did not want it to trigger because it was for a non production
app that they were running in their `sandbox` PaaS space.

This commit means that only apps in their `prod` PaaS space are
alerted on. Gideon and myself tested this by checking the 
graphs for the new query vs the old query on our prometheus.

Note, it appears that because there is an label overwrite as
per https://prometheus.io/docs/prometheus/latest/configuration/configuration/
(see `honor_labels` on that page), we have to use the `exported_space`
rather than `space`. I will raise a separate trello ticket to
see if we can make these labels clearer/more user friendly.