### PR TITLE
Remove multi nat-gateways in dev to save on cost

### DIFF
--- a/terraform/projects/infra-networking/main.tf
+++ b/terraform/projects/infra-networking/main.tf
@@ -84,6 +84,8 @@ module "vpc" {
   database_subnets = ["10.0.201.0/24", "10.0.202.0/24", "10.0.203.0/24"]
 
   enable_nat_gateway = true
+  single_nat_gateway = "${var.dev_environment == "true" ? true : false }"
+
 
   enable_dns_hostnames = true
   enable_dns_support   = true

--- a/terraform/projects/infra-networking/main.tf
+++ b/terraform/projects/infra-networking/main.tf
@@ -86,7 +86,6 @@ module "vpc" {
   enable_nat_gateway = true
   single_nat_gateway = "${var.dev_environment == "true" ? true : false }"
 
-
   enable_dns_hostnames = true
   enable_dns_support   = true
 


### PR DESCRIPTION
The dev enviroment currently creates three of every network component  based
on the configuration in the vpc module. I have added a small change which will
prevent the dev enviroment from creating a nat gateway for each AZ. If the
instance count is 3 in dev the single nat gateway will still be enabled. This
is fine since the dev enviroment is not HA enviroment. There will be extra routes
created to route traffic through the AZ which has all the active nat-gateway.

The current production enviroment currently supports an gateway per AZ. This is for HA
purposes.

Ticket: https://trello.com/c/UWSPjbFJ/532-add-singular-nat-gateways-to-aws-dev-environments