### PR TITLE
Add Prometheus module

### DIFF
--- a/deploy_enclave.sh
+++ b/deploy_enclave.sh
@@ -1,0 +1,78 @@
+#! /usr/bin/env bash
+
+set -eu
+
+while getopts "p:e:a:s:t:" arg; do
+  case $arg in
+    e)
+      ENCLAVE="${OPTARG}"
+      ;;
+    a)
+      TERRAFORM_ACTION="${OPTARG}"
+      ;;
+    p)
+      PROFILE="${OPTARG}"
+      ;;
+    s)
+      STATE="${OPTARG}"
+      ;;
+    t)
+      TARGET="${OPTARG}"
+      ;;
+  esac
+done
+
+AWS_REGION="eu-west-2"
+bucket_name="govukobserve-tfstate-prom-enclave-${ENCLAVE}"
+
+
+
+TERRAFORM_ACTION=${TERRAFORM_ACTION:-plan}
+STATE=${STATE:-network}
+
+role="arn:aws:iam::170611269615:role/prometheus_deployer"
+role_session="test"
+
+response="$(aws-vault exec "${PROFILE}" -- \
+    aws sts assume-role \
+        --role-arn="${role}" \
+        --role-session-name="${role_session}")"
+
+
+export AWS_ACCESS_KEY_ID="$(echo "$response" | jq -r .Credentials.AccessKeyId)"
+export AWS_SECRET_ACCESS_KEY="$(echo "$response" | jq -r .Credentials.SecretAccessKey)"
+export AWS_SESSION_TOKEN="$(echo "$response" | jq -r .Credentials.SessionToken)"
+
+buckets=$(aws s3api list-buckets --query "Buckets[].Name")
+if echo ${buckets} | grep -q ${bucket_name}; then
+    #bucket exists
+    echo "${bucket_name} exists"
+else
+    echo "creating ${bucket_name}"
+    aws s3api create-bucket --bucket="${bucket_name}" --region "${AWS_REGION}" --create-bucket-configuration LocationConstraint="${AWS_REGION}"
+fi
+
+planfile="tf-$(date +"%Y_%m_%d_%H:%I%S").plan"
+
+pushd "terraform/projects/enclave/${ENCLAVE}/${STATE}"
+    terraform init -reconfigure
+    if [ "${STATE}" == "network" ]
+    then
+        terraform apply --target module.network.aws_vpc_endpoint.ec2
+    fi
+    if [ "${TERRAFORM_ACTION}" == "apply" ] 
+    then
+        terraform plan --out "${planfile}"
+        echo "Do you wish to apply plan?"
+        select yn in "yes" "no"; do
+            case $yn in
+                yes)
+                    terraform apply "${planfile}"
+                    break;;
+                no) exit;;
+            esac
+        done
+    else
+        terraform "${TERRAFORM_ACTION}"
+    fi
+popd

--- a/terraform/modules/enclave/network/ec2_vpc_endpoint.tf
+++ b/terraform/modules/enclave/network/ec2_vpc_endpoint.tf
@@ -1,0 +1,35 @@
+resource "aws_vpc_endpoint" "ec2" {
+  vpc_id             = "${var.target_vpc}"
+  service_name       = "com.amazonaws.eu-west-2.ec2"
+  vpc_endpoint_type  = "Interface"
+  security_group_ids = ["${aws_security_group.ec2-private-api-interface.id}"]
+  subnet_ids         = ["${aws_subnet.observe.*.id}"]
+}
+
+resource "aws_security_group" "ec2-private-api-interface" {
+  vpc_id = "${var.target_vpc}"
+  name   = "prometheus_to_ec2"
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = 443
+    to_port     = 443
+    cidr_blocks = ["10.0.3.32/27"]
+  }
+
+  tags {
+    Name        = "${var.team}-${var.product}-${var.environment}-ec2-vpc-endpoint-sg"
+    Environment = "${var.environment}"
+    Product     = "${var.product}"
+    Team        = "${var.team}"
+    ManagedBy   = "terraform"
+  }
+}
+
+data "aws_network_interface" "ec2_endpoint_network_interfaces" {
+  count = "${length(aws_vpc_endpoint.ec2.network_interface_ids)}"
+
+  id = "${element(aws_vpc_endpoint.ec2.network_interface_ids, count.index)}"
+
+  depends_on = ["aws_vpc_endpoint.ec2"]
+}

