### PR TITLE
Add Sidekiq metrics for DGU

### DIFF
--- a/terraform/projects/app-ecs-services/config/alerts/data-gov-uk.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/data-gov-uk.yml
@@ -34,3 +34,12 @@ groups:
         summary: "Index size of Elasticsearch for {{ $labels.job }} has decreased significantly"
         description: "The index size of Elasticsearch for {{ $labels.job }} has decreased by more than 300 documents in the last 30 minutes"
         runbook: https://docs.publishing.service.gov.uk/manual/data-gov-uk-troubleshooting.html#different-number-of-datasets-in-ckan-to-find
+  - alert: DataGovUk_HighSidekiqEnqueuedJobs
+    expr: sidekiq_enqueued_jobs{org="gds-data-discovery",job="publish-data-production-queue-monitor"} > 800
+    for: 5m
+    labels:
+        product: "data-gov-uk"
+    annotations:
+        summary: "Sidekiq's enqueued jobs do not seem to be clearing for Publish Data on production"
+        description: "Sidekiq has had more than 800 enqueued jobs for Publish Data on production for at least 5 minutes"
+        runbook: https://docs.publishing.service.gov.uk/manual/data-gov-uk-monitoring.html#sidekiq-publish

--- a/terraform/projects/app-ecs-services/config/alerts/data-gov-uk.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/data-gov-uk.yml
@@ -8,7 +8,7 @@ groups:
         product: "data-gov-uk"
     annotations:
         summary: "App {{ $labels.app }} has high CPU usage"
-        description: "Application {{ $labels.app }} has been using over 80% CPU (averaged over all instances) for 5 minutes or more."
+        description: "Application {{ $labels.app }} has been using over 80% CPU (averaged over all instances) for 5 minutes or more"
   - alert: DataGovUk_HighDiskUsage
     expr: max(disk_utilization{job="metric-exporter"}) by (app) >= 80
     labels:


### PR DESCRIPTION
# Why I am making this change

We would like to know when the Sidekiq queues are above a threshold for more than 5 minutes.

# What approach I took

I copied and pasted from a previous alert and changed the values.
Used the [Prometheus Dashboard](https://prom-2.monitoring.gds-reliability.engineering/graph?g0.range_input=1h&g0.expr=sidekiq_enqueued_jobs%20&g0.tab=1) to generate the PromQL.

The numbers are complete guesses at the moment and I expect to have to adjust them.

Looking at Grafana for the Sidekiq queues, it looks like we get spikes up to about 1.3K. They clear down within 5 minutes. I've chosen 800 since it is around 60% of the spike.

<img width="1282" alt="screen shot 2018-09-19 at 12 07 58" src="https://user-images.githubusercontent.com/647311/45750167-04229100-bc06-11e8-87fa-b71ca3504180.png">
