### PR TITLE
Add routing for registers alerts

### DIFF
--- a/terraform/projects/app-ecs-services/alertmanager-service.tf
+++ b/terraform/projects/app-ecs-services/alertmanager-service.tf
@@ -154,12 +154,17 @@ data "pass_password" "dgu_pagerduty_service_key" {
   path = "pagerduty/integration-keys/dgu"
 }
 
+data "pass_password" "registers_zendesk" {
+  path = "receivers/registers/zendesk"
+}
+
 data "template_file" "alertmanager_config_file" {
   template = "${file("templates/alertmanager.tpl")}"
 
   vars {
     pagerduty_service_key     = "${data.pass_password.pagerduty_service_key.password}"
     dgu_pagerduty_service_key = "${data.pass_password.dgu_pagerduty_service_key.password}"
+    registers_zendesk         = "${data.pass_password.registers_zendesk.password}"
     smtp_from                 = "alerts@${data.terraform_remote_state.infra_networking.public_subdomain}"
 
     # Port as requested by https://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-connect.html

--- a/terraform/projects/app-ecs-services/templates/alertmanager.tpl
+++ b/terraform/projects/app-ecs-services/templates/alertmanager.tpl
@@ -16,6 +16,9 @@ route:
   - receiver: "dgu-pagerduty"
     match:
       product: "data-gov-uk"
+  - receiver: "registers-zendesk"
+    match:
+      product: "registers"
 
 receivers:
 - name: "re-observe-pagerduty"
@@ -27,3 +30,6 @@ receivers:
 - name: "dgu-pagerduty"
   pagerduty_configs:
     - service_key: "${dgu_pagerduty_service_key}"
+- name: "registers-zendesk"
+  email_configs:
+  - to: "${registers_zendesk}"


### PR DESCRIPTION
# Why I am making this change

So that Registers alerts become tickets in Zendesk.

# What approach I took

All alerts will go to the email address provided by Registers.