--- a/terraform/modules/enclave/network/main.tf
+++ b/terraform/modules/enclave/network/main.tf
@@ -1,0 +1,185 @@
+resource "aws_subnet" "observe" {
+  count                   = "${length(keys(var.availability_zones))}"
+  availability_zone       = "${element(keys(var.availability_zones), count.index)}"
+  cidr_block              = "${lookup(var.availability_zones, element(keys(var.availability_zones), count.index))}"
+  map_public_ip_on_launch = false
+  vpc_id                  = "${var.target_vpc}"
+
+  tags {
+    Name        = "${var.team}-${var.product}-${var.environment}-subnet-${element(keys(var.availability_zones), count.index)}"
+    Environment = "${var.environment}"
+    Product     = "${var.product}"
+    Team        = "${var.team}"
+    ManagedBy   = "terraform"
+  }
+}
+
+resource "aws_route_table" "observe" {
+  vpc_id = "${var.target_vpc}"
+
+  tags {
+    Name        = "${var.team}-${var.product}-${var.environment}-rt-${element(keys(var.availability_zones), count.index)}"
+    Environment = "${var.environment}"
+    Product     = "${var.product}"
+    Team        = "${var.team}"
+    ManagedBy   = "terraform"
+  }
+}
+
+# A default route via the internet gateway.
+resource "aws_route" "default" {
+  route_table_id         = "${aws_route_table.observe.id}"
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = "${var.internet_gateway_id}"
+}
+
+resource "aws_route" "vpc_peers" {
+  count = "${length(keys(var.vpc_peers))}"
+
+  route_table_id            = "${aws_route_table.observe.id}"
+  destination_cidr_block    = "${element(keys(var.vpc_peers), count.index)}"
+  vpc_peering_connection_id = "${lookup(var.vpc_peers, element(keys(var.vpc_peers), count.index))}"
+}
+
+# Associate route table with observe subnets
+resource "aws_route_table_association" "observe" {
+  count = "${length(keys(var.availability_zones))}"
+
+  subnet_id      = "${element(aws_subnet.observe.*.id, count.index)}"
+  route_table_id = "${aws_route_table.observe.id}"
+}
+
+resource "aws_security_group" "prometheus_instance" {
+  vpc_id = "${var.target_vpc}"
+  name   = "${var.team}-${var.product}-${var.environment}-prometheus-instance"
+
+  tags {
+    Name        = "${var.team}-${var.product}-${var.environment}-prometheus-instance-sg"
+    Environment = "${var.environment}"
+    Product     = "${var.product}"
+    Team        = "${var.team}"
+    ManagedBy   = "terraform"
+  }
+}
+
+resource "aws_security_group_rule" "allow_ssh_from_gds" {
+  type        = "ingress"
+  protocol    = "tcp"
+  from_port   = 22
+  to_port     = 22
+  cidr_blocks = ["${var.cidr_admin_whitelist}"]
+
+  security_group_id = "${aws_security_group.prometheus_instance.id}"
+}
+
+resource "aws_security_group_rule" "allow_access_to_egress_proxies" {
+  type        = "egress"
+  protocol    = "tcp"
+  from_port   = 8080
+  to_port     = 8080
+  cidr_blocks = ["10.0.1.87/32"]
+
+  security_group_id = "${aws_security_group.prometheus_instance.id}"
+}
+
+resource "aws_security_group_rule" "dns_udp" {
+  type      = "egress"
+  protocol  = "udp"
+  from_port = 53
+  to_port   = 53
+
+  cidr_blocks = [
+    "10.0.1.251/32",
+    "10.0.1.253/32",
+  ]
+
+  security_group_id = "${aws_security_group.prometheus_instance.id}"
+}
+
+resource "aws_security_group_rule" "dns_tcp" {
+  type      = "egress"
+  protocol  = "tcp"
+  from_port = 53
+  to_port   = 53
+
+  cidr_blocks = [
+    "10.0.1.251/32",
+    "10.0.1.253/32",
+  ]
+
+  security_group_id = "${aws_security_group.prometheus_instance.id}"
+}
+
+resource "aws_security_group_rule" "node_exporter" {
+  type      = "egress"
+  protocol  = "tcp"
+  from_port = 9100
+  to_port   = 9100
+
+  cidr_blocks = [
+    "10.0.0.0/22",
+    "10.1.0.0/22",
+  ]
+
+  security_group_id = "${aws_security_group.prometheus_instance.id}"
+}
+
+resource "aws_security_group_rule" "node_exporter_from_other_prom" {
+  type      = "ingress"
+  protocol  = "tcp"
+  from_port = 9100
+  to_port   = 9100
+
+  cidr_blocks = [
+    "10.0.3.32/27",
+  ]
+
+  security_group_id = "${aws_security_group.prometheus_instance.id}"
+}
+
+resource "aws_security_group_rule" "s3" {
+  type      = "egress"
+  protocol  = "tcp"
+  from_port = 443
+  to_port   = 443
+
+  cidr_blocks = [
+    "${aws_vpc_endpoint.private-s3.cidr_blocks}",
+  ]
+
+  security_group_id = "${aws_security_group.prometheus_instance.id}"
+}
+
+resource "aws_security_group_rule" "ec2_endpoint" {
+  type      = "egress"
+  protocol  = "tcp"
+  from_port = 443
+  to_port   = 443
+
+  cidr_blocks = [
+    "${formatlist("%s/32", flatten(data.aws_network_interface.ec2_endpoint_network_interfaces.*.private_ips))}",
+  ]
+
+  security_group_id = "${aws_security_group.prometheus_instance.id}"
+}
+
+resource "aws_vpc_endpoint" "private-s3" {
+  vpc_id          = "${var.target_vpc}"
+  service_name    = "com.amazonaws.eu-west-2.s3"
+  route_table_ids = ["${aws_route_table.observe.id}"]
+
+  policy = "${data.aws_iam_policy_document.s3_vpc_endpoint_policy.json}"
+}
+
+data "aws_iam_policy_document" "s3_vpc_endpoint_policy" {
+  statement {
+    actions   = ["*"]
+    effect    = "Allow"
+    resources = ["*"]
+
+    principals = {
+      type        = "*"
+      identifiers = ["*"]
+    }
+  }
+}

