### PR TITLE
Add ticket alert for failing target

### DIFF
--- a/terraform/projects/app-ecs-services/config/alerts/alerts.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/alerts.yml
@@ -63,3 +63,14 @@ groups:
         summary: "Service is approaching capacity."
         description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}."
         runbook: "https://re-team-manual.cloudapps.digital/observe-support.html#re-observe-prometheus-high-load"
+
+  - alert: RE_Observe_Target_Down
+    expr: up{} == 0
+    for: 20m
+    labels:
+        product: "prometheus"
+        severity: "ticket"
+    annotations:
+        summary: "{{ $labels.job }} target is down"
+        description: "One of the {{ $labels.job }} targets has been down for 20 minutes"
+        runbook: "https://re-team-manual.cloudapps.digital/observe-support.html#re-observe-target-down"


### PR DESCRIPTION
# Why I am making this change

Any target that is consistently failing is bad. Not all targets
are currently covered with alerts and therefore there is a good
chance that one of our targets goes down and no one realises and
nothing is done about it. If we were to allow targets to remain
down in prometheus without being fixed we may become blind to
actual problems which are not alerted on.

We have also seen some bugs in our CF service discovery with
targets leftover that no long exist but think they should still be
scraped. Alerting on this will enable us to know when that has
happened and further investigate this bug.
https://trello.com/c/L7V0ciSx/545-failing-venerable-targets-in-prometheus

# What approach I took

This is a ticket rather than a page because this is supposed to be
a catch all solution just to make sure we don't let failing targets
exist for long periods rather than a means to launching into an
incident response for the app (which may be owned by another team).
If a team has a failing target but no alert on it then we can give
them a nudge so they are aware.

20m has been chosen as the `for` period as it should indicate that
this isn't just a temporary problem, for example a target failing
during a deploy.

Instructions will be provided in the team runbook to assist in what
to do if this alert fires.

A longer run solution may be that the responsibility of a failing
target is automatically routed to the team that owns that target.
This could be done assuming there is a reciever linked to every
PaaS org, however this is not currently the case. We may be able to
change this to do so in the future but would want to chat to our
users to find out if this would be useful/appropriate.

Note, we currently are not receiving tickets as not have implemented zendesk for our team yet so these alerts will not be delivered until that has been done.
