### PR TITLE
Update deploy script to reflect changes to how auth in verify enclave

### DIFF
--- a/deploy_enclave.sh
+++ b/deploy_enclave.sh
@@ -33,46 +33,36 @@ STATE=${STATE:-network}
 role="arn:aws:iam::170611269615:role/prometheus_deployer"
 role_session="test"
 
-response="$(aws-vault exec "${PROFILE}" -- \
-    aws sts assume-role \
-        --role-arn="${role}" \
-        --role-session-name="${role_session}")"
-
-
-export AWS_ACCESS_KEY_ID="$(echo "$response" | jq -r .Credentials.AccessKeyId)"
-export AWS_SECRET_ACCESS_KEY="$(echo "$response" | jq -r .Credentials.SecretAccessKey)"
-export AWS_SESSION_TOKEN="$(echo "$response" | jq -r .Credentials.SessionToken)"
-
-buckets=$(aws s3api list-buckets --query "Buckets[].Name")
+buckets=$(aws-vault exec ${PROFILE} -- aws s3api list-buckets --query "Buckets[].Name")
 if echo ${buckets} | grep -q ${bucket_name}; then
     #bucket exists
     echo "${bucket_name} exists"
 else
     echo "creating ${bucket_name}"
-    aws s3api create-bucket --bucket="${bucket_name}" --region "${AWS_REGION}" --create-bucket-configuration LocationConstraint="${AWS_REGION}"
+    aws-vault exec ${PROFILE} -- aws s3api create-bucket --bucket="${bucket_name}" --region "${AWS_REGION}" --create-bucket-configuration LocationConstraint="${AWS_REGION}"
 fi
 
 planfile="tf-$(date +"%Y_%m_%d_%H:%I%S").plan"
 
 pushd "terraform/projects/enclave/${ENCLAVE}/${STATE}"
-    terraform init -reconfigure
+    aws-vault exec ${PROFILE} -- terraform init -reconfigure
     if [ "${STATE}" == "network" ]
     then
-        terraform apply --target module.network.aws_vpc_endpoint.ec2
+        aws-vault exec ${PROFILE} -- terraform apply --target module.network.aws_vpc_endpoint.ec2
     fi
     if [ "${TERRAFORM_ACTION}" == "apply" ] 
     then
-        terraform plan --out "${planfile}"
+        aws-vault exec ${PROFILE} -- terraform plan --out "${planfile}"
         echo "Do you wish to apply plan?"
         select yn in "yes" "no"; do
             case $yn in
                 yes)
-                    terraform apply "${planfile}"
+                    aws-vault exec ${PROFILE} -- terraform apply "${planfile}"
                     break;;
                 no) exit;;
             esac
         done
     else
-        terraform "${TERRAFORM_ACTION}"
+        aws-vault exec ${PROFILE} -- terraform "${TERRAFORM_ACTION}"
     fi
 popd


### PR DESCRIPTION
The deploy_script now uses aws-vault to do all auth you need to specify
a profile for aws-vault to use.
i.e.

if your profile is:

    [profile verify-perf-a]
    source_profile = gds-user
    mfa_serial = arn:aws:iam::622626885786:mfa/some.user@digital.cabinet-office.gov.uk
    role_arn = arn:aws:iam::170611269615:role/prometheus_deployer

then the command will be

    `./deploy_enclave.sh -e verify-perf-a -p verify-perf-a -a plan -s
prometheus`