### PR TITLE
Add alerting for DGU significant change to Elasticsearch index size

### DIFF
--- a/terraform/projects/app-ecs-services/config/alerts/data-gov-uk.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/data-gov-uk.yml
@@ -24,3 +24,19 @@ groups:
     annotations:
         summary: "App {{ $labels.app }} has high disk usage"
         description: "Application {{ $labels.app }} has an instance which is using over 80% disk."
+  - alert: DataGovUk_ElasticSearchIndexSizeIncrease
+    expr: sum by (job) (increase(elasticsearch_indices_docs{space="data-gov-uk"}[30m])) >= 100
+    for: 1m
+    labels:
+        product: "data-gov-uk"
+    annotations:
+        summary: "Index size of Elasticsearch for {{ $labels.job }} has increased significantly"
+        description: "The index size of Elasticsearch for {{ $labels.job }} has increased by more than 100 documents in the last 30 minutes"
+  - alert: DataGovUk_ElasticSearchIndexSizeDecrease
+    expr: sum by (job) (increase(elasticsearch_indices_docs{space="data-gov-uk"}[30m])) <= -100
+    for: 1m
+    labels:
+        product: "data-gov-uk"
+    annotations:
+        summary: "Index size of Elasticsearch for {{ $labels.job }} has decreased significantly"
+        description: "The index size of Elasticsearch for {{ $labels.job }} has decreased by more than 100 documents in the last 30 minutes"


### PR DESCRIPTION
This will trigger an alert if the Elasticsearch index size for data.gov.uk increases or decreases by more than 100 documents in a 30 minute period.

# Why I am making this change

We need an alert on DGU to notify of a significant change in index size.  We have had several incidents recently where data has been incorrectly marked as draft and therefore removed from the Elasticsearch index.  There was no alerting, so this was not picked up until we were informed by users.

# What approach I took

Value of ±100 documents in a 30 minute period was chosen as we do not believe this number of records would likely be published during that period.  The choice of this value can be observed over time and iterated if required.

Trello card: https://trello.com/c/tMxktv9p/440-add-an-alert-for-significant-data-size-changes-in-dgu-elasticsearch