### PR TITLE
Add link to runbook in alert description

### DIFF
--- a/terraform/projects/app-ecs-services/config/alerts/alerts.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/alerts.yml
@@ -9,7 +9,8 @@ groups:
         severity: "page"
     annotations:
         summary: "Service is below the expected instance Threshold"
-        description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}. https://re-team-manual.cloudapps.digital/observe-support.html#RE_Observe_AlertManager_Below_Threshold"
+        description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}."
+        runbook: "https://re-team-manual.cloudapps.digital/observe-support.html#RE_Observe_AlertManager_Below_Threshold"
   - alert: RE_Observe_Prometheus_Below_Threshold
     expr: up{job="prometheus"} == 0 and on(job) sum by(job) (up{job="prometheus"}) <= 1
     for: 10s
@@ -18,7 +19,8 @@ groups:
         severity: "page"
     annotations:
         summary: "Service is below the expected instance Threshold"
-        description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}. Runbook: https://re-team-manual.cloudapps.digital/observe-support.html#RE_Observe_Prometheus_Below_Threshold"
+        description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}."
+        runbook: "https://re-team-manual.cloudapps.digital/observe-support.html#RE_Observe_Prometheus_Below_Threshold"
   - alert: RE_Observe_No_FileSd_Targets
     # this expression is a little weird - count() has no value instead of 0 if there are no
     # matching metrics.  But no value isn't less than 1 so we aren't able to trigger an alert
@@ -36,7 +38,8 @@ groups:
         severity: "page"
     annotations:
         summary: "No file_sd targets detected"
-        description: "No file_sd targets were detected.  Is there a problem accessing the targets bucket? Runbook: https://re-team-manual.cloudapps.digital/observe-support.html#RE_Observe_No_FileSd_Targets"
+        description: "No file_sd targets were detected.  Is there a problem accessing the targets bucket?"
+        runbook: "https://re-team-manual.cloudapps.digital/observe-support.html#RE_Observe_No_FileSd_Targets"
 
 # this can be improved however maybe this is something we need to focus on in Q2 when working on the support plan
 
@@ -48,7 +51,8 @@ groups:
         severity: "page"
     annotations:
         summary: "Service is over capacity."
-        description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}. Runbook: https://re-team-manual.cloudapps.digital/observe-support.html#prometheus-over-capacity"
+        description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}."
+        runbook: "https://re-team-manual.cloudapps.digital/observe-support.html#prometheus-over-capacity"
 
   - alert: RE_Observe_Prometheus_High_Load
     expr: sum by(instance)(rate(prometheus_engine_query_duration_seconds_sum{job="prometheus"}[2h])) > 4
@@ -57,4 +61,5 @@ groups:
         severity: "ticket"
     annotations:
         summary: "Service is approaching capacity."
-        description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}. Runbook: https://re-team-manual.cloudapps.digital/observe-support.html#RE_Observe_Prometheus_High_Load"
+        description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}."
+        runbook: "https://re-team-manual.cloudapps.digital/observe-support.html#RE_Observe_Prometheus_High_Load"

--- a/terraform/projects/app-ecs-services/config/alerts/alerts.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/alerts.yml
@@ -9,7 +9,7 @@ groups:
         severity: "page"
     annotations:
         summary: "Service is below the expected instance Threshold"
-        description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}"
+        description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}. https://re-team-manual.cloudapps.digital/observe-support.html#RE_Observe_AlertManager_Below_Threshold"
   - alert: RE_Observe_Prometheus_Below_Threshold
     expr: up{job="prometheus"} == 0 and on(job) sum by(job) (up{job="prometheus"}) <= 1
     for: 10s
@@ -18,7 +18,7 @@ groups:
         severity: "page"
     annotations:
         summary: "Service is below the expected instance Threshold"
-        description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}"
+        description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}. Runbook: https://re-team-manual.cloudapps.digital/observe-support.html#RE_Observe_Prometheus_Below_Threshold"
   - alert: RE_Observe_No_FileSd_Targets
     # this expression is a little weird - count() has no value instead of 0 if there are no
     # matching metrics.  But no value isn't less than 1 so we aren't able to trigger an alert
@@ -36,7 +36,7 @@ groups:
         severity: "page"
     annotations:
         summary: "No file_sd targets detected"
-        description: "No file_sd targets were detected.  Is there a problem accessing the targets bucket?"
+        description: "No file_sd targets were detected.  Is there a problem accessing the targets bucket? Runbook: https://re-team-manual.cloudapps.digital/observe-support.html#RE_Observe_No_FileSd_Targets"
 
 # this can be improved however maybe this is something we need to focus on in Q2 when working on the support plan
 
@@ -48,7 +48,7 @@ groups:
         severity: "page"
     annotations:
         summary: "Service is over capacity."
-        description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}"
+        description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}. Runbook: https://re-team-manual.cloudapps.digital/observe-support.html#prometheus-over-capacity"
 
   - alert: RE_Observe_Prometheus_High_Load
     expr: sum by(instance)(rate(prometheus_engine_query_duration_seconds_sum{job="prometheus"}[2h])) > 4
@@ -57,4 +57,4 @@ groups:
         severity: "ticket"
     annotations:
         summary: "Service is approaching capacity."
-        description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}"
+        description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}. Runbook: https://re-team-manual.cloudapps.digital/observe-support.html#RE_Observe_Prometheus_High_Load"


### PR DESCRIPTION
# Why I am making this change

Each alert should have a runbook URL in its labels, and the runbook URL should appear in any notification (via pagerduty, email, or zendesk).

# What approach I took

For now, we'll just have the runbook under the Observe support section of the RE team manual
