### PR TITLE
Alertmnager mesh direct

### DIFF
--- a/terraform/projects/app-ecs-instances/ecs-iam-policy.tf
+++ b/terraform/projects/app-ecs-instances/ecs-iam-policy.tf
@@ -46,7 +46,7 @@ data "aws_iam_policy_document" "ecs_instance_document" {
       "ecr:BatchGetImage",
       "logs:CreateLogStream",
       "logs:PutLogEvents",
-      "route53:ChangeResourceRecordSets"
+      "route53:ChangeResourceRecordSets",
     ]
   }
 

--- a/terraform/projects/app-ecs-instances/ecs-iam-policy.tf
+++ b/terraform/projects/app-ecs-instances/ecs-iam-policy.tf
@@ -46,6 +46,7 @@ data "aws_iam_policy_document" "ecs_instance_document" {
       "ecr:BatchGetImage",
       "logs:CreateLogStream",
       "logs:PutLogEvents",
+      "route53:ChangeResourceRecordSets"
     ]
   }
 

--- a/terraform/projects/app-ecs-instances/instance-user-data.tpl
+++ b/terraform/projects/app-ecs-instances/instance-user-data.tpl
@@ -6,6 +6,7 @@ sudo yum install -y aws-cli wget
 REGION="${region}"
 DEVICE="xvdf"
 
+IP_V4_ADDRESS=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
 echo "[$(date '+%H:%M:%S %d-%m-%Y')] finding current instance ID"
 INSTANCE_ID=$(wget -q -O - http://169.254.169.254/latest/meta-data/instance-id)
 
@@ -75,3 +76,46 @@ echo "ECS_CLUSTER=${cluster_name}" >> /etc/ecs/ecs.config
 yum install -y ecs-init
 start ecs
 service docker start
+
+case "$AZ" in
+        "eu-west-1a")
+            dns_name="mesh-1"
+            ;;
+
+        "eu-west-1b")
+            dns_name="mesh-2"
+            ;;
+
+        "eu-west-1c")
+            dns_name="mesh-3"
+            ;;
+
+         *)
+            echo "no Dns values found"
+            ;;
+
+esac
+
+
+cat <<EOF >/ecs/dns_update.json
+{
+    "Comment": "Update new instance IP address route 53",
+    "Changes": [
+        {
+            "Action": "UPSERT",
+            "ResourceRecordSet": {
+                "Name": "$dns_name.${private_subdomain}",
+                "Type": "A",
+                "TTL": 300,
+                "ResourceRecords": [
+                    {
+                        "Value": "$IP_V4_ADDRESS"
+                    }
+                ]
+            }
+        }
+    ]
+}
+EOF
+
+aws route53 change-resource-record-sets --hosted-zone-id ${dns_zone_id} --change-batch file:///ecs/dns_update.json

--- a/terraform/projects/app-ecs-instances/main.tf
+++ b/terraform/projects/app-ecs-instances/main.tf
@@ -146,6 +146,8 @@ data "template_file" "instance_user_data" {
     cluster_name = "${local.cluster_name}"
     volume_ids   = "${join(" ", aws_ebs_volume.prometheus_ebs_volume.*.id)}"
     region       = "${var.aws_region}"
+    dns_zone_id  = "${data.terraform_remote_state.infra_networking.private_zone_id}"
+    private_subdomain = "${data.terraform_remote_state.infra_networking.private_subdomain}"
   }
 }
 

--- a/terraform/projects/app-ecs-instances/main.tf
+++ b/terraform/projects/app-ecs-instances/main.tf
@@ -143,10 +143,10 @@ data "template_file" "instance_user_data" {
   template = "${file("instance-user-data.tpl")}"
 
   vars {
-    cluster_name = "${local.cluster_name}"
-    volume_ids   = "${join(" ", aws_ebs_volume.prometheus_ebs_volume.*.id)}"
-    region       = "${var.aws_region}"
-    dns_zone_id  = "${data.terraform_remote_state.infra_networking.private_zone_id}"
+    cluster_name      = "${local.cluster_name}"
+    volume_ids        = "${join(" ", aws_ebs_volume.prometheus_ebs_volume.*.id)}"
+    region            = "${var.aws_region}"
+    dns_zone_id       = "${data.terraform_remote_state.infra_networking.private_zone_id}"
     private_subdomain = "${data.terraform_remote_state.infra_networking.private_subdomain}"
   }
 }

--- a/terraform/projects/app-ecs-services/alertmanager-service.tf
+++ b/terraform/projects/app-ecs-services/alertmanager-service.tf
@@ -98,8 +98,8 @@ data "template_file" "alertmanager_container_defn" {
     log_group        = "${aws_cloudwatch_log_group.task_logs.name}"
     region           = "${var.aws_region}"
     config_bucket    = "${aws_s3_bucket.config_bucket.id}"
-    alertmanager_url = "--web.external-url=\"https://${local.alertmanager_public_fqdns[count.index]}\""
-    commands      = "${var.prometheis_total == "1" ? join("\",\"", local.flattened_args) : join("\",\"", flatten(list(local.list_of_args)))}"
+    alertmanager_url = "--web.external-url=https://${local.alertmanager_public_fqdns[count.index]}"
+    commands      = "${var.prometheis_total == "1" ? join("\",\"", flatten(list(local.list_of_args))) : join("\",\"", local.flattened_args) }"
   }
 }
 

