### PR TITLE
Fix issue with alert manager task definition

### DIFF
--- a/terraform/projects/app-ecs-services/alertmanager-service.tf
+++ b/terraform/projects/app-ecs-services/alertmanager-service.tf
@@ -84,7 +84,7 @@ data "template_file" "alertmanager_container_defn" {
 
 resource "aws_ecs_task_definition" "alertmanager_server" {
   count                 = "${length(local.alertmanager_public_fqdns)}"
-  family                = "${var.stack_name}-alertmanager-server"
+  family                = "${var.stack_name}-alertmanager-server-${count.index + 1}"
   container_definitions = "${element(data.template_file.alertmanager_container_defn.*.rendered, count.index)}"
   task_role_arn         = "${aws_iam_role.alertmanager_task_iam_role.arn}"
 

--- a/terraform/projects/app-ecs-services/prometheus-service.tf
+++ b/terraform/projects/app-ecs-services/prometheus-service.tf
@@ -129,7 +129,7 @@ data "template_file" "prometheus_container_defn" {
 
 resource "aws_ecs_task_definition" "prometheus_server" {
   count                 = "${length(local.prometheus_public_fqdns)}"
-  family                = "${var.stack_name}-prometheus-server-${count.index}"
+  family                = "${var.stack_name}-prometheus-server-${count.index + 1}"
   container_definitions = "${element(data.template_file.prometheus_container_defn.*.rendered, count.index)}"
   task_role_arn         = "${aws_iam_role.prometheus_task_iam_role.arn}"
 


### PR DESCRIPTION
We needed to fix a problem with the alert manager task definition. This is
because are using a count which creates three task definition but only
one is ever used. We have set this to a static one value now. We intend
to use something in the future that will enable referencing a single
URL.