### PR TITLE
Use a single scrape interval

### DIFF
--- a/terraform/projects/app-ecs-services/templates/prometheus.tpl
+++ b/terraform/projects/app-ecs-services/templates/prometheus.tpl
@@ -9,12 +9,10 @@ rule_files:
   - "/etc/prometheus/alerts/*"
 scrape_configs:
   - job_name: prometheus
-    scrape_interval: 5s
     static_configs:
       - targets: ["${prometheus_dns_names}"]
   - job_name: alertmanager
     scheme: http
-    scrape_interval: 5s
     static_configs:
       - targets: ["${alertmanager_dns_names}"]
   - job_name: paas-targets


### PR DESCRIPTION
# Why I am making this change

Prometheus Up & Running page 147 says:

> you can also override the `scrape_interval`, but in general you
> should aim for a single scrape interval in a Prometheus for sanity

This sounds like sensible advice.  I'm not sure why we had separate
scrape intervals for these services anyway.

