### PR TITLE
Allow access to prometheus UI to internal users

### DIFF
--- a/terraform/projects/app-ecs-albs/main.tf
+++ b/terraform/projects/app-ecs-albs/main.tf
@@ -107,10 +107,9 @@ resource "aws_lb" "monitoring_internal_alb" {
   name               = "${var.stack_name}-internal-alb"
   internal           = true
   load_balancer_type = "application"
-  security_groups    = ["${data.terraform_remote_state.infra_security_groups.alertmanager_external_sg_id}"]
-
+  security_groups    = ["${data.terraform_remote_state.infra_security_groups.monitoring_internal_sg_id}"]
   subnets = [
-    "${data.terraform_remote_state.infra_networking.private_subnets}",
+    "${data.terraform_remote_state.infra_networking.private_subnets}"
   ]
 
   tags = "${merge(

--- a/terraform/projects/app-ecs-albs/main.tf
+++ b/terraform/projects/app-ecs-albs/main.tf
@@ -108,8 +108,9 @@ resource "aws_lb" "monitoring_internal_alb" {
   internal           = true
   load_balancer_type = "application"
   security_groups    = ["${data.terraform_remote_state.infra_security_groups.monitoring_internal_sg_id}"]
+
   subnets = [
-    "${data.terraform_remote_state.infra_networking.private_subnets}"
+    "${data.terraform_remote_state.infra_networking.private_subnets}",
   ]
 
   tags = "${merge(

--- a/terraform/projects/app-ecs-instances/main.tf
+++ b/terraform/projects/app-ecs-instances/main.tf
@@ -167,9 +167,7 @@ module "ecs_instance" {
   image_id      = "${module.ami.ami_id}"
   instance_type = "${var.ecs_instance_type}"
 
-  security_groups = ["${data.terraform_remote_state.infra_security_groups.monitoring_internal_sg_id}",
-    "${data.terraform_remote_state.infra_security_groups.monitoring_external_sg_id}",
-  ]
+  security_groups = ["${data.terraform_remote_state.infra_security_groups.monitoring_internal_sg_id}"]
 
   iam_instance_profile = "${var.stack_name}-ecs-profile"
 

--- a/terraform/projects/app-ecs-services/templates/nginx-auth-proxy.conf.tpl
+++ b/terraform/projects/app-ecs-services/templates/nginx-auth-proxy.conf.tpl
@@ -8,9 +8,6 @@ server {
 
 server {
   listen 80;
-  auth_basic "Prometheus";
-  auth_basic_user_file /etc/nginx/conf.d/.htpasswd;
-
 
   server_name alerts-1.*;
 
@@ -32,8 +29,6 @@ server {
 
 server {
   listen 80;
-  auth_basic "Prometheus";
-  auth_basic_user_file /etc/nginx/conf.d/.htpasswd;
 
 
   server_name alerts-2.*;
@@ -56,8 +51,6 @@ server {
 
 server {
   listen 80;
-  auth_basic "Prometheus";
-  auth_basic_user_file /etc/nginx/conf.d/.htpasswd;
 
 
   server_name alerts-3.*;
@@ -80,8 +73,6 @@ server {
 
 server {
   listen 80;
-  auth_basic "Prometheus";
-  auth_basic_user_file /etc/nginx/conf.d/.htpasswd;
 
 
   server_name prom-1.*;
@@ -104,8 +95,6 @@ server {
 
 server {
   listen 80;
-  auth_basic "Prometheus";
-  auth_basic_user_file /etc/nginx/conf.d/.htpasswd;
 
 
   server_name prom-2.*;
@@ -128,8 +117,6 @@ server {
 
 server {
   listen 80;
-  auth_basic "Prometheus";
-  auth_basic_user_file /etc/nginx/conf.d/.htpasswd;
 
 
   server_name prom-3.*;

--- a/terraform/projects/infra-security-groups/README.md
+++ b/terraform/projects/infra-security-groups/README.md
@@ -22,7 +22,6 @@ and cascade issues.
 
 | Name | Description |
 |------|-------------|
-| alertmanager_external_sg_id | alertmanager_external_sg ID |
 | monitoring_external_sg_id | monitoring_external_sg ID |
 | monitoring_internal_sg_id | monitoring_internal_sg ID |
 

--- a/terraform/projects/infra-security-groups/main.tf
+++ b/terraform/projects/infra-security-groups/main.tf
@@ -142,7 +142,7 @@ resource "aws_security_group_rule" "monitoring_external_sg_ingress_any_http" {
   from_port         = 80
   protocol          = "tcp"
   security_group_id = "${aws_security_group.monitoring_external_sg.id}"
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = ["${var.cidr_admin_whitelist}"]
 }
 
 resource "aws_security_group_rule" "monitoring_external_sg_ingress_any_https" {
@@ -151,16 +151,7 @@ resource "aws_security_group_rule" "monitoring_external_sg_ingress_any_https" {
   from_port         = 443
   protocol          = "tcp"
   security_group_id = "${aws_security_group.monitoring_external_sg.id}"
-  cidr_blocks       = ["0.0.0.0/0"]
-}
-
-resource "aws_security_group_rule" "allow_prometheus_access_alertmanager" {
-  type              = "ingress"
-  to_port           = 80
-  from_port         = 80
-  protocol          = "tcp"
-  security_group_id = "${aws_security_group.alertmanager_external_sg.id}"
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = ["${var.cidr_admin_whitelist}"]
 }
 
 resource "aws_security_group_rule" "allow_prometheus_access_paas_proxy" {

--- a/terraform/projects/infra-security-groups/main.tf
+++ b/terraform/projects/infra-security-groups/main.tf
@@ -118,7 +118,7 @@ resource "aws_security_group" "alertmanager_external_sg" {
   )}"
 }
 
-resource "aws_security_group_rule" "alertmanager_external_sg_ingress_any_http" {
+resource "aws_security_group_rule" "alertmanager_external_sg_ingress_office_http" {
   type              = "ingress"
   to_port           = 80
   from_port         = 80
@@ -136,7 +136,7 @@ resource "aws_security_group_rule" "alertmanager_internal_alb" {
   source_security_group_id = "${aws_security_group.monitoring_internal_sg.id}"
 }
 
-resource "aws_security_group_rule" "monitoring_external_sg_ingress_any_http" {
+resource "aws_security_group_rule" "monitoring_external_sg_ingress_office_http" {
   type              = "ingress"
   to_port           = 80
   from_port         = 80
@@ -145,7 +145,7 @@ resource "aws_security_group_rule" "monitoring_external_sg_ingress_any_http" {
   cidr_blocks       = ["${var.cidr_admin_whitelist}"]
 }
 
-resource "aws_security_group_rule" "monitoring_external_sg_ingress_any_https" {
+resource "aws_security_group_rule" "monitoring_external_sg_ingress_office_https" {
   type              = "ingress"
   to_port           = 443
   from_port         = 443

--- a/terraform/projects/infra-security-groups/main.tf
+++ b/terraform/projects/infra-security-groups/main.tf
@@ -157,7 +157,6 @@ resource "aws_security_group_rule" "permit_internal_any_any" {
   source_security_group_id = "${aws_security_group.monitoring_internal_sg.id}"
 }
 
-
 resource "aws_security_group_rule" "monitoring_internal_sg_ingress_alb_http" {
   type      = "ingress"
   from_port = 0

--- a/terraform/projects/infra-security-groups/main.tf
+++ b/terraform/projects/infra-security-groups/main.tf
@@ -147,6 +147,17 @@ resource "aws_security_group" "monitoring_internal_sg" {
   )}"
 }
 
+resource "aws_security_group_rule" "permit_internal_any_any" {
+  type      = "ingress"
+  from_port = 0
+  to_port   = 0
+  protocol  = "-1"
+
+  security_group_id        = "${aws_security_group.monitoring_internal_sg.id}"
+  source_security_group_id = "${aws_security_group.monitoring_internal_sg.id}"
+}
+
+
 resource "aws_security_group_rule" "monitoring_internal_sg_ingress_alb_http" {
   type      = "ingress"
   from_port = 0

--- a/terraform/projects/infra-security-groups/main.tf
+++ b/terraform/projects/infra-security-groups/main.tf
@@ -105,37 +105,6 @@ resource "aws_security_group" "monitoring_external_sg" {
   )}"
 }
 
-resource "aws_security_group" "alertmanager_external_sg" {
-  name        = "${var.stack_name}-alert-external-sg"
-  vpc_id      = "${data.terraform_remote_state.infra_networking.vpc_id}"
-  description = "Controls external access to the LBs"
-
-  tags = "${merge(
-    local.default_tags,
-    var.additional_tags,
-    map("Stackname", "${var.stack_name}"),
-    map("Name", "${var.stack_name}-monitoring-external-sg")
-  )}"
-}
-
-resource "aws_security_group_rule" "alertmanager_external_sg_ingress_office_http" {
-  type              = "ingress"
-  to_port           = 80
-  from_port         = 80
-  protocol          = "tcp"
-  security_group_id = "${aws_security_group.alertmanager_external_sg.id}"
-  cidr_blocks       = ["${var.cidr_admin_whitelist}"]
-}
-
-resource "aws_security_group_rule" "alertmanager_internal_alb" {
-  type                     = "ingress"
-  to_port                  = 80
-  from_port                = 80
-  protocol                 = "tcp"
-  security_group_id        = "${aws_security_group.alertmanager_external_sg.id}"
-  source_security_group_id = "${aws_security_group.monitoring_internal_sg.id}"
-}
-
 resource "aws_security_group_rule" "monitoring_external_sg_ingress_office_http" {
   type              = "ingress"
   to_port           = 80
@@ -152,24 +121,6 @@ resource "aws_security_group_rule" "monitoring_external_sg_ingress_office_https"
   protocol          = "tcp"
   security_group_id = "${aws_security_group.monitoring_external_sg.id}"
   cidr_blocks       = ["${var.cidr_admin_whitelist}"]
-}
-
-resource "aws_security_group_rule" "allow_prometheus_access_paas_proxy" {
-  type                     = "ingress"
-  to_port                  = 8080
-  from_port                = 8080
-  protocol                 = "tcp"
-  security_group_id        = "${aws_security_group.alertmanager_external_sg.id}"
-  source_security_group_id = "${aws_security_group.monitoring_internal_sg.id}"
-}
-
-resource "aws_security_group_rule" "alertmanager_external_sg_egress_any_any" {
-  type              = "egress"
-  from_port         = 0
-  to_port           = 0
-  protocol          = "-1"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.alertmanager_external_sg.id}"
 }
 
 resource "aws_security_group_rule" "monitoring_external_sg_egress_any_any" {
@@ -206,16 +157,6 @@ resource "aws_security_group_rule" "monitoring_internal_sg_ingress_alb_http" {
   source_security_group_id = "${aws_security_group.monitoring_external_sg.id}"
 }
 
-resource "aws_security_group_rule" "monitoring_internal_sg_alertmanager_alb" {
-  type      = "ingress"
-  from_port = 0
-  to_port   = 0
-  protocol  = "-1"
-
-  security_group_id        = "${aws_security_group.monitoring_internal_sg.id}"
-  source_security_group_id = "${aws_security_group.alertmanager_external_sg.id}"
-}
-
 resource "aws_security_group_rule" "monitoring_internal_sg_egress_any_any" {
   type              = "egress"
   from_port         = 0
@@ -230,11 +171,6 @@ resource "aws_security_group_rule" "monitoring_internal_sg_egress_any_any" {
 output "monitoring_external_sg_id" {
   value       = "${aws_security_group.monitoring_external_sg.id}"
   description = "monitoring_external_sg ID"
-}
-
-output "alertmanager_external_sg_id" {
-  value       = "${aws_security_group.alertmanager_external_sg.id}"
-  description = "alertmanager_external_sg ID"
 }
 
 output "monitoring_internal_sg_id" {


### PR DESCRIPTION
The aim was to permit users access to prometheus is expression browser.
We used IP  white listing in order to contrl access to the enviroment.

This is related to this ticket: https://trello.com/c/xTIIBsPs/313-give-users-access-to-the-prometheus-interface