### PR TITLE
Enable make file to allow access to terraform console

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,5 +75,5 @@ jump: ## Jump onto the first instance on a dev environment
 
 
 .PHONY: create-console
-create_console: ## Create terraform console session, make create-console project=<project name>
+create-console: ## Create terraform console session, make create-console project=<project name>
 	. ./setup.sh -e ${project}

--- a/Makefile
+++ b/Makefile
@@ -72,3 +72,8 @@ taint: ## Taint a resource, make taint project=<project name> resource=<resource
 .PHONY: jump
 jump: ## Jump onto the first instance on a dev environment
 	. ./setup.sh -j
+
+
+.PHONY: create_console
+create_console: ## Create console session
+	. ./setup.sh -e ${project}

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,6 @@ jump: ## Jump onto the first instance on a dev environment
 	. ./setup.sh -j
 
 
-.PHONY: create_console
-create_console: ## Create console session
+.PHONY: create-console
+create_console: ## Create terraform console session, make create-console project=<project name>
 	. ./setup.sh -e ${project}

--- a/setup.sh
+++ b/setup.sh
@@ -366,7 +366,7 @@ else
                 jumpbox
         ;;
         -e) echo "Starting console session: ${ENV}"
-                create_console
+                create-console
         ;;
         *) echo "Invalid option"
         ;;

--- a/setup.sh
+++ b/setup.sh
@@ -208,6 +208,17 @@ jumpbox() {
         ssh -At -oStrictHostKeyChecking=no ec2-user@$JUMPBOX ssh -oStrictHostKeyChecking=no ec2-user@$INSTANCE_IP
 }
 
+create_console() {
+        echo $1
+        cd $TERRAFORMPROJ$1
+
+        aws-vault exec ${PROFILE_NAME} -- $TERRAFORMPATH console -var-file=$TERRAFORMTFVARS
+
+        if [ $? != 0 ]; then
+           exit
+        fi
+}
+
 #################################
 #################################
 ENV_VARS_SET=1
@@ -353,6 +364,9 @@ else
         ;;
         -j) echo "Jump onto instance: ${ENV}"
                 jumpbox
+        ;;
+        -e) echo "Starting console session: ${ENV}"
+                create_console
         ;;
         *) echo "Invalid option"
         ;;

--- a/setup.sh
+++ b/setup.sh
@@ -208,7 +208,7 @@ jumpbox() {
         ssh -At -oStrictHostKeyChecking=no ec2-user@$JUMPBOX ssh -oStrictHostKeyChecking=no ec2-user@$INSTANCE_IP
 }
 
-create_console() {
+create-console() {
         echo $1
         cd $TERRAFORMPROJ$1
 


### PR DESCRIPTION
Edit the terraform make file to allow us to use terraforms console feature.
This feature allows you to test interpolations and terraform funcations. This
will enable to us to reduce the number of times we run plan and apply. We can
test all our variables against our terraform funcations local before making an apply.

This is one of the thing that slowed down development time for me.
This commit will greatly improve the development process for me and hopefully
for the team also.

Ticket: https://trello.com/c/hLSlzPfT/533-add-console-state-option-to-make-file-to-enable-speedy-development 