--- a/terraform/modules/enclave/network/outputs.tf
+++ b/terraform/modules/enclave/network/outputs.tf
@@ -1,0 +1,21 @@
+output "availability_zones" {
+  value = "${var.availability_zones}"
+}
+
+output "subnet_ids" {
+  value = "${aws_subnet.observe.*.id}"
+}
+
+output "security_groups" {
+  value = [
+    "${aws_security_group.prometheus_instance.id}",
+  ]
+}
+
+output "endpoint_network_interface_ip" {
+  value = "${flatten(data.aws_network_interface.ec2_endpoint_network_interfaces.*.private_ips)}"
+}
+
+output "routing_table" {
+  value = "${aws_route_table.observe.id}"
+}

--- a/terraform/modules/enclave/network/variables.tf
+++ b/terraform/modules/enclave/network/variables.tf
@@ -1,0 +1,47 @@
+variable "availability_zones" {
+  type    = "map"
+  default = {}
+}
+
+# the traget VPC which the 
+variable "target_vpc" {
+  description = "The target VPC which Prometheus will be deployed to"
+  type        = "string"
+}
+
+variable "internet_gateway_id" {
+  description = "The internet gateway of the target VPC"
+
+  type = "string"
+}
+
+#Needed by Verify to peer with the high VPC can be left empty if there are no
+#VPCs to peer with
+variable "vpc_peers" {
+  description = "Map of VPCs to peer with the key is the subnet the value is the VPC peer ID"
+
+  type    = "map"
+  default = {}
+}
+
+variable "cidr_admin_whitelist" {
+  description = "CIDR ranges permitted to communicate with administrative endpoints"
+  type        = "list"
+
+  default = [
+    "213.86.153.212/32",
+    "213.86.153.213/32",
+    "213.86.153.214/32",
+    "213.86.153.235/32",
+    "213.86.153.236/32",
+    "213.86.153.237/32",
+    "85.133.67.244/32",
+  ]
+}
+
+variable environment {}
+variable product {}
+
+variable team {
+  default = "observe"
+}

