### PR TITLE
Send emails from alertmanager using SES

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -47,6 +47,7 @@ targets_s3_bucket="$DEFAULT_DEV_TARGETS_S3_BUCKET"
 additional_tags = {
   "Environment" = "${ENV}"
 }
+ticket_recipient_email = "${TICKET_RECIPIENT_EMAIL}"
 EOF
 echo "stacks/${ENV}.tfvars created"
 fi

--- a/terraform/projects/app-ecs-albs/README.md
+++ b/terraform/projects/app-ecs-albs/README.md
@@ -20,6 +20,7 @@ Create ALBs for the ECS cluster
 | alertmanager_alb_dns | External Alertmanager ALB DNS name |
 | alertmanager_alb_zoneid | External Alertmanager ALB zone id |
 | alerts_private_record_fqdns | Alertmanagers private DNS FQDNs |
+| alerts_public_record_fqdns | Alertmanagers public DNS FQDNs |
 | monitoring_external_tg | Monitoring external target group |
 | monitoring_internal_tg | External Alertmanager ALB target group |
 | paas_proxy_alb_dns | Internal PaaS ALB DNS name |

--- a/terraform/projects/app-ecs-albs/main.tf
+++ b/terraform/projects/app-ecs-albs/main.tf
@@ -431,6 +431,11 @@ output "prom_public_record_fqdns" {
   description = "Prometheus public DNS FQDNs"
 }
 
