### PR TITLE
Add existing PaaS targets to EC2 prometheus

### DIFF
--- a/terraform/modules/enclave/paas-config/main.tf
+++ b/terraform/modules/enclave/paas-config/main.tf
@@ -3,6 +3,7 @@ data "template_file" "prometheus_config_template" {
 
   vars {
     prometheus_dns_names = "${var.prometheus_dns_names}"
+    environment          = "${var.environment}"
   }
 }
 

--- a/terraform/modules/enclave/paas-config/prometheus.conf.tpl
+++ b/terraform/modules/enclave/paas-config/prometheus.conf.tpl
@@ -5,3 +5,9 @@ scrape_configs:
   - job_name: prometheus
     static_configs:
       - targets: ["${prometheus_dns_names}"]
+  - job_name: paas-targets
+    scheme: http
+    proxy_url: 'http://paas-proxy.${environment}.monitoring.private:8080'
+    file_sd_configs:
+      - files: ['/etc/prometheus/targets/*.json']
+        refresh_interval: 30s

--- a/terraform/modules/enclave/paas-config/variables.tf
+++ b/terraform/modules/enclave/paas-config/variables.tf
@@ -1,2 +1,3 @@
 variable "prometheus_dns_names" {}
 variable "prometheus_config_bucket" {}
+variable "environment" {}

--- a/terraform/modules/enclave/prometheus/cloud.conf
+++ b/terraform/modules/enclave/prometheus/cloud.conf
@@ -18,16 +18,15 @@ write_files:
     path: /etc/cron.d/config_pull
     permissions: 0755
     content: |
-        */2 * * * * root aws s3 sync s3://${config_bucket}/prometheus/ /etc/prometheus/ --region=${region}
+        * * * * * root aws s3 sync s3://${config_bucket}/prometheus/ /etc/prometheus/ --region=${region}
         @reboot root mount /dev/xvdh /mnt
         @reboot root /root/watch_prometheus_dir
   - owner: root:root
     path: /etc/cron.d/targets_pull
     permissions: 0755
     content: |
-        */2 * * * * root aws s3 sync s3://${targets_bucket}/active/ /etc/prometheus/targets --region=${region}
-        @reboot root mount /dev/xvdh /mnt
-        @reboot root /root/watch_prometheus_dir
+        # if targets bucket exists then sync it, otherwise this cron runs but has no effect
+        * * * * * root [ "${targets_bucket}" != "" ] && aws s3 sync s3://${targets_bucket}/active/ /etc/prometheus/targets --region=${region}
   - content: |
        #!/bin/bash
        if file -s /dev/xvdh | grep -q "/dev/xvdh: data"; then
@@ -54,7 +53,7 @@ bootcmd:
 
 runcmd:
   - "if [ '${aws_ec2_ip}' ]; then echo '${aws_ec2_ip} ec2.eu-west-2.amazonaws.com' >> /etc/hosts; fi"
-  - [ bash, -c, "/root/format_disk.sh"]
-  - [ bash, -c, "mount /dev/xvdh /mnt"]
+  - [bash, -c, "/root/format_disk.sh"]
+  - [bash, -c, "mount /dev/xvdh /mnt"]
   - [bash, -c, "chown -R prometheus /mnt/"]
   - [reboot]

--- a/terraform/modules/enclave/prometheus/cloud.conf
+++ b/terraform/modules/enclave/prometheus/cloud.conf
@@ -21,6 +21,13 @@ write_files:
         */2 * * * * root aws s3 sync s3://${config_bucket}/prometheus/ /etc/prometheus/ --region=${region}
         @reboot root mount /dev/xvdh /mnt
         @reboot root /root/watch_prometheus_dir
