### PR TITLE
Prefix all alert names with team names

### DIFF
--- a/terraform/projects/app-ecs-services/config/alerts/alerts.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/alerts.yml
@@ -1,7 +1,7 @@
 groups:
-- name: PrometheusCore
+- name: RE_Observe
   rules:
-  - alert: AlertManager_Below_Threshold
+  - alert: RE_Observe_AlertManager_Below_Threshold
     expr: up{job="alertmanager"} == 0 and on(job) sum by(job) (up{job="alertmanager"}) <= 1
     for: 10s
     labels:
@@ -10,7 +10,7 @@ groups:
     annotations:
         summary: "Service is below the expected instance Threshold"
         description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}"
-  - alert: Prometheus_Below_Threshold
+  - alert: RE_Observe_Prometheus_Below_Threshold
     expr: up{job="prometheus"} == 0 and on(job) sum by(job) (up{job="prometheus"}) <= 1
     for: 10s
     labels:
@@ -19,7 +19,7 @@ groups:
     annotations:
         summary: "Service is below the expected instance Threshold"
         description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}"
-  - alert: NoFileSdTargets
+  - alert: RE_Observe_No_FileSd_Targets
     # this expression is a little weird - count() has no value instead of 0 if there are no
     # matching metrics.  But no value isn't less than 1 so we aren't able to trigger an alert
     # that a regular count() is zero.  So we force missing values to be equal to
@@ -40,7 +40,7 @@ groups:
 
 # this can be improved however maybe this is something we need to focus on in Q2 when working on the support plan
 
-  - alert: Prometheus_Over_Capacity
+  - alert: RE_Observe_Prometheus_Over_Capacity
     expr: sum by(instance)(rate(prometheus_engine_query_duration_seconds_sum{job="prometheus"}[5m])) > 8
     for: 10s
     labels:
@@ -50,7 +50,7 @@ groups:
         summary: "Service is over capacity."
         description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}"
 
-  - alert: Prometheus_High_Load
+  - alert: RE_Observe_Prometheus_High_Load
     expr: sum by(instance)(rate(prometheus_engine_query_duration_seconds_sum{job="prometheus"}[2h])) > 4
     labels:
         product: "prometheus"

--- a/terraform/projects/app-ecs-services/config/alerts/data-gov-uk.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/data-gov-uk.yml
@@ -1,7 +1,7 @@
 groups:
 - name: DataGovUk
   rules:
-  - alert: NoInstancesForSomeTime
+  - alert: DataGovUk_NoInstancesForSomeTime
     expr: count(sum(cpu{job="metric-exporter"}) without (cell_id)) by (app) == 0
     for: 30m
     labels:
@@ -9,7 +9,7 @@ groups:
     annotations:
         summary: "App {{ $labels.app }} has no instances"
         description: "Application {{ $labels.app }} has had no instances for half an hour."
-  - alert: HighCpuUsage
+  - alert: DataGovUk_HighCpuUsage
     expr: avg(cpu{job="metric-exporter"}) by (app) >= 80
     for: 5m
     labels:
@@ -17,7 +17,7 @@ groups:
     annotations:
         summary: "App {{ $labels.app }} has high CPU usage"
         description: "Application {{ $labels.app }} has been using over 80% CPU (averaged over all instances) for 5 minutes or more."
-  - alert: HighDiskUsage
+  - alert: DataGovUk_HighDiskUsage
     expr: max(disk_utilization{job="metric-exporter"}) by (app) >= 80
     labels:
         product: "data-gov-uk"

--- a/terraform/projects/app-ecs-services/config/alerts/registers.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/registers.yml
@@ -1,7 +1,7 @@
 groups:
 - name: Registers
   rules:
-  - alert: RequestsExcess5xx
+  - alert: Registers_RequestsExcess5xx
     expr: sum by(app) (rate(requests{job="openregister-metric-exporter", exported_space="prod", status_range="5xx"}[5m])) / sum by(app) (rate(requests{job="openregister-metric-exporter", exported_space="prod"}[5m])) >= 0.25
     for: 120s
     labels:


### PR DESCRIPTION
This enables alerts to be easily distinguished between teams
in prometheus and alertmanager