### PR TITLE
Remove filtering of the ip

### DIFF
--- a/terraform/modules/enclave/prometheus/prometheus.conf.tpl
+++ b/terraform/modules/enclave/prometheus/prometheus.conf.tpl
@@ -9,9 +9,6 @@ scrape_configs:
       profile: "${ec2_instance_profile}"
       port: 9100
     relabel_configs:
-    - source_labels: [__meta_ec2_private_ip]
-      regex: '10\.[0-1]\.[1-3]\..*'
-      action: keep
     - source_labels: [__meta_ec2_tag_Name]
       regex: '.*\.secops\..*'
       action: drop


### PR DESCRIPTION
The relabel_config was used to remove app network ip addresses by
explicitly keeping non app network private_ips.

In the end this was not required, we have opted to scrape over both the
app network and the mgmt network.

It was thought that service discovery listed all interfaces of an
instance, because some instances have more then one interface then we
would need to pick one, also the instance where attached to two
different networks. For consistency we where going to use the mgmt
network everywhere so we need a way to remove the app network
interfaces.

It transpires that service discovery only lists one interface per
instance and we need to use the app network for scraping targets with
two interfaces so the default behaviour is desired.