+  - owner: root:root
+    path: /etc/cron.d/targets_pull
+    permissions: 0755
+    content: |
+        */2 * * * * root aws s3 sync s3://${targets_bucket}/active/ /etc/prometheus/targets --region=${region}
+        @reboot root mount /dev/xvdh /mnt
+        @reboot root /root/watch_prometheus_dir
   - content: |
        #!/bin/bash
        if file -s /dev/xvdh | grep -q "/dev/xvdh: data"; then

--- a/terraform/modules/enclave/prometheus/iam.tf
+++ b/terraform/modules/enclave/prometheus/iam.tf
@@ -51,6 +51,8 @@ data "aws_iam_policy_document" "instance_role_policy" {
     resources = [
       "arn:aws:s3:::${aws_s3_bucket.prometheus_config.id}/*",
       "arn:aws:s3:::${aws_s3_bucket.prometheus_config.id}",
+      "arn:aws:s3:::${var.targets_bucket}/*",
+      "arn:aws:s3:::${var.targets_bucket}",
     ]
   }
 }

--- a/terraform/modules/enclave/prometheus/iam.tf
+++ b/terraform/modules/enclave/prometheus/iam.tf
@@ -1,3 +1,15 @@
+locals {
+  s3_bucket_resources = [
+    "arn:aws:s3:::${aws_s3_bucket.prometheus_config.id}/*",
+    "arn:aws:s3:::${aws_s3_bucket.prometheus_config.id}",
+    "arn:aws:s3:::${var.targets_bucket}/*",
+    "arn:aws:s3:::${var.targets_bucket}",
+  ]
+
+  aws_iam_instance_role_policy_resources = "${slice(local.s3_bucket_resources, 0, 
+    length(var.targets_bucket) > 0 ? length(local.s3_bucket_resources) : 2 )}"
+}
+
 #Prepare to attach role to instance
 resource "aws_iam_instance_profile" "prometheus_instance_profile" {
   name = "prometheus_${var.environment}_config_reader_profile"
@@ -48,12 +60,7 @@ data "aws_iam_policy_document" "instance_role_policy" {
       "s3:ListBucket",
     ]
 
-    resources = [
-      "arn:aws:s3:::${aws_s3_bucket.prometheus_config.id}/*",
-      "arn:aws:s3:::${aws_s3_bucket.prometheus_config.id}",
-      "arn:aws:s3:::${var.targets_bucket}/*",
-      "arn:aws:s3:::${var.targets_bucket}",
-    ]
+    resources = ["${local.aws_iam_instance_role_policy_resources}"]
   }
 }
 

--- a/terraform/modules/enclave/prometheus/main.tf
+++ b/terraform/modules/enclave/prometheus/main.tf
@@ -61,10 +61,11 @@ data "template_file" "user_data_script" {
   template = "${file("${path.module}/cloud.conf")}"
 
   vars {
-    config_bucket = "${aws_s3_bucket.prometheus_config.id}"
-    egress_proxy  = "${var.egress_proxy}"
-    aws_ec2_ip    = "${var.ec2_endpoint_ips[0]}"
-    region        = "${var.region}"
+    config_bucket  = "${aws_s3_bucket.prometheus_config.id}"
+    egress_proxy   = "${var.egress_proxy}"
+    aws_ec2_ip     = "${var.ec2_endpoint_ips[0]}"
+    region         = "${var.region}"
+    targets_bucket = "${var.targets_bucket}"
   }
 }
 

