### PR TITLE
Include env files for staging and prod environments

### DIFF
--- a/environment_production.sh
+++ b/environment_production.sh
@@ -1,0 +1,4 @@
+export TERRAFORM_BUCKET="prometheus-production"
+export PROFILE_NAME="gds-prometheus-prod" # This may depend on your local AWS vault set up
+export ENV="production"
+export DEV_ENVIRONMENT=false

--- a/environment_staging.sh
+++ b/environment_staging.sh
@@ -1,0 +1,4 @@
+export TERRAFORM_BUCKET="prometheus-staging"
+export PROFILE_NAME="gds-prometheus-staging" # This may depend on your local AWS vault set up
+export ENV="staging"
+export DEV_ENVIRONMENT=false


### PR DESCRIPTION
Deployment has been slowed as these variables have not been known
or takes a bit of time to dig them out from elsewhere. This should
make things quicker.

Note, `PROFILE_NAME` is likely to differ by each developer as it
is the name you deceided on for your AWS vault profiles. I've
included mine for the moment which is likely not ideal but
may be an improvement to start with.

Will also require a small word change to our deployment instructions in the deployment docs - https://docs.google.com/spreadsheets/d/1zKpNDcul6X1iYtXNmKrQ_xo0P92_VlYhLtlPyNSw1jc/edit#gid=413288099. 