--- a/terraform/modules/enclave/prometheus/cloud.conf
+++ b/terraform/modules/enclave/prometheus/cloud.conf
@@ -1,0 +1,52 @@
+#cloud-config
+apt_preserve_sources_list: true
+apt_sources:
+ - source: "deb [arch=amd64] http://www.mirrorservice.org/sites/archive.ubuntu.com/ubuntu bionic main restricted universe multiverse"
+ - source: "deb [arch=amd64] http://www.mirrorservice.org/sites/archive.ubuntu.com/ubuntu bionic-security main restricted universe multiverse"
+ - source: "deb [arch=amd64] http://www.mirrorservice.org/sites/archive.ubuntu.com/ubuntu bionic-updates main restricted universe multiverse"
+
+package_update: true
+package_upgrade: true
+packages: ['prometheus', 'prometheus-node-exporter', 'awscli', 'inotify-tools']
+
+write_files:
+  - owner: root:root
+    path: /etc/default/prometheus
+    permissions: 0444
+    content: 'ARGS="--storage.tsdb.path=\"/mnt/\""'
+  - owner: root:root
+    path: /etc/cron.d/config_pull
+    content: |
+        */2 * * * * root aws s3 sync s3://${config_bucket}/prometheus/ /etc/prometheus/ --region=${region}
+        @reboot root mount /dev/xvdh /mnt
+        @reboot root /root/watch_prometheus_dir
+  - content: |
+       #!/bin/bash
+       if file -s /dev/xvdh | grep -q "/dev/xvdh: data"; then
+         mkfs -t 'ext4' -L 'prometheus_disk' '/dev/xvdh'
+       else
+         echo "disk already formated"
+       fi
+    path: /root/format_disk.sh
+    permissions: 0755
+  - content: |
+       #!/bin/bash
+       inotifywait -e modify,create,delete,move -m -r /etc/prometheus |
+       while read -r directory events; do
+         systemctl reload prometheus
+       done
+    path: /root/watch_prometheus_dir
+    permissions: 0755
+# Remove the default ubuntu repositories from the sources list
+  - content: ''
+    path: '/etc/apt/sources.list'
+
+bootcmd:
+  - "if [ '${egress_proxy}' ]; then echo 'writing proxy config' && echo 'Acquire::http::Proxy \"http://${egress_proxy}\";' > /etc/apt/apt.conf.d/05proxy; fi"
+
+runcmd:
+  - "if [ '${aws_ec2_ip}' ]; then echo '${aws_ec2_ip} ec2.eu-west-2.amazonaws.com' >> /etc/hosts; fi"
+  - [ bash, -c, "/root/format_disk.sh"]
+  - [ bash, -c, "mount /dev/xvdh /mnt"]
+  - [bash, -c, "chown -R prometheus /mnt/"]
+  - [reboot]

--- a/terraform/modules/enclave/prometheus/config_bucket.tf
+++ b/terraform/modules/enclave/prometheus/config_bucket.tf
@@ -1,0 +1,26 @@
+data "aws_region" "current" {}
+
+data "template_file" "prometheus_config_template" {
+  template = "${file("${path.module}/prometheus.conf.tpl")}"
+
+  vars {
+    ec2_instance_profile = "${aws_iam_instance_profile.prometheus_instance_profile.name}"
+    aws_region           = "${data.aws_region.current.name}"
+  }
+}
+
+resource "aws_s3_bucket_object" "prometheus_config" {
+  bucket  = "${aws_s3_bucket.prometheus_config.id}"
+  key     = "prometheus/prometheus.yml"
+  content = "${data.template_file.prometheus_config_template.rendered}"
+  etag    = "${md5(data.template_file.prometheus_config_template.rendered)}"
+}
+
+resource "aws_s3_bucket" "prometheus_config" {
+  bucket = "gdsobserve-verify-${var.environment}-prometheus-config-store"
+  acl    = "private"
+
+  versioning {
+    enabled = true
+  }
+}