--- a/terraform/modules/enclave/prometheus/output.tf
+++ b/terraform/modules/enclave/prometheus/output.tf
@@ -25,3 +25,7 @@ output "s3_config_bucket" {
 output "ec2_instance_profile_name" {
   value = "${aws_iam_instance_profile.prometheus_instance_profile.name}"
 }
+
+output "ec2_instance_prometheus_sg" {
+  value = "${aws_security_group.allow_prometheus.id}"
+}

--- a/terraform/modules/enclave/prometheus/test/integration/prometheus/controls/aws_cloud_resources.rb
+++ b/terraform/modules/enclave/prometheus/test/integration/prometheus/controls/aws_cloud_resources.rb
@@ -11,6 +11,7 @@ allow_ip_subnets = [
     "213.86.153.237/32",
     "85.133.67.244/32",
 ]
+policy_struct = aws_iam_policy('prometheus_instance_profile_test').policy
 
 
 control "aws_cloud_resources" do
@@ -35,6 +36,12 @@ control "aws_cloud_resources" do
     it { should have_statement(Action: ['s3:Get*','s3:ListBucket'], Effect: 'Allow', Sid: 's3Bucket') }
     it { should have_statement(Action: 'ec2:Describe*', Effect: 'Allow', Resource: '*', Sid: 'ec2Policy') }
     its('statement_count') { should cmp 2 }
+  end
+
+  describe aws_iam_policy('prometheus_instance_profile resources count') do
+    subject { policy_struct['Statement'][1]['Resource'].length }
+    # expect 2 resource counts for verify perf a stack
+    it { should == 2 }
   end
 
   describe aws_s3_bucket_object(bucket_name: s3_bucket_id, key: 'prometheus/prometheus.yml') do

--- a/terraform/modules/enclave/prometheus/test/integration/prometheus/controls/operating_system.rb
+++ b/terraform/modules/enclave/prometheus/test/integration/prometheus/controls/operating_system.rb
@@ -56,6 +56,9 @@ control "operating_system" do
   describe file('/etc/apt/apt.conf.d/05proxy') do
     its('content') { should eq nil}
   end
+
+  # do not expect the paas targets directory to exist for verify perf a stack
+  describe directory('/etc/prometheus/targets') do
+    it { should_not exist }
+  end
 end
-
-

--- a/terraform/modules/enclave/prometheus/variables.tf
+++ b/terraform/modules/enclave/prometheus/variables.tf
@@ -68,3 +68,7 @@ variable "allowed_cidrs" {
 }
 
 variable "config_bucket" {}
+
+variable "targets_bucket" {
+  default = ""
+}

--- a/terraform/projects/enclave/paas-production/prometheus/main.tf
+++ b/terraform/projects/enclave/paas-production/prometheus/main.tf
@@ -50,9 +50,10 @@ module "prometheus" {
   target_vpc = "vpc-0cdd9631927b526ce"
   enable_ssh = true
 
-  product       = "${local.product}"
-  environment   = "${local.environment}"
-  config_bucket = "${local.config_bucket}"
+  product        = "${local.product}"
+  environment    = "${local.environment}"
+  config_bucket  = "${local.config_bucket}"
+  targets_bucket = "gds-prometheus-targets"
 
   subnet_ids          = "${data.terraform_remote_state.network.public_subnets}"
   availability_zones  = "${data.terraform_remote_state.network.subnets_by_az}"
@@ -63,6 +64,7 @@ module "prometheus" {
 module "paas-config" {
   source = "../../../../modules/enclave/paas-config"
 
+  environment              = "${local.environment}"
   prometheus_dns_names     = "${join("\",\"", formatlist("%s:9090", module.prometheus.prometheus_private_dns))}"
   prometheus_config_bucket = "${local.config_bucket}"
 }
@@ -73,4 +75,8 @@ output "public_ips" {
 
 output "public_dns" {
   value = "[\n    ${join("\n    ", formatlist("%s:9090", module.prometheus.prometheus_public_dns))}\n]"
+}
+
+output "ec2_instance_prometheus_sg" {
+  value = "${module.prometheus.ec2_instance_prometheus_sg}"
 }

--- a/terraform/projects/enclave/paas-staging/prometheus/main.tf
+++ b/terraform/projects/enclave/paas-staging/prometheus/main.tf
@@ -50,9 +50,10 @@ module "prometheus" {
   target_vpc = "vpc-0bbf4123f5b385806"
   enable_ssh = true
 
-  product       = "${local.product}"
-  environment   = "${local.environment}"
-  config_bucket = "${local.config_bucket}"
+  product        = "${local.product}"
+  environment    = "${local.environment}"
+  config_bucket  = "${local.config_bucket}"
+  targets_bucket = "gds-prometheus-targets-staging"
 
   subnet_ids          = "${data.terraform_remote_state.network.public_subnets}"
   availability_zones  = "${data.terraform_remote_state.network.subnets_by_az}"
@@ -63,6 +64,7 @@ module "prometheus" {
 module "paas-config" {
   source = "../../../../modules/enclave/paas-config"
 
+  environment              = "${local.environment}"
   prometheus_dns_names     = "${join("\",\"", formatlist("%s:9090", module.prometheus.prometheus_private_dns))}"
   prometheus_config_bucket = "${local.config_bucket}"
 }
@@ -73,4 +75,8 @@ output "public_ips" {
 
 output "public_dns" {
   value = "[\n    ${join("\n    ", formatlist("%s:9090", module.prometheus.prometheus_public_dns))}\n]"
+}
+
+output "ec2_instance_prometheus_sg" {
+  value = "${module.prometheus.ec2_instance_prometheus_sg}"
 }

--- a/terraform/projects/infra-security-groups/main.tf
+++ b/terraform/projects/infra-security-groups/main.tf
@@ -41,6 +41,8 @@ locals {
     Terraform = "true"
     Project   = "infra-security-groups"
   }
+
+  enclave_paas_prometheus_remote_state_bucket_name = "govukobserve-tfstate-prom-enclave-paas-${var.stack_name}"
 }
 
 # Resources
@@ -69,6 +71,16 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "infra-networking.tfstate"
+    region = "${var.aws_region}"
+  }
+}
+
+data "terraform_remote_state" "enclave-paas-prometheus" {
+  backend = "s3"
+
+  config {
+    bucket = "${local.enclave_paas_prometheus_remote_state_bucket_name}"
+    key    = "prometheus.tfstate"
     region = "${var.aws_region}"
   }
 }
