### PR TITLE
Remove unused security group

### DIFF
--- a/terraform/projects/infra-security-groups/main.tf
+++ b/terraform/projects/infra-security-groups/main.tf
@@ -118,15 +118,6 @@ resource "aws_security_group" "alertmanager_external_sg" {
   )}"
 }
 
-resource "aws_security_group_rule" "alertmanager_external_sg_ingress_any_http" {
-  type              = "ingress"
-  to_port           = 80
-  from_port         = 80
-  protocol          = "tcp"
-  security_group_id = "${aws_security_group.alertmanager_external_sg.id}"
-  cidr_blocks       = ["${var.cidr_admin_whitelist}"]
-}
-
 resource "aws_security_group_rule" "alertmanager_internal_alb" {
   type                     = "ingress"
   to_port                  = 80

--- a/terraform/projects/infra-security-groups/main.tf
+++ b/terraform/projects/infra-security-groups/main.tf
@@ -27,21 +27,6 @@ variable "remote_state_bucket" {
   default     = "ecs-monitoring"
 }
 
-variable "cidr_admin_whitelist" {
-  description = "CIDR ranges permitted to communicate with administrative endpoints"
-  type        = "list"
-
-  default = [
-    "213.86.153.212/32",
-    "213.86.153.213/32",
-    "213.86.153.214/32",
-    "213.86.153.235/32",
-    "213.86.153.236/32",
-    "213.86.153.237/32",
-    "85.133.67.244/32",
-  ]
-}
-
 variable "stack_name" {
   type        = "string"
   description = "Unique name for this collection of resources"


### PR DESCRIPTION
"Looking over this rule with @DavidJeche, we can't understand what it was supposed to be doing. It allows http access directly from our office IPs to the internal load balancer. Why did we ever want this?

If I try to visit the internal ALB (by copypasting it's default DNS record into a browser), it just times out, suggesting that even with this rule, access isn't permitted. Did it ever work? Since we always have accessed alertmanager via the nginx auth proxy (not directly), I'm not sure we've ever seen this rule in action."

https://github.com/alphagov/prometheus-aws-configuration-beta/pull/73/files#r209182084