### PR TITLE
Allow Prometheus to be accessed via Verify jumpbox

### DIFF
--- a/terraform/modules/enclave/network/main.tf
+++ b/terraform/modules/enclave/network/main.tf
@@ -78,10 +78,10 @@ resource "aws_security_group_rule" "allow_access_to_egress_proxies" {
   from_port = 8080
   to_port   = 8080
 
-  # Hardcoding these IPs is technical debt: they are IPs associated with
-  # egress-proxy.service.dmz, which is an ELB on a dynamic IP range.
-  # we should find a better way to do this
-  cidr_blocks = ["10.0.1.151/32", "10.0.1.142/32"]
+  # egress-proxy.service.dmz is an ELB with a dynamic IP range.
+  # We therefore need to allow the security group to reach the whole subnet.
+  # There may be a better way to do this.
+  cidr_blocks = ["10.0.1.0/24"]
 
   security_group_id = "${aws_security_group.prometheus_instance.id}"
 }
@@ -124,6 +124,17 @@ resource "aws_security_group_rule" "node_exporter" {
     "10.0.0.0/22",
     "10.1.0.0/22",
   ]
+
+  security_group_id = "${aws_security_group.prometheus_instance.id}"
+}
+
+resource "aws_security_group_rule" "allow_web_interface" {
+  type      = "ingress"
+  protocol  = "tcp"
+  from_port = 9090
+  to_port   = 9090
+
+  cidr_blocks = ["${var.cidr_access_web_interface}"]
 
   security_group_id = "${aws_security_group.prometheus_instance.id}"
 }

--- a/terraform/modules/enclave/network/variables.tf
+++ b/terraform/modules/enclave/network/variables.tf
@@ -24,6 +24,10 @@ variable "vpc_peers" {
   default = {}
 }
 
+variable cidr_access_web_interface {
+  default = ["10.1.1.249/32"]
+}
+
 variable "cidr_admin_whitelist" {
   description = "CIDR ranges permitted to communicate with administrative endpoints"
   type        = "list"

--- a/terraform/modules/enclave/prometheus/output.tf
+++ b/terraform/modules/enclave/prometheus/output.tf
@@ -6,6 +6,10 @@ output "public_ip_address" {
   value = "${aws_instance.prometheus.*.public_ip}"
 }
 
+output "private_ip_address" {
+  value = "${aws_instance.prometheus.*.private_ip}"
+}
+
 output "prometheus_instance_id" {
   value = "${aws_instance.prometheus.*.id}"
 }

--- a/terraform/modules/enclave/verify-dns/main.tf
+++ b/terraform/modules/enclave/verify-dns/main.tf
@@ -1,0 +1,14 @@
+data "aws_route53_zone" "private_hosted_zone" {
+  name   = "${var.hosted_zone_name}"
+  vpc_id = "${var.target_vpc}"
+}
+
+resource "aws_route53_record" "prometheus" {
+  count = "{var.prometheus_private_ip_count}"
+
+  zone_id = "${data.aws_route53_zone.private_hosted_zone.zone_id}"
+  name    = "${var.hostname_prefix}-${count.index + 1}.${data.aws_route53_zone.private_hosted_zone.name}"
+  type    = "A"
+  ttl     = "300"
+  records = ["${element(var.prometheus_private_ips, count.index)}"]
+}

--- a/terraform/modules/enclave/verify-dns/variables.tf
+++ b/terraform/modules/enclave/verify-dns/variables.tf
@@ -1,0 +1,22 @@
+variable "hosted_zone_name" {
+  description = "The name of the hosted zone the records will be added to"
+}
+
+variable "target_vpc" {
+  description = "The VPC which contains the hosted zone which will be updated"
+}
+
+variable "prometheus_private_ip_count" {
+  description = "Terrafrom cannot calculate the count of private ips when starting from nothing"
+  default     = "2"
+}
+
+variable "prometheus_private_ips" {
+  description = "The list of instance ips which will have records created for them"
+  type        = "list"
+}
+
+variable "hostname_prefix" {
+  description = "The prefix of the hostname added to the record i.e. {hostname_prefix}-1.internal"
+  default     = "prometheus"
+}

--- a/terraform/projects/enclave/verify-perf-a/prometheus/main.tf
+++ b/terraform/projects/enclave/verify-perf-a/prometheus/main.tf
@@ -60,6 +60,14 @@ module "verify-config" {
   prometheus_config_bucket  = "${local.config_bucket}"
 }
 
+module "private_dns" {
+  source = "../../../../modules/enclave/verify-dns"
+
+  prometheus_private_ips = "${module.prometheus.private_ip_address}"
+  hosted_zone_name       = "service.dmz"
+  target_vpc             = "vpc-0067a6d5138a90c5e"
+}
+
 output "public_ips" {
   value = "${module.prometheus.public_ip_address}"
 }


### PR DESCRIPTION
# Why I am making this change

Verify use an nginx reverse proxy to expose their tools, graphite,
sensu etc. They have asked us to expose prometheus in the same way.

# What approach I took

The jump box must be able to reach the prometheus instances, we have
created an `allow_web_interface` ingress rule to allow this.

Verify need to know the ip address of the Prometheus instances to be
able to direct traffic to them. Prometheus IP addresses are not hard
coded and can change when instances are rebuilt. We therefore cannot
hard code the IP address in the verify config.
Instead we need to use DNS, verify have a private hosted zone which
we can use to add the addresses of the promethues instances. This code
is encapsulated as a module to enable us to only included it in the
verify project.