### PR TITLE
Add DGU pagerduty set up

### DIFF
--- a/terraform/projects/app-ecs-services/alertmanager-service.tf
+++ b/terraform/projects/app-ecs-services/alertmanager-service.tf
@@ -125,12 +125,17 @@ data "pass_password" "pagerduty_service_key" {
   path = "pagerduty/integration-keys/production"
 }
 
+data "pass_password" "dgu_pagerduty_service_key" {
+  path = "pagerduty/integration-keys/dgu"
+}
+
 data "template_file" "alertmanager_config_file" {
   template = "${file("templates/alertmanager.tpl")}"
 
   vars {
-    pagerduty_service_key = "${data.pass_password.pagerduty_service_key.password}"
-    smtp_from             = "alerts@${data.terraform_remote_state.infra_networking.public_subdomain}"
+    pagerduty_service_key     = "${data.pass_password.pagerduty_service_key.password}"
+    dgu_pagerduty_service_key = "${data.pass_password.dgu_pagerduty_service_key.password}"
+    smtp_from                 = "alerts@${data.terraform_remote_state.infra_networking.public_subdomain}"
 
     # Port as requested by https://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-connect.html
     smtp_smarthost         = "email-smtp.${var.aws_region}.amazonaws.com:587"

--- a/terraform/projects/app-ecs-services/templates/alertmanager.tpl
+++ b/terraform/projects/app-ecs-services/templates/alertmanager.tpl
@@ -7,17 +7,23 @@ global:
   smtp_auth_password: "${smtp_password}"
 
 route:
-  receiver: "pagerduty"
+  receiver: "re-observe-pagerduty"
   routes:
-  - receiver: "ticket-alert"
+  - receiver: "re-observe-ticket-alert"
     match:
       product: "prometheus"
       severity: "ticket"
+  - receiver: "dgu-pagerduty"
+    match:
+      product: "data-gov-uk"
 
 receivers:
-- name: "pagerduty"
+- name: "re-observe-pagerduty"
   pagerduty_configs:
     - service_key: "${pagerduty_service_key}"
-- name: "ticket-alert"
+- name: "re-observe-ticket-alert"
   email_configs:
   - to: "${ticket_recipient_email}"
+- name: "dgu-pagerduty"
+  pagerduty_configs:
+    - service_key: "${dgu_pagerduty_service_key}"


### PR DESCRIPTION
https://trello.com/c/wdDkQauH/483-enable-dgus-alerts-to-page-govuk-during-working-hours

Uses the DGU service integration key to route all alerts
with product="data-gov-uk" to the pagerduty DGU service.

We have also prefixed all receivers with their product name for easier distinction.

This has been tested in a dev environment and currently points at a new DGU pagerduty service. That service is only linked to @thomasleese's email address at the moment and is not going to be notifying GOV.UK 2ndline until they are happy to turn it on.
