### PR TITLE
Use `nginx:stable-alpine` rather than `nginx:alpine` images

### DIFF
--- a/terraform/projects/app-ecs-services/task-definitions/nginx-auth-proxy.json
+++ b/terraform/projects/app-ecs-services/task-definitions/nginx-auth-proxy.json
@@ -1,7 +1,7 @@
 [
 {
   "name": "nginx-auth-proxy",
-  "image": "nginx:alpine",
+  "image": "nginx:stable-alpine",
   "cpu": 128,
   "memory": 128,
   "essential": true,

--- a/terraform/projects/app-ecs-services/task-definitions/paas_proxy.json
+++ b/terraform/projects/app-ecs-services/task-definitions/paas_proxy.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "paas-proxy",
-    "image": "nginx:alpine",
+    "image": "nginx:stable-alpine",
     "cpu": 128,
     "memory": 128,
     "essential": true,


### PR DESCRIPTION
# Why I am making this change
Nginx tasks are currently failing to start due to
https://github.com/nginxinc/docker-nginx/issues/230

If an instance was to go down then nginx containers could not start
and our service would go down.

# What approach I took

This is a hotfix that should allow nginx tasks to restart if needbe
as suggested by other users in the github issue by swapping
to an older nginx image that can be found.

We may want to address pinning to an exact version at a later point
but this should do as a hotfix.
