### PR TITLE
Enables AWS AMI to autp-update

### DIFF
--- a/terraform/modules/common/ami/main.tf
+++ b/terraform/modules/common/ami/main.tf
@@ -1,9 +1,5 @@
 ## Variables
 
-variable "amazon_release" {
-  description = "The amazon release used to generate the encrypted ami"
-}
-
 ## Data sources
 
 data "aws_ami" "source" {
@@ -11,7 +7,7 @@ data "aws_ami" "source" {
 
   filter {
     name   = "name"
-    values = ["amzn-ami-${var.amazon_release}-amazon-ecs-optimized"]
+    values = ["amzn-ami-*-amazon-ecs-optimized"]
   }
 
   filter {

--- a/terraform/modules/jumpbox/main.tf
+++ b/terraform/modules/jumpbox/main.tf
@@ -50,7 +50,6 @@ resource "aws_key_pair" "ssh_key" {
 
 module "ami" {
   source         = "../common/ami"
-  amazon_release = "${var.ecs_optimised_ami_version}"
 }
 
 resource "aws_security_group" "bastion_security_group" {

--- a/terraform/modules/jumpbox/main.tf
+++ b/terraform/modules/jumpbox/main.tf
@@ -49,7 +49,7 @@ resource "aws_key_pair" "ssh_key" {
 }
 
 module "ami" {
-  source         = "../common/ami"
+  source = "../common/ami"
 }
 
 resource "aws_security_group" "bastion_security_group" {

--- a/terraform/projects/app-ecs-instances/main.tf
+++ b/terraform/projects/app-ecs-instances/main.tf
@@ -153,7 +153,6 @@ data "template_file" "instance_user_data" {
 
 module "ami" {
   source         = "../../modules/common/ami"
-  amazon_release = "${var.ecs_optimised_ami_version}"
 }
 
 module "ecs_instance" {

--- a/terraform/projects/app-ecs-instances/main.tf
+++ b/terraform/projects/app-ecs-instances/main.tf
@@ -152,7 +152,7 @@ data "template_file" "instance_user_data" {
 }
 
 module "ami" {
-  source         = "../../modules/common/ami"
+  source = "../../modules/common/ami"
 }
 
 module "ecs_instance" {


### PR DESCRIPTION
# Why I am making this change

We had an issue where our version of the ECS agent on the instances had become stale. This PR will allow terraform to perform a dynamic lookup of the images available. Once the lookup is done it will then download the names, parse them and pick the latest versioned ami. 

# What approach I took

We had to change the way in which the lookup was performed. We had to change some of the parameters. We included a will card in order to fetch the list of possible images. This was done in a common module of this directory.