### PR TITLE
Stop requiring basic auth from office ips

### DIFF
--- a/terraform/projects/app-ecs-services/README.md
+++ b/terraform/projects/app-ecs-services/README.md
@@ -9,6 +9,7 @@ Create services and task definitions for the ECS cluster
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | aws_region | AWS region | string | `eu-west-1` | no |
+| cidr_admin_whitelist | CIDR ranges permitted to communicate with administrative endpoints | list | `<list>` | no |
 | dev_environment | Boolean flag for development environments | string | `false` | no |
 | prom_cpu | CPU requirement for prometheus | string | `512` | no |
 | prom_memoryReservation | memory reservation requirement for prometheus | string | `2048` | no |

--- a/terraform/projects/app-ecs-services/main.tf
+++ b/terraform/projects/app-ecs-services/main.tf
@@ -11,6 +11,21 @@ variable "aws_region" {
   default     = "eu-west-1"
 }
 
+variable "cidr_admin_whitelist" {
+  description = "CIDR ranges permitted to communicate with administrative endpoints"
+  type        = "list"
+
+  default = [
+    "213.86.153.212/32",
+    "213.86.153.213/32",
+    "213.86.153.214/32",
+    "213.86.153.235/32",
+    "213.86.153.236/32",
+    "213.86.153.237/32",
+    "85.133.67.244/32",
+  ]
+}
+
 variable "dev_environment" {
   type        = "string"
   description = "Boolean flag for development environments"

--- a/terraform/projects/app-ecs-services/nginx-auth-proxy.tf
+++ b/terraform/projects/app-ecs-services/nginx-auth-proxy.tf
@@ -43,6 +43,7 @@ data "template_file" "nginx-auth-proxy-config-file" {
   template = "${file("templates/nginx-auth-proxy.conf.tpl")}"
 
   vars {
+    allow_cidrs             = "${join("",formatlist("allow %s;\n", var.cidr_admin_whitelist))}"
     alertmanager_1_dns_name = "${data.terraform_remote_state.app_ecs_albs.alerts_private_record_fqdns.0}"
     alertmanager_2_dns_name = "${data.terraform_remote_state.app_ecs_albs.alerts_private_record_fqdns.1}"
     alertmanager_3_dns_name = "${data.terraform_remote_state.app_ecs_albs.alerts_private_record_fqdns.2}"

--- a/terraform/projects/app-ecs-services/templates/nginx-auth-proxy.conf.tpl
+++ b/terraform/projects/app-ecs-services/templates/nginx-auth-proxy.conf.tpl
@@ -1,4 +1,8 @@
+auth_basic "Prometheus";
+auth_basic_user_file /etc/nginx/conf.d/.htpasswd;
+
 server {
+  auth_basic off;
   listen 80 default_server;
 
   location /health {
@@ -8,9 +12,6 @@ server {
 
 server {
   listen 80;
-  auth_basic "Prometheus";
-  auth_basic_user_file /etc/nginx/conf.d/.htpasswd;
-
 
   server_name alerts-1.*;
 
@@ -32,9 +33,6 @@ server {
 
 server {
   listen 80;
-  auth_basic "Prometheus";
-  auth_basic_user_file /etc/nginx/conf.d/.htpasswd;
-
 
   server_name alerts-2.*;
 
@@ -56,9 +54,6 @@ server {
 
 server {
   listen 80;
-  auth_basic "Prometheus";
-  auth_basic_user_file /etc/nginx/conf.d/.htpasswd;
-
 
   server_name alerts-3.*;
 
@@ -80,9 +75,6 @@ server {
 
 server {
   listen 80;
-  auth_basic "Prometheus";
-  auth_basic_user_file /etc/nginx/conf.d/.htpasswd;
-
 
   server_name prom-1.*;
 
@@ -104,9 +96,6 @@ server {
 
 server {
   listen 80;
-  auth_basic "Prometheus";
-  auth_basic_user_file /etc/nginx/conf.d/.htpasswd;
-
 
   server_name prom-2.*;
 
@@ -128,9 +117,6 @@ server {
 
 server {
   listen 80;
-  auth_basic "Prometheus";
-  auth_basic_user_file /etc/nginx/conf.d/.htpasswd;
-
 
   server_name prom-3.*;
 

--- a/terraform/projects/app-ecs-services/templates/nginx-auth-proxy.conf.tpl
+++ b/terraform/projects/app-ecs-services/templates/nginx-auth-proxy.conf.tpl
@@ -1,5 +1,11 @@
+satisfy any;
 auth_basic "Prometheus";
 auth_basic_user_file /etc/nginx/conf.d/.htpasswd;
+real_ip_header X-Forwarded-For;
+set_real_ip_from 10.0.0.0/8;
+set_real_ip_from 127.0.0.1/32;
+${allow_cidrs}
+deny all;
 
 server {
   auth_basic off;


### PR DESCRIPTION
This updates our nginx config to allow users from the office IPs to
bypass the basic auth requirement.  Users outside the office IPs can
still access prometheus if they do have the basic auth creds.  This
means that, in particular, grafana can access prometheus.

The pieces of this commit are:

 - cidr_admin_whitelist: the office IP addresses - taken from internal IT wiki
 - `satisfy any`: this nginx directive says "if the user has any of:
   an approved IP address or basic auth creds, let them in"
 - `real_ip_header` and `set_real_ip_from`: these get the real client
   IP from a header provided by the load balancer
 - `allow %s`: this is the directive (provided in the `formatlist`
   call) that allows access from a CIDR
 - `deny all`: if you haven't been allowed by any previous directive,
   you get denied access now