--- a/terraform/projects/app-ecs-services/alertmanager-service.tf
+++ b/terraform/projects/app-ecs-services/alertmanager-service.tf
@@ -12,7 +12,6 @@ variable "mesh_urls" {
   type = "list"
 
   default = ["mesh-1", "mesh-2", "mesh-3"]
-
 }
 
 variable "prometheis_total" {
@@ -24,8 +23,9 @@ variable "prometheis_total" {
 ## Locals
 locals {
   alertmanager_public_fqdns = "${data.terraform_remote_state.app_ecs_albs.alerts_public_record_fqdns}"
-  alertmanager_mesh = "${formatlist("--cluster.peer=%s.${local.private_subdomain}:9094", var.mesh_urls)}"
-  list_of_args = ["--config.file=/etc/alertmanager/alertmanager.yml"]
+  alertmanager_mesh         = "${formatlist("--cluster.peer=%s.${local.private_subdomain}:9094", var.mesh_urls)}"
+  list_of_args              = ["--config.file=/etc/alertmanager/alertmanager.yml"]
+
   #We have to define alert manager args counts on at template definition level since we have no local instance
   private_subdomain = "${data.terraform_remote_state.infra_networking.private_subdomain}"
   flattened_args    = "${flatten(concat(list(local.list_of_args), list(local.alertmanager_mesh)))}"
@@ -99,7 +99,7 @@ data "template_file" "alertmanager_container_defn" {
     region           = "${var.aws_region}"
     config_bucket    = "${aws_s3_bucket.config_bucket.id}"
     alertmanager_url = "--web.external-url=https://${local.alertmanager_public_fqdns[count.index]}"
-    commands      = "${var.prometheis_total == "1" ? join("\",\"", flatten(list(local.list_of_args))) : join("\",\"", local.flattened_args) }"
+    commands         = "${var.prometheis_total == "1" ? join("\",\"", flatten(list(local.list_of_args))) : join("\",\"", local.flattened_args) }"
   }
 }
 

--- a/terraform/projects/app-ecs-services/task-definitions/alertmanager-server.json
+++ b/terraform/projects/app-ecs-services/task-definitions/alertmanager-server.json
@@ -9,12 +9,13 @@
       {
         "containerPort": 9093,
         "hostPort": 9093
+      },
+      {
+        "containerPort": 9094,
+        "hostPort": 9094
       }
     ],
-    "command": [
-      "--config.file=/etc/alertmanager/alertmanager.yml",
-      "--web.external-url=${alertmanager_url}"
-    ],
+    "command": ["${commands}", "${alertmanager_url}"],
     "mountPoints": [
       {
         "sourceVolume": "alertmanager",

--- a/terraform/projects/infra-networking/main.tf
+++ b/terraform/projects/infra-networking/main.tf
@@ -36,8 +36,6 @@ variable "prometheus_subdomain" {
   default     = "monitoring"
 }
 
-
-
 # locals
 # --------------------------------------------------------------
 
@@ -106,8 +104,8 @@ resource "aws_route53_zone" "subdomain" {
 }
 
 resource "aws_route53_zone" "private" {
-  vpc_id = "${module.vpc.vpc_id}"
-  name   = "${local.private_subdomain_name}"
+  vpc_id        = "${module.vpc.vpc_id}"
+  name          = "${local.private_subdomain_name}"
   force_destroy = true
 }
 

--- a/terraform/projects/infra-networking/main.tf
+++ b/terraform/projects/infra-networking/main.tf
@@ -36,6 +36,8 @@ variable "prometheus_subdomain" {
   default     = "monitoring"
 }
 
+
+
 # locals
 # --------------------------------------------------------------
 
@@ -106,6 +108,7 @@ resource "aws_route53_zone" "subdomain" {
 resource "aws_route53_zone" "private" {
   vpc_id = "${module.vpc.vpc_id}"
   name   = "${local.private_subdomain_name}"
+  force_destroy = true
 }
 
 ## Development resources
@@ -173,4 +176,9 @@ output "private_subnets_ips" {
 output "nat_gateway" {
   value       = "${module.vpc.nat_public_ips}"
   description = "List of nat gateway IP"
+}
+
+output "private_subdomain" {
+  value       = "${aws_route53_zone.private.name}"
+  description = "This is the subdomain for private zone"
 }


### PR DESCRIPTION
# Why I am making this change

Allow alertmanager's to mesh with each other in order to
prevent duplicate states. Changes that include creating a new task definition.
This task definition will permit alert managers to mesh and it will also provide a single place
to provide arguments for the task definition. To make it as clean as possible. Please feel
free to change anything you would like.

# What approach I took

Open up a container port 9094. Dynamically add DNS record via start-up script. Change the way arguments are passed to the task definition to enable mesh system reference.

Verify that this can function with one instance i.e dev environments.