--- a/terraform/modules/enclave/prometheus/iam.tf
+++ b/terraform/modules/enclave/prometheus/iam.tf
@@ -1,0 +1,62 @@
+#Prepare to attach role to instance
+resource "aws_iam_instance_profile" "prometheus_instance_profile" {
+  name = "prometheus_config_reader_profile"
+  role = "${aws_iam_role.prometheus_role.name}"
+}
+
+#Create role
+resource "aws_iam_role" "prometheus_role" {
+  name = "prometheus_profile"
+
+  assume_role_policy = "${data.aws_iam_policy_document.prometheus_assume_role_policy.json}"
+}
+
+#Create permission to assume role
+data "aws_iam_policy_document" "prometheus_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+#Define the policy to attach the role too
+resource "aws_iam_policy" "prometheus_instance_profile" {
+  name        = "prometheus_instance_profile"
+  path        = "/"
+  description = "This is the main profile, that has bucket permission and decribe permissions"
+
+  policy = "${data.aws_iam_policy_document.instance_role_policy.json}"
+}
+
+#define IAM policy documention
+data "aws_iam_policy_document" "instance_role_policy" {
+  statement {
+    sid       = "ec2Policy"
+    actions   = ["ec2:Describe*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "s3Bucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.prometheus_config.id}/*",
+      "arn:aws:s3:::${aws_s3_bucket.prometheus_config.id}",
+    ]
+  }
+}
+
+#Attach policy to role
+resource "aws_iam_role_policy_attachment" "iam_policy" {
+  role       = "${aws_iam_role.prometheus_role.name}"
+  policy_arn = "${aws_iam_policy.prometheus_instance_profile.arn}"
+}

--- a/terraform/modules/enclave/prometheus/main.tf
+++ b/terraform/modules/enclave/prometheus/main.tf
@@ -1,0 +1,70 @@
+terraform {
+  required_version = "= 0.11.7"
+}
+
+locals {
+  enable_public_ip = "${var.enable_ssh == 1 ? true : false}"
+}
+
+resource "aws_key_pair" "ssh_key" {
+  key_name   = "${var.environment}-prom-key"
+  public_key = "${file("~/.ssh/id_rsa.pub")}"
+}
+
+resource "aws_instance" "prometheus" {
+  count = "${length(var.subnet_ids)}"
+
+  ami                  = "${var.ami_id}"
+  instance_type        = "${var.instance_size}"
+  user_data            = "${data.template_file.user_data_script.rendered}"
+  iam_instance_profile = "${aws_iam_instance_profile.prometheus_instance_profile.id}"
+  subnet_id            = "${element(var.subnet_ids, count.index)}"
+
+  associate_public_ip_address = "${local.enable_public_ip}"
+
+  key_name = "${aws_key_pair.ssh_key.key_name}"
+
+  vpc_security_group_ids = ["${var.vpc_security_groups}"]
+
+  tags {
+    Name        = "${var.product}-${var.environment}-prometheus-${element(keys(var.availability_zones), count.index)}"
+    Environment = "${var.environment}"
+    Product     = "${var.product}"
+    ManagedBy   = "terraform"
+  }
+}
+
+resource "aws_volume_attachment" "attach-prometheus-disk" {
+  count = "${length(var.subnet_ids)}"
+
+  device_name = "${var.device_mount_path}"
+  volume_id   = "${element(aws_ebs_volume.promethues-disk.*.id, count.index)}"
+  instance_id = "${element(aws_instance.prometheus.*.id, count.index)}"
+
+  # Required to work around a bug in terraform https://github.com/hashicorp/terraform/issues/2957
+  # terraform tries to destroy the attachment before stoping/destorying the instance
+  skip_destroy = true
+}
+
+resource "aws_ebs_volume" "promethues-disk" {
+  count = "${length(var.subnet_ids)}"
+
+  availability_zone = "${element(keys(var.availability_zones), count.index)}"
+  size              = "20"
+
+  tags {
+    Name = "promethues-disk"
+  }
+}
+
+data "template_file" "user_data_script" {
+  template = "${file("${path.module}/cloud.conf")}"
+
+  vars {
+    config_bucket  = "${aws_s3_bucket.prometheus_config.id}"
+    egress_proxy   = "${var.egress_proxy}"
+    aws_ec2_ip     = "${var.ec2_endpoint_ips[0]}"
+    region         = "${var.region}"
+    verify_enclave = "${var.verify_enclave}"
+  }
+}

--- a/terraform/modules/enclave/prometheus/output.tf
+++ b/terraform/modules/enclave/prometheus/output.tf
@@ -1,0 +1,19 @@
+output "cloudinit-script" {
+  value = "${data.template_file.user_data_script.rendered}"
+}
+
+output "public_ip_address" {
+  value = "${aws_instance.prometheus.*.public_ip}"
+}
+
+output "prometheus_instance_id" {
+  value = "${aws_instance.prometheus.*.id}"
+}
+
+output "prometheus_public_dns" {
+  value = "${aws_instance.prometheus.*.public_dns}"
+}
+
+output "s3_config_bucket" {
+  value = "${aws_s3_bucket.prometheus_config.bucket}"
+}

--- a/terraform/modules/enclave/prometheus/prometheus.conf.tpl
+++ b/terraform/modules/enclave/prometheus/prometheus.conf.tpl
@@ -1,0 +1,24 @@
+global:
+  scrape_interval:     30s
+  evaluation_interval: 30s
+
+scrape_configs:
+  - job_name: 'node_exporters'
+    ec2_sd_configs:
+    - region: "${aws_region}"
+      profile: "${ec2_instance_profile}"
+      port: 9100
+    relabel_configs:
+    - source_labels: [__meta_ec2_private_ip]
+      regex: '10\.[0-1]\.[1-3]\..*'
+      action: keep
+    - source_labels: [__meta_ec2_tag_Name]
+      regex: '.*\.secops\..*'
+      action: drop
+    - source_labels: [__meta_ec2_tag_Name]
+      regex: '.*\.stubs\..*'
+      action: drop
+    - source_labels: [__meta_ec2_private_ip]
+      target_label: private_ip
+    - source_labels: [__meta_ec2_tag_Name]
+      target_label: instance

--- a/terraform/modules/enclave/prometheus/variables.tf
+++ b/terraform/modules/enclave/prometheus/variables.tf
@@ -1,0 +1,57 @@
+variable "ami_id" {}
+
+variable "device_mount_path" {
+  description = "The path to mount the promethus disk"
+  default     = "/dev/sdh"
+}
+
+variable "availability_zones" {
+  description = "A map of availability zones to subnets"
+
+  type    = "map"
+  default = {}
+}
+
+variable "subnet_ids" {
+  type = "list"
+}
+
+variable "instance_size" {
+  type        = "string"
+  description = "This is the default instance size"
+  default     = "t2.medium"
+}
+
+variable "target_vpc" {
+  description = "The VPC in which the system will be deployed"
+}
+
+variable "product" {}
+
+variable "environment" {}
+
+variable "vpc_security_groups" {
+  type    = "list"
+  default = []
+}
+
+variable "enable_ssh" {
+  default = false
+}
+
+variable "ec2_endpoint_ips" {
+  type    = "list"
+  default = []
+}
+
+variable "region" {
+  default = "eu-west-2"
+}
+
+variable "verify_enclave" {
+  default = "true"
+}
+
+variable "egress_proxy" {
+  default = ""
+}

--- a/terraform/projects/enclave/verify-perf-a/network/outputs.tf
+++ b/terraform/projects/enclave/verify-perf-a/network/outputs.tf
@@ -1,0 +1,15 @@
+output "availability_zones" {
+  value = "${module.network.availability_zones}"
+}
+
+output "subnet_ids" {
+  value = "${module.network.subnet_ids}"
+}
+
+output "security_groups" {
+  value = "${module.network.security_groups}"
+}
+
+output "endpoint_network_interface_ip" {
+  value = "${module.network.endpoint_network_interface_ip}"
+}

--- a/terraform/projects/enclave/verify-perf-a/network/site.tf
+++ b/terraform/projects/enclave/verify-perf-a/network/site.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_version = "= 0.11.7"
+
+  backend "s3" {
+    bucket  = "govukobserve-tfstate-prom-enclave-verify-perf-a"
+    key     = "network.tfstate"
+    encrypt = true
+    region  = "eu-west-2"
+  }
+}
+
+provider "aws" {
+  region              = "eu-west-2"
+  allowed_account_ids = ["170611269615"]
+}
+
+module "network" {
+  source              = "../../../../modules/enclave/network"
+  environment         = "Perf"
+  product             = "Hub"
+  target_vpc          = "vpc-0067a6d5138a90c5e"
+  internet_gateway_id = "igw-01394f4441848e37a"
+
+  availability_zones = {
+    "eu-west-2a" = "10.0.3.32/28"
+    "eu-west-2b" = "10.0.3.48/28"
+  }
+
+  vpc_peers = {
+    "10.1.0.0/22" = "pcx-05fa5d08a41dd0755"
+  }
+}

--- a/terraform/projects/enclave/verify-perf-a/prometheus/main.tf
+++ b/terraform/projects/enclave/verify-perf-a/prometheus/main.tf
@@ -1,0 +1,51 @@
+terraform {
+  required_version = "= 0.11.7"
+
+  backend "s3" {
+    bucket  = "govukobserve-tfstate-prom-enclave-verify-perf-a"
+    key     = "prometheus.tfstate"
+    encrypt = true
+    region  = "eu-west-2"
+  }
+}
+
+provider "aws" {
+  region              = "eu-west-2"
+  allowed_account_ids = ["170611269615"]
+}
+
+data "terraform_remote_state" "network" {
+  backend = "s3"
+
+  config {
+    bucket  = "govukobserve-tfstate-prom-enclave-verify-perf-a"
+    key     = "network.tfstate"
+    encrypt = true
+    region  = "eu-west-2"
+  }
+}
+
+module "prometheus" {
+  source = "../../../../modules/enclave/prometheus"
+
+  # Canonicals Ubunutu 18.04 Bionic Beaver in eu-west-2
+  ami_id = "ami-e4ad5983"
+
+  # Verifys perf-a low-vpc
+  target_vpc = "vpc-0067a6d5138a90c5e"
+
+  enable_ssh   = true
+  egress_proxy = "egress-proxy.service.dmz:8080"
+
+  product     = "hub"
+  environment = "perf"
+
+  subnet_ids          = "${data.terraform_remote_state.network.subnet_ids}"
+  availability_zones  = "${data.terraform_remote_state.network.availability_zones}"
+  vpc_security_groups = ["${data.terraform_remote_state.network.security_groups}"]
+  ec2_endpoint_ips    = ["${data.terraform_remote_state.network.endpoint_network_interface_ip}"]
+}
+
+output "public_ips" {
+  value = "${module.prometheus.public_ip_address}"
+}


### PR DESCRIPTION
This commit deploys prometheus.

There are two modules defined, enclave/network and enclave/prometheus

There are two projects enclave/verify-perf-a/network and
enclave/verify-perf-a/prometheus

The projects instantiate the respective modules with variables for that
particular environment, for example the vpc_id which verify-perf-a specific
is defined in projects/enclave/verify-perf-a/network and passed through to
the network module which can then use the vpc id to build the subnets.

Using this pattern it is easy to deploy prometheus to new verify
environments by creating new enclave projects and specifying the
appropriate variables.

The network module defines two subnets in different availability zones,
whist not strictly necessary (verify only operates out of a single
availability zone) it was felt it was easier to do it now then build with a
single instance and add the second later.

The network also describes the security groups and vpc endpoints. VPC
endpoints are used to reach s3 and the ec2 api. The s3 endpoint is an
example of a "Gateway" endpoint, it makes external IP address routeable
without going over the public internet. The ec2 endpoint is an example of
interface endpoint, again the goal is to access the ec2 api endpoint
without needing to access the public internet. However in this case instead
of using routing rules to reach the endpoint a network interface is added
to the subnet. If you want to reach the service you connect to the local ip
of the network interface instead of the public ip. This caused a problem,
prometheus uses the EC2 API for service discovery, prometheus uses the aws
go sdk which does not allow you to override the ip address used to connect
to the service. The sdk will always try and connect via
ec2.eu-west-2.amazonaws.com (the sdk does let you configure proxies but
that doesn't help in this case) we therefore have to override the address
of ec2.eu-west-2.amazonaws.com in the hosts file. To do this required a
data lookup against the network interfaces and a bit of terraform trickery
to pull out a list of private_ips for the network interfaces. This is a
little hacky so the ec2-endpoint code has been kept in a separate file to
make it easier to remove if decided to adopt a different approach.

The prometheus module defines the prometheus istances, the disks and the
prometheus config. The instances are built using cloud init. The config
file is published to an s3 bucket. The instances poll the s3 bucket and
download the config and restart the prometheus service. Currently the state
of the scripts which manage the process are proof of concept, they work but
with caveats, currently prometheus is restarted every 2 minutes because the
scripts are not able to tell if the config has been modified and there is
no validation of the config. Prometheus reloads config without interruption
to the service and promethues ignores invalid config and continues running
with the old. So whilst the config updating process could be improved the
impact of the existing scripts is minimal.

Currently the configuration assumes it is being ran within a verify
environment this was to speed up development.

A deploy script was created to help with the running of terraform. It is
proof of concept quality too. An example command `./deploy_enclave.sh -e
verify-perf-a -p gds-tech-ops -a apply -s prometheus` will apply the
prometheus terraform the verfiy-perf-a enclave. The script assumes role to
the promethues_deployer role in the verify account, changes directory in to
correct project directory and executes terraform -a is the action so you
can `-a apply` to apply `-a plan` to run a plan and
`-a destroy` to destroy the environment. The apply runs a plan first saving
the plan file to be used in the apply currently the script does not clean
up the plan files.