### PR TITLE
manage the shared dev route53 zone better

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -8,8 +8,9 @@ TERRAFORMBACKVARS=$(pwd)/stacks/${ENV}.backend
 TERRAFORMTFVARS=$(pwd)/stacks/${ENV}.tfvars
 ROOTPROJ=$(pwd)
 TERRAFORMPROJ=$(pwd)/terraform/projects/
+##-----8<----------- please remove me after 2018-08-24 ⤵
 SHARED_DEV_SUBDOMAIN_RESOURCE=aws_route53_zone.shared_dev_subdomain
-SHARED_DEV_DNS_ZONE=Z3702PZTSCDWPA  # this is the dev.gds-reliability.engineering DNS hosted zone ID
+##-----8<----------- please remove me after 2018-08-24 ⤴
 declare -a COMPONENTS=("infra-networking" "infra-security-groups" "infra-jump-instance" "app-ecs-instances" "app-ecs-albs" "app-ecs-services")
 declare -a COMPONENTSDESTROY=("app-ecs-services" "app-ecs-albs" "app-ecs-instances" "infra-jump-instance" "infra-security-groups" "infra-networking")
 

--- a/terraform/projects/infra-networking/main.tf
+++ b/terraform/projects/infra-networking/main.tf
@@ -113,15 +113,14 @@ resource "aws_route53_zone" "private" {
 # These resources are only created for development environments (not staging or prod)
 # This is to add the extra delegation from dev.gds-reliability.engineering to the prometheus subdomain
 
-resource "aws_route53_zone" "shared_dev_subdomain" {
-  count = "${var.dev_environment == "true" ? 1 : 0}"
-  name  = "${local.shared_dev_subdomain_name}"
+data "aws_route53_zone" "shared_dev_subdomain" {
+  name = "${local.shared_dev_subdomain_name}"
 }
 
 resource "aws_route53_record" "shared_dev_ns" {
   count   = "${var.dev_environment == "true" ? 1 : 0}"
-  zone_id = "${aws_route53_zone.shared_dev_subdomain.zone_id}"
-  name    = "${var.stack_name}.${aws_route53_zone.shared_dev_subdomain.name}"
+  zone_id = "${data.aws_route53_zone.shared_dev_subdomain.zone_id}"
+  name    = "${var.stack_name}.${data.aws_route53_zone.shared_dev_subdomain.name}"
   type    = "NS"
   ttl     = "30"
 


### PR DESCRIPTION
Currently, we treat the shared dev.gds-reliability.engineering zone as
a resource that gets `terraform import`-ed into each project
separately.  To ensure that we don't try to remove the shared zone
when running `terraform destroy`, we have some code in setup.sh which
runs `terraform state rm` on the zone to remove it from the statefile,
prior to destroying the project.

This commit changes the shared zone to be managed as a [data source][1]
instead.  This means that our projects can depend on the zone but
don't own it and therefore won't accidentally try to change or destroy
it.  This also means that, longer-term, setup.sh can remove all the
special case code around `terraform import` and `terraform state rm`.

For a transition period, however, the shared zone will still be around
in people's existing state files, so I've edited setup.sh to simply
try to remove the shared zone from state whenever we do any plan,
apply or destroy on infra-networking in a dev environment.  This code
can be removed once every stack has been touched.  I've marked the
code to be removed in clear comments with a timestamp.

(It's not the end of the world if someone does try to destroy the
shared dev zone resource, because terraform will fail to destroy
non-empty route53 zones.  It'll just cause a failure to the user.)

[1]: https://www.terraform.io/docs/providers/aws/d/route53_zone.html