@@ -146,6 +158,15 @@ resource "aws_security_group_rule" "allow_prometheus_access_paas_proxy" {
   protocol                 = "tcp"
   security_group_id        = "${aws_security_group.alertmanager_external_sg.id}"
   source_security_group_id = "${aws_security_group.monitoring_internal_sg.id}"
+}
+
+resource "aws_security_group_rule" "allow_ec2_prometheus_access_paas_proxy" {
+  type                     = "ingress"
+  to_port                  = 8080
+  from_port                = 8080
+  protocol                 = "tcp"
+  security_group_id        = "${aws_security_group.alertmanager_external_sg.id}"
+  source_security_group_id = "${data.terraform_remote_state.enclave-paas-prometheus.ec2_instance_prometheus_sg}"
 }
 
 resource "aws_security_group_rule" "alertmanager_external_sg_egress_any_any" {


### PR DESCRIPTION
# Why I am making this change

To enable the EC2 prometheus staging and production stacks to scrape PaaS targets using the existing PaaS targets in the ECS stack.

# What approach I took

In order to scrape the PaaS targets a cronjob was introduced to the `cloud.conf` file which scrapes the PaaS targets every minute. The existing ECS PaaS-Proxy was reused to get access to the metrics endpoints of the PaaS apps by adding a security group rule to `infra-security-groups`, so this means that in order for the PaaS targets to be scrape-able, the `infra-security-groups` project needs to be applied after the EC2 prometheus stack has been deployed.

There should be no impact on the verify perf a stack, Kitchen tests have been updated to ensure this by checking the number of IAM policy document resources is 2 and that the targets directory is not created on the Verify perf a prometheus instance.

As there is an existing [PR](https://github.com/alphagov/prometheus-aws-configuration-beta/pull/124]) which refactors the tests to run on both EC2 prometheus stack and Verify Perf stack it was decided not to create tests for the EC2 prometheus stack yet but just prove that the Verify Perf stack is not impacted by the code changes.