### PR TITLE
Get email address for zendesk alerts from pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ export TERRAFORM_BUCKET=<terraform state bucket name, should be unique or match 
 export PROFILE_NAME=<your profile name in `~/.aws/config` to access RE AWS>
 export ENV=<desired name of your test environment, or `staging` / `production`>
 export DEV_ENVIRONMENT=<'true' or 'false'>
-export TICKET_RECIPIENT_EMAIL=$(git config user.email) # or whatever email address you want to receive ticket notifications on
 ```
 
 Applying or destroying the entire stack on the staging and production environments has been blocked but is possible on other development environments.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ export TERRAFORM_BUCKET=<terraform state bucket name, should be unique or match 
 export PROFILE_NAME=<your profile name in `~/.aws/config` to access RE AWS>
 export ENV=<desired name of your test environment, or `staging` / `production`>
 export DEV_ENVIRONMENT=<'true' or 'false'>
+export DEV_TICKET_RECIPIENT_EMAIL=$(git config user.email) # or whatever email address you want to receive ticket notifications on
 ```
 
 Applying or destroying the entire stack on the staging and production environments has been blocked but is possible on other development environments.

--- a/environment_sample.sh
+++ b/environment_sample.sh
@@ -2,4 +2,3 @@ export TERRAFORM_BUCKET=<your-bucket>
 export PROFILE_NAME=gds-tech-ops
 export ENV=<your-env>
 export DEV_ENVIRONMENT=true
-export TICKET_RECIPIENT_EMAIL=$(git config user.email) # or whatever email address you want to receive ticket notifications on

--- a/environment_sample.sh
+++ b/environment_sample.sh
@@ -2,3 +2,4 @@ export TERRAFORM_BUCKET=<your-bucket>
 export PROFILE_NAME=gds-tech-ops
 export ENV=<your-env>
 export DEV_ENVIRONMENT=true
+export DEV_TICKET_RECIPIENT_EMAIL=$(git config user.email) # or whatever email address you want to receive ticket notifications on

--- a/setup.sh
+++ b/setup.sh
@@ -48,7 +48,6 @@ targets_s3_bucket="$DEFAULT_DEV_TARGETS_S3_BUCKET"
 additional_tags = {
   "Environment" = "${ENV}"
 }
-ticket_recipient_email = "${TICKET_RECIPIENT_EMAIL}"
 EOF
 echo "stacks/${ENV}.tfvars created"
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -48,6 +48,7 @@ targets_s3_bucket="$DEFAULT_DEV_TARGETS_S3_BUCKET"
 additional_tags = {
   "Environment" = "${ENV}"
 }
+dev_ticket_recipient_email = "${DEV_TICKET_RECIPIENT_EMAIL}"
 EOF
 echo "stacks/${ENV}.tfvars created"
 fi

--- a/terraform/projects/app-ecs-services/alertmanager-service.tf
+++ b/terraform/projects/app-ecs-services/alertmanager-service.tf
@@ -158,6 +158,10 @@ data "pass_password" "registers_zendesk" {
   path = "receivers/registers/zendesk"
 }
 
+data "pass_password" "observe_zendesk" {
+  path = "receivers/observe/zendesk"
+}
+
 data "template_file" "alertmanager_config_file" {
   template = "${file("templates/alertmanager.tpl")}"
 
@@ -171,7 +175,7 @@ data "template_file" "alertmanager_config_file" {
     smtp_smarthost         = "email-smtp.${var.aws_region}.amazonaws.com:587"
     smtp_username          = "${aws_iam_access_key.smtp.id}"
     smtp_password          = "${aws_iam_access_key.smtp.ses_smtp_password}"
-    ticket_recipient_email = "${var.ticket_recipient_email}"
+    ticket_recipient_email = "${data.pass_password.observe_zendesk.password}"
   }
 }
 
@@ -189,7 +193,7 @@ data "template_file" "alertmanager_dev_config_file" {
     smtp_smarthost         = "email-smtp.${var.aws_region}.amazonaws.com:587"
     smtp_username          = "${aws_iam_access_key.smtp.id}"
     smtp_password          = "${aws_iam_access_key.smtp.ses_smtp_password}"
-    ticket_recipient_email = "${var.ticket_recipient_email}"
+    ticket_recipient_email = "${data.pass_password.observe_zendesk.password}"
   }
 }
 

--- a/terraform/projects/app-ecs-services/alertmanager-service.tf
+++ b/terraform/projects/app-ecs-services/alertmanager-service.tf
@@ -190,10 +190,10 @@ data "template_file" "alertmanager_dev_config_file" {
     smtp_from = "alerts@${data.terraform_remote_state.infra_networking.public_subdomain}"
 
     # Port as requested by https://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-connect.html
-    smtp_smarthost         = "email-smtp.${var.aws_region}.amazonaws.com:587"
-    smtp_username          = "${aws_iam_access_key.smtp.id}"
-    smtp_password          = "${aws_iam_access_key.smtp.ses_smtp_password}"
-    ticket_recipient_email = "${data.pass_password.observe_zendesk.password}"
+    smtp_smarthost             = "email-smtp.${var.aws_region}.amazonaws.com:587"
+    smtp_username              = "${aws_iam_access_key.smtp.id}"
+    smtp_password              = "${aws_iam_access_key.smtp.ses_smtp_password}"
+    dev_ticket_recipient_email = "${var.dev_ticket_recipient_email}"
   }
 }
 

--- a/terraform/projects/app-ecs-services/main.tf
+++ b/terraform/projects/app-ecs-services/main.tf
@@ -50,6 +50,12 @@ variable "stack_name" {
   default     = "ecs-monitoring"
 }
 
+variable "dev_ticket_recipient_email" {
+  type        = "string"
+  description = "Email address to send ticket alerts to"
+  default     = ""
+}
+
 # Resources
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-ecs-services/main.tf
+++ b/terraform/projects/app-ecs-services/main.tf
@@ -50,12 +50,6 @@ variable "stack_name" {
   default     = "ecs-monitoring"
 }
 
-variable "ticket_recipient_email" {
-  type        = "string"
-  description = "Email address to send ticket alerts to"
-  default     = "prometheus-notifications@digital.cabinet-office.gov.uk"
-}
-
 # Resources
 # --------------------------------------------------------------
 

--- a/terraform/projects/app-ecs-services/templates/alertmanager-dev.tpl
+++ b/terraform/projects/app-ecs-services/templates/alertmanager-dev.tpl
@@ -18,4 +18,4 @@ receivers:
 - name: "unmatched-default-root-route"
 - name: "ticket-alert"
   email_configs:
-  - to: "${ticket_recipient_email}"
+  - to: ""

--- a/terraform/projects/app-ecs-services/templates/alertmanager-dev.tpl
+++ b/terraform/projects/app-ecs-services/templates/alertmanager-dev.tpl
@@ -18,4 +18,4 @@ receivers:
 - name: "unmatched-default-root-route"
 - name: "ticket-alert"
   email_configs:
-  - to: ""
+  - to: "${dev_ticket_recipient_email}"


### PR DESCRIPTION
# Why I am making this change

So we can get Zendesk tickets for Prometheus alerts.

# What approach I took

Using the email address for that queue