+output "alerts_public_record_fqdns" {
+  value       = "${aws_route53_record.alerts_alias.*.fqdn}"
+  description = "Alertmanagers public DNS FQDNs"
+}
+
 output "alerts_private_record_fqdns" {
   value       = "${aws_route53_record.alerts_private_record.*.fqdn}"
   description = "Alertmanagers private DNS FQDNs"

--- a/terraform/projects/app-ecs-albs/main.tf
+++ b/terraform/projects/app-ecs-albs/main.tf
@@ -375,6 +375,7 @@ resource "aws_route53_record" "paas_proxy_private_record" {
 }
 
 ## Outputs
+
 output "monitoring_external_tg" {
   value       = "${aws_lb_target_group.nginx_auth_proxy_external_endpoint.arn}"
   description = "Monitoring external target group"

--- a/terraform/projects/app-ecs-services/README.md
+++ b/terraform/projects/app-ecs-services/README.md
@@ -15,4 +15,5 @@ Create services and task definitions for the ECS cluster
 | remote_state_bucket | S3 bucket we store our terraform state in | string | `ecs-monitoring` | no |
 | stack_name | Unique name for this collection of resources | string | `ecs-monitoring` | no |
 | targets_s3_bucket | The default s3 bucket to grab targets | string | `gds-prometheus-targets` | no |
+| ticket_recipient_email | Email address to send ticket alerts to | string | `prometheus-notifications@digital.cabinet-office.gov.uk` | no |
 

--- a/terraform/projects/app-ecs-services/alertmanager-service.tf
+++ b/terraform/projects/app-ecs-services/alertmanager-service.tf
@@ -7,6 +7,11 @@
 *
 */
 
+## Locals
+locals {
+  alertmanager_public_fqdns = "${data.terraform_remote_state.app_ecs_albs.alerts_public_record_fqdns}"
+}
+
 ## IAM roles & policies
 
 resource "aws_iam_role" "alertmanager_task_iam_role" {
@@ -66,18 +71,21 @@ resource "aws_iam_role_policy_attachment" "alertmanager_policy_attachment" {
 ### container, task, service definitions
 
 data "template_file" "alertmanager_container_defn" {
+  count    = "${length(local.alertmanager_public_fqdns)}"
   template = "${file("task-definitions/alertmanager-server.json")}"
 
   vars {
-    log_group     = "${aws_cloudwatch_log_group.task_logs.name}"
-    region        = "${var.aws_region}"
-    config_bucket = "${aws_s3_bucket.config_bucket.id}"
+    alertmanager_url = "https://${local.alertmanager_public_fqdns[count.index]}"
+    log_group        = "${aws_cloudwatch_log_group.task_logs.name}"
+    region           = "${var.aws_region}"
+    config_bucket    = "${aws_s3_bucket.config_bucket.id}"
   }
 }
 
 resource "aws_ecs_task_definition" "alertmanager_server" {
+  count                 = "${length(local.alertmanager_public_fqdns)}"
   family                = "${var.stack_name}-alertmanager-server"
-  container_definitions = "${data.template_file.alertmanager_container_defn.rendered}"
+  container_definitions = "${element(data.template_file.alertmanager_container_defn.*.rendered, count.index)}"
   task_role_arn         = "${aws_iam_role.alertmanager_task_iam_role.arn}"
 
   volume {
@@ -96,7 +104,7 @@ resource "aws_ecs_service" "alertmanager_server" {
 
   name            = "${var.stack_name}-alertmanager-server-${count.index + 1}"
   cluster         = "${var.stack_name}-ecs-monitoring"
-  task_definition = "${aws_ecs_task_definition.alertmanager_server.arn}"
+  task_definition = "${element(aws_ecs_task_definition.alertmanager_server.*.arn, count.index)}"
   desired_count   = 1
 
   load_balancer {
@@ -121,8 +129,8 @@ data "template_file" "alertmanager_config_file" {
   template = "${file("templates/alertmanager.tpl")}"
 
   vars {
-    pagerduty_service_key  = "${data.pass_password.pagerduty_service_key.password}"
-    smtp_from              = "alerts@${data.terraform_remote_state.infra_networking.public_subdomain}"
+    pagerduty_service_key = "${data.pass_password.pagerduty_service_key.password}"
+    smtp_from             = "alerts@${data.terraform_remote_state.infra_networking.public_subdomain}"
 
     # Port as requested by https://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-connect.html
     smtp_smarthost         = "email-smtp.${var.aws_region}.amazonaws.com:587"
@@ -140,7 +148,7 @@ data "template_file" "alertmanager_dev_config_file" {
   # (e.g. your personal email for testing).
   # https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses-procedure.html
   vars {
-    smtp_from              = "alerts@${data.terraform_remote_state.infra_networking.public_subdomain}"
+    smtp_from = "alerts@${data.terraform_remote_state.infra_networking.public_subdomain}"
 
     # Port as requested by https://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-connect.html
     smtp_smarthost         = "email-smtp.${var.aws_region}.amazonaws.com:587"

--- a/terraform/projects/app-ecs-services/alertmanager-service.tf
+++ b/terraform/projects/app-ecs-services/alertmanager-service.tf
@@ -121,12 +121,33 @@ data "template_file" "alertmanager_config_file" {
   template = "${file("templates/alertmanager.tpl")}"
 
   vars {
-    pagerduty_service_key = "${data.pass_password.pagerduty_service_key.password}"
+    pagerduty_service_key  = "${data.pass_password.pagerduty_service_key.password}"
+    smtp_from              = "alerts@${data.terraform_remote_state.infra_networking.public_subdomain}"
+
+    # Port as requested by https://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-connect.html
+    smtp_smarthost         = "email-smtp.${var.aws_region}.amazonaws.com:587"
+    smtp_username          = "${aws_iam_access_key.smtp.id}"
+    smtp_password          = "${aws_iam_access_key.smtp.ses_smtp_password}"
+    ticket_recipient_email = "${var.ticket_recipient_email}"
   }
 }
 
 data "template_file" "alertmanager_dev_config_file" {
   template = "${file("templates/alertmanager-dev.tpl")}"
+
+  # For dev stacks, as we have not requested "AWS SES production access", by default
+  # emails will not be sent unless you verify the recipient's email address
+  # (e.g. your personal email for testing).
+  # https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses-procedure.html
+  vars {
+    smtp_from              = "alerts@${data.terraform_remote_state.infra_networking.public_subdomain}"
+
+    # Port as requested by https://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-connect.html
+    smtp_smarthost         = "email-smtp.${var.aws_region}.amazonaws.com:587"
+    smtp_username          = "${aws_iam_access_key.smtp.id}"
+    smtp_password          = "${aws_iam_access_key.smtp.ses_smtp_password}"
+    ticket_recipient_email = "${var.ticket_recipient_email}"
+  }
 }
 
 resource "aws_s3_bucket_object" "alertmanager" {
@@ -134,4 +155,81 @@ resource "aws_s3_bucket_object" "alertmanager" {
   key     = "alertmanager/alertmanager.yml"
   content = "${var.dev_environment == "true" ? data.template_file.alertmanager_dev_config_file.rendered : data.template_file.alertmanager_config_file.rendered}"
   etag    = "${md5(var.dev_environment == "true" ? data.template_file.alertmanager_dev_config_file.rendered : data.template_file.alertmanager_config_file.rendered)}"
+}
+
+## AWS SES
+
+resource "aws_ses_domain_identity" "main" {
+  domain = "${data.terraform_remote_state.infra_networking.public_subdomain}"
+}
+
+resource "aws_route53_record" "txt_amazonses_verification_record" {
+  zone_id = "${data.terraform_remote_state.infra_networking.public_zone_id}"
+  name    = "_amazonses.${data.terraform_remote_state.infra_networking.public_subdomain}"
+  type    = "TXT"
+  ttl     = "600"
+  records = ["${aws_ses_domain_identity.main.verification_token}"]
+}
+
+resource "aws_ses_domain_dkim" "main" {
+  domain = "${aws_ses_domain_identity.main.domain}"
+}
+
+resource "aws_route53_record" "dkim_amazonses_verification_record" {
+  count   = 3
+  zone_id = "${data.terraform_remote_state.infra_networking.public_zone_id}"
+  name    = "${element(aws_ses_domain_dkim.main.dkim_tokens, count.index)}._domainkey.${data.terraform_remote_state.infra_networking.public_subdomain}"
+  type    = "CNAME"
+  ttl     = "600"
+  records = ["${element(aws_ses_domain_dkim.main.dkim_tokens, count.index)}.dkim.amazonses.com"]
+}
+
+resource "aws_ses_domain_mail_from" "alerts" {
+  domain           = "${aws_ses_domain_identity.main.domain}"
+  mail_from_domain = "mail.${aws_ses_domain_identity.main.domain}"
+}
+
+resource "aws_route53_record" "alerts_ses_domain_mail_from_mx" {
+  zone_id = "${data.terraform_remote_state.infra_networking.public_zone_id}"
+  name    = "${aws_ses_domain_mail_from.alerts.mail_from_domain}"
+  type    = "MX"
+  ttl     = "600"
+  records = ["10 feedback-smtp.${var.aws_region}.amazonses.com"]
+}
+
+resource "aws_route53_record" "alerts_ses_domain_mail_from_txt" {
+  zone_id = "${data.terraform_remote_state.infra_networking.public_zone_id}"
+  name    = "${aws_ses_domain_mail_from.alerts.mail_from_domain}"
+  type    = "TXT"
+  ttl     = "600"
+  records = ["v=spf1 include:amazonses.com -all"]
+}
+
+# IAM for SMTP
+
+resource "aws_iam_user" "smtp" {
+  name = "${var.stack_name}.smtp"
+  path = "/system/"
+}
+
+resource "aws_iam_access_key" "smtp" {
+  user = "${aws_iam_user.smtp.name}"
+}
+
+resource "aws_iam_user_policy" "smtp_ro" {
+  name = "${var.stack_name}.smtp"
+  user = "${aws_iam_user.smtp.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "ses:SendRawEmail",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
 }

--- a/terraform/projects/app-ecs-services/config/alerts/alerts.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/alerts.yml
@@ -6,6 +6,7 @@ groups:
     for: 10s
     labels:
         product: "prometheus"
+        severity: "page"
     annotations:
         summary: "Service is below the expected instance Threshold"
         description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}"
@@ -14,6 +15,7 @@ groups:
     for: 10s
     labels:
         product: "prometheus"
+        severity: "page"
     annotations:
         summary: "Service is below the expected instance Threshold"
         description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}"
@@ -31,6 +33,7 @@ groups:
     for: 10s
     labels:
         product: "prometheus"
+        severity: "page"
     annotations:
         summary: "No file_sd targets detected"
         description: "No file_sd targets were detected.  Is there a problem accessing the targets bucket?"
@@ -42,7 +45,7 @@ groups:
     for: 10s
     labels:
         product: "prometheus"
-        severity: page
+        severity: "page"
     annotations:
         summary: "Service is over capacity."
         description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}"
@@ -51,7 +54,7 @@ groups:
     expr: sum by(instance)(rate(prometheus_engine_query_duration_seconds_sum{job="prometheus"}[2h])) > 4
     labels:
         product: "prometheus"
-        severity: ticket
+        severity: "ticket"
     annotations:
         summary: "Service is approaching capacity."
         description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}"

--- a/terraform/projects/app-ecs-services/config/alerts/alerts.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/alerts.yml
@@ -58,3 +58,15 @@ groups:
     annotations:
         summary: "Service is approaching capacity."
         description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}"
+
+# Just for testing, should be removed after testing complete on staging and production
+
+  - alert: AlwaysAlert
+    expr: up{job="alertmanager"}  <= 3
+    for: 10s
+    labels:
+        product: "prometheus"
+        severity: "ticket"
+    annotations:
+        summary: "Always alerting"
+        description: "Always alerting"

--- a/terraform/projects/app-ecs-services/main.tf
+++ b/terraform/projects/app-ecs-services/main.tf
@@ -35,6 +35,12 @@ variable "stack_name" {
   default     = "ecs-monitoring"
 }
 
+variable "ticket_recipient_email" {
+  type        = "string"
+  description = "Email address to send ticket alerts to"
+  default     = "prometheus-notifications@digital.cabinet-office.gov.uk"
+}
+
 # Resources
 # --------------------------------------------------------------
 
@@ -133,4 +139,3 @@ resource "aws_s3_bucket" "config_bucket" {
 }
 
 ## Outputs
-

--- a/terraform/projects/app-ecs-services/main.tf
+++ b/terraform/projects/app-ecs-services/main.tf
@@ -139,3 +139,4 @@ resource "aws_s3_bucket" "config_bucket" {
 }
 
 ## Outputs
+

--- a/terraform/projects/app-ecs-services/prometheus-service.tf
+++ b/terraform/projects/app-ecs-services/prometheus-service.tf
@@ -218,7 +218,7 @@ resource "aws_ecs_service" "config_updater" {
   name            = "${var.stack_name}-targets-grabber"
   cluster         = "${var.stack_name}-ecs-monitoring"
   task_definition = "${aws_ecs_task_definition.config_updater.arn}"
-  desired_count   = 3
+  desired_count   = "${length(data.terraform_remote_state.app_ecs_instances.available_azs)}"
 }
 
 data "template_file" "config_updater_defn" {

--- a/terraform/projects/app-ecs-services/task-definitions/alertmanager-server.json
+++ b/terraform/projects/app-ecs-services/task-definitions/alertmanager-server.json
@@ -12,7 +12,8 @@
       }
     ],
     "command": [
-      "--config.file=/etc/alertmanager/alertmanager.yml"
+      "--config.file=/etc/alertmanager/alertmanager.yml",
+      "--web.external-url=${alertmanager_url}"
     ],
     "mountPoints": [
       {

--- a/terraform/projects/app-ecs-services/templates/alertmanager-dev.tpl
+++ b/terraform/projects/app-ecs-services/templates/alertmanager-dev.tpl
@@ -1,8 +1,21 @@
 global:
   resolve_timeout: 5m
 
+  smtp_from: "${smtp_from}"
+  smtp_smarthost: "${smtp_smarthost}"
+  smtp_auth_username: "${smtp_username}"
+  smtp_auth_password: "${smtp_password}"
+
 route:
-  receiver: 'unmatched-default-root-route'
+  receiver: "unmatched-default-root-route"
+  routes:
+  - receiver: "ticket-alert"
+    match:
+      product: "prometheus"
+      severity: "ticket"
 
 receivers:
-- name: 'unmatched-default-root-route'
+- name: "unmatched-default-root-route"
+- name: "ticket-alert"
+  email_configs:
+  - to: "${ticket_recipient_email}"

--- a/terraform/projects/app-ecs-services/templates/alertmanager.tpl
+++ b/terraform/projects/app-ecs-services/templates/alertmanager.tpl
@@ -1,10 +1,23 @@
 global:
   resolve_timeout: 5m
 
+  smtp_from: "${smtp_from}"
+  smtp_smarthost: "${smtp_smarthost}"
+  smtp_auth_username: "${smtp_username}"
+  smtp_auth_password: "${smtp_password}"
+
 route:
-  receiver: 'pagerduty'
+  receiver: "pagerduty"
+  routes:
+  - receiver: "ticket-alert"
+    match:
+      product: "prometheus"
+      severity: "ticket"
 
 receivers:
-- name: 'pagerduty'
+- name: "pagerduty"
   pagerduty_configs:
     - service_key: "${pagerduty_service_key}"
+- name: "ticket-alert"
+  email_configs:
+  - to: "${ticket_recipient_email}"


### PR DESCRIPTION
This is the first step to enable integration with zendesk, it uses AWS SES (Simple Email Service) to allow alertmanager to send emails.

In order to test it on dev environment and to enable staging to send emails the recipients email address will need to be verified on the SES AWS console.

On the production environment, production access has been requested which will allow emails to be sent to any recipient and the daily quota has been increased to 200. 

Note - 
- After merging, the alert that always triggers will need to be removed, they have been left in to trigger the alert to send an email.
- Each alertmanager will send an email, so for staging and prod as there are 3 alertmanagers (one for each availability zone), we expect to receive 3 emails per ticket alert.
  - One way of handling this would be to provide a weave mesh for the alertmanagers (https://www.robustperception.io/high-availability-prometheus-alerting-and-notification), unfortunately it appears that ECS only allows a single port to be exposed, and meshing requires an additional port to be open. We should be able to use meshing this when the prometheus and alertmanager run on an instance rather than in ECS.
- as we are using the default alertmanager configuration the default value for `repeat_interval` is 4 hours, this means that the email will be sent out every 4 hours until the alert is resovled.

Reference -

https://trello.com/c/Fpir7Ilk