### PR TITLE
Remove DataGovUk_NoInstancesForSomeTime alert

### DIFF
--- a/terraform/projects/app-ecs-services/config/alerts/data-gov-uk.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/data-gov-uk.yml
@@ -1,14 +1,6 @@
 groups:
 - name: DataGovUk
   rules:
-  - alert: DataGovUk_NoInstancesForSomeTime
-    expr: count(sum(cpu{job="metric-exporter"}) without (cell_id)) by (app) == 0
-    for: 30m
-    labels:
-        product: "data-gov-uk"
-    annotations:
-        summary: "App {{ $labels.app }} has no instances"
-        description: "Application {{ $labels.app }} has had no instances for half an hour."
   - alert: DataGovUk_HighCpuUsage
     expr: avg(cpu{job="metric-exporter"}) by (app) >= 80
     for: 5m


### PR DESCRIPTION
We think it's impossible to trigger, so we should remove it from this list so people don't think we're covered by it when really we're not. We can bring it back once we've found a better solution.

[Trello Card](https://trello.com/c/SmReDbrc/619-remove-modify-dgu-instance-count-alert-that-we-believe-is-not-possible-to-be-triggered)