### PR TITLE
Prefer "without" over "by"

### DIFF
--- a/terraform/projects/app-ecs-services/config/alerts/alerts.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/alerts.yml
@@ -2,7 +2,7 @@ groups:
 - name: RE_Observe
   rules:
   - alert: RE_Observe_AlertManager_Below_Threshold
-    expr: up{job="alertmanager"} == 0 and on(job) sum by(job) (up{job="alertmanager"}) <= 1
+    expr: up{job="alertmanager"} == 0 and ignoring(instance) sum without(instance) (up{job="alertmanager"}) <= 1
     for: 10s
     labels:
         product: "prometheus"
@@ -12,7 +12,7 @@ groups:
         description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}."
         runbook: "https://re-team-manual.cloudapps.digital/observe-support.html#re-observe-alertmanager-below-threshold"
   - alert: RE_Observe_Prometheus_Below_Threshold
-    expr: up{job="prometheus"} == 0 and on(job) sum by(job) (up{job="prometheus"}) <= 1
+    expr: up{job="prometheus"} == 0 and ignoring(instance) sum without(instance) (up{job="prometheus"}) <= 1
     for: 10s
     labels:
         product: "prometheus"
@@ -44,7 +44,7 @@ groups:
 # this can be improved however maybe this is something we need to focus on in Q2 when working on the support plan
 
   - alert: RE_Observe_Prometheus_Over_Capacity
-    expr: sum by(instance)(rate(prometheus_engine_query_duration_seconds_sum{job="prometheus"}[5m])) > 8
+    expr: sum without(slice)(rate(prometheus_engine_query_duration_seconds_sum{job="prometheus"}[5m])) > 8
     for: 10s
     labels:
         product: "prometheus"
@@ -55,7 +55,7 @@ groups:
         runbook: "https://re-team-manual.cloudapps.digital/observe-support.html#re-observe-prometheus-over-capacity"
 
   - alert: RE_Observe_Prometheus_High_Load
-    expr: sum by(instance)(rate(prometheus_engine_query_duration_seconds_sum{job="prometheus"}[2h])) > 4
+    expr: sum without(slice)(rate(prometheus_engine_query_duration_seconds_sum{job="prometheus"}[2h])) > 4
     labels:
         product: "prometheus"
         severity: "ticket"


### PR DESCRIPTION
# Why I am making this change

Prometheus Up & Running page 88 says:

> `without` is preferred \[over `by`\] because if there are additional
> labels such as `env` or `region` across all of a job, they will not
> be lost.  This helps when you are sharing your rules with others.

A similar argument (on page 247) says we should prefer `ignoring` over
`on`.

# What approach I took

In our specific cases:

RE_Observe_AlertManager_Below_Threshold and
RE_Observe_Prometheus_Below_Threshold were doing sum `by(job)` and
`on(job)`, but this assumes that we only have a single
deployment.  If we added another prometheus/alertmanager in another
region, say, these jobs would unintentionally aggregate across
regions.  Changing them to sum `without(instance)` and
`ignoring(instance)` avoids this, and makes it clear what we're
aggregating over.

Similarly, RE_Observe_Prometheus_Over_Capacity and
RE_Observe_Prometheus_High_Load were doing sum `by(instance)`, but
changing them to `without(slice)` makes it clear that we're summing
across the different query engine slice timings and avoids
accidentally summing across hypothetical future regions.

This commit only touches alerts.yml and leaves registers.yml and
data-gov-uk.yml for the moment.

