### PR TITLE
Add scrape of hub policy app

### DIFF
--- a/terraform/modules/enclave/network/main.tf
+++ b/terraform/modules/enclave/network/main.tf
@@ -73,11 +73,15 @@ resource "aws_security_group_rule" "allow_ssh_from_gds" {
 }
 
 resource "aws_security_group_rule" "allow_access_to_egress_proxies" {
-  type        = "egress"
-  protocol    = "tcp"
-  from_port   = 8080
-  to_port     = 8080
-  cidr_blocks = ["10.0.1.87/32"]
+  type      = "egress"
+  protocol  = "tcp"
+  from_port = 8080
+  to_port   = 8080
+
+  # Hardcoding these IPs is technical debt: they are IPs associated with
+  # egress-proxy.service.dmz, which is an ELB on a dynamic IP range.
+  # we should find a better way to do this
+  cidr_blocks = ["10.0.1.151/32", "10.0.1.142/32"]
 
   security_group_id = "${aws_security_group.prometheus_instance.id}"
 }

--- a/terraform/modules/enclave/network/main.tf
+++ b/terraform/modules/enclave/network/main.tf
@@ -137,6 +137,19 @@ resource "aws_security_group_rule" "node_exporter_from_other_prom" {
   security_group_id = "${aws_security_group.prometheus_instance.id}"
 }
 
+resource "aws_security_group_rule" "hub_policy" {
+  type      = "egress"
+  protocol  = "tcp"
+  from_port = 50111
+  to_port   = 50111
+
+  cidr_blocks = [
+    "10.1.0.0/22",
+  ]
+
+  security_group_id = "${aws_security_group.prometheus_instance.id}"
+}
+
 resource "aws_security_group_rule" "s3" {
   type      = "egress"
   protocol  = "tcp"

--- a/terraform/modules/enclave/prometheus/prometheus.conf.tpl
+++ b/terraform/modules/enclave/prometheus/prometheus.conf.tpl
@@ -15,8 +15,6 @@ scrape_configs:
     - source_labels: [__meta_ec2_tag_Name]
       regex: '.*\.stubs\..*'
       action: drop
-    - source_labels: [__meta_ec2_private_ip]
-      target_label: private_ip
     - source_labels: [__meta_ec2_tag_Name]
       target_label: instance
 
@@ -29,7 +27,5 @@ scrape_configs:
     - source_labels: [__meta_ec2_tag_Name]
       regex: 'policy.*'
       action: keep
-    - source_labels: [__meta_ec2_private_ip]
-      target_label: private_ip
     - source_labels: [__meta_ec2_tag_Name]
       target_label: instance

--- a/terraform/modules/enclave/prometheus/prometheus.conf.tpl
+++ b/terraform/modules/enclave/prometheus/prometheus.conf.tpl
@@ -19,6 +19,7 @@ scrape_configs:
       target_label: instance
 
   - job_name: 'hub_policy'
+    metrics_path: /prometheus/metrics
     ec2_sd_configs:
     - region: "${aws_region}"
       profile: "${ec2_instance_profile}"

--- a/terraform/modules/enclave/prometheus/prometheus.conf.tpl
+++ b/terraform/modules/enclave/prometheus/prometheus.conf.tpl
@@ -19,3 +19,17 @@ scrape_configs:
       target_label: private_ip
     - source_labels: [__meta_ec2_tag_Name]
       target_label: instance
+
+  - job_name: 'hub_policy'
+    ec2_sd_configs:
+    - region: "${aws_region}"
+      profile: "${ec2_instance_profile}"
+      port: 50111
+    relabel_configs:
+    - source_labels: [__meta_ec2_tag_Name]
+      regex: 'policy.*'
+      action: keep
+    - source_labels: [__meta_ec2_private_ip]
+      target_label: private_ip
+    - source_labels: [__meta_ec2_tag_Name]
+      target_label: instance

--- a/terraform/modules/enclave/prometheus/test/integration/prometheus/controls/aws_cloud_resources.rb
+++ b/terraform/modules/enclave/prometheus/test/integration/prometheus/controls/aws_cloud_resources.rb
@@ -55,6 +55,7 @@ control "aws_cloud_resources" do
     it { should allow_out(port: '53', ipv4_range: '10.0.1.251/32') }
     it { should allow_out(port: '53', ipv4_range: '10.0.1.253/32') }
     it { should allow_out(port: '8080', ipv4_range: '10.0.1.87/32') }
+    it { should allow_out(port: '50111', ipv4_range: '10.1.0.0/22') }
   end
 
   describe aws_security_group(group_name: 'prometheus_to_ec2') do

--- a/terraform/modules/enclave/prometheus/test/integration/prometheus/controls/aws_cloud_resources.rb
+++ b/terraform/modules/enclave/prometheus/test/integration/prometheus/controls/aws_cloud_resources.rb
@@ -54,6 +54,7 @@ control "aws_cloud_resources" do
     it { should allow_in(port: '22', ipv4_range: allow_ip_subnets) }
     it { should allow_out(port: '53', ipv4_range: '10.0.1.251/32') }
     it { should allow_out(port: '53', ipv4_range: '10.0.1.253/32') }
+    it { should allow_out(port: '8080', ipv4_range: '10.0.1.87/32') }
   end
 
   describe aws_security_group(group_name: 'prometheus_to_ec2') do


### PR DESCRIPTION
# Why I am making this change

We want to scrape the Verify policy app which will be implemented with application level metrics.

# What approach I took

Proof of concept so we have gone for the basic solution which is
to use a regex for `policy` on the instance name and hardcode
the port that we know the app is exposed on. This solution is likely
not scalable but we can deal with that later.

Note, I haven't been able to run the infra tests myself as there is currently a bug with two people running the tests at the same which I believe @DavidJeche will be looking at. I believe they would pass though 🤞 