### PR TITLE
Increase thresholds for DGU Elasticsearch Alerts

### DIFF
--- a/terraform/projects/app-ecs-services/config/alerts/data-gov-uk.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/data-gov-uk.yml
@@ -24,6 +24,7 @@ groups:
     annotations:
         summary: "Index size of Elasticsearch for {{ $labels.job }} has increased significantly"
         description: "The index size of Elasticsearch for {{ $labels.job }} has increased by more than 300 documents in the last 30 minutes"
+        runbook: https://docs.publishing.service.gov.uk/manual/data-gov-uk-troubleshooting.html#different-number-of-datasets-in-ckan-to-find
   - alert: DataGovUk_ElasticSearchIndexSizeDecrease
     expr: max by (job) (delta(elasticsearch_indices_docs{space="data-gov-uk"}[30m])) <= -300
     for: 1m
@@ -32,3 +33,4 @@ groups:
     annotations:
         summary: "Index size of Elasticsearch for {{ $labels.job }} has decreased significantly"
         description: "The index size of Elasticsearch for {{ $labels.job }} has decreased by more than 300 documents in the last 30 minutes"
+        runbook: https://docs.publishing.service.gov.uk/manual/data-gov-uk-troubleshooting.html#different-number-of-datasets-in-ckan-to-find

--- a/terraform/projects/app-ecs-services/config/alerts/data-gov-uk.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/data-gov-uk.yml
@@ -17,18 +17,18 @@ groups:
         summary: "App {{ $labels.app }} has high disk usage"
         description: "Application {{ $labels.app }} has an instance which is using over 80% disk."
   - alert: DataGovUk_ElasticSearchIndexSizeIncrease
-    expr: max by (job) (delta(elasticsearch_indices_docs{space="data-gov-uk"}[30m])) >= 100
+    expr: max by (job) (delta(elasticsearch_indices_docs{space="data-gov-uk"}[30m])) >= 300
     for: 1m
     labels:
         product: "data-gov-uk"
     annotations:
         summary: "Index size of Elasticsearch for {{ $labels.job }} has increased significantly"
-        description: "The index size of Elasticsearch for {{ $labels.job }} has increased by more than 100 documents in the last 30 minutes"
+        description: "The index size of Elasticsearch for {{ $labels.job }} has increased by more than 300 documents in the last 30 minutes"
   - alert: DataGovUk_ElasticSearchIndexSizeDecrease
-    expr: max by (job) (delta(elasticsearch_indices_docs{space="data-gov-uk"}[30m])) <= -100
+    expr: max by (job) (delta(elasticsearch_indices_docs{space="data-gov-uk"}[30m])) <= -300
     for: 1m
     labels:
         product: "data-gov-uk"
     annotations:
         summary: "Index size of Elasticsearch for {{ $labels.job }} has decreased significantly"
-        description: "The index size of Elasticsearch for {{ $labels.job }} has decreased by more than 100 documents in the last 30 minutes"
+        description: "The index size of Elasticsearch for {{ $labels.job }} has decreased by more than 300 documents in the last 30 minutes"


### PR DESCRIPTION
I've seen it increase/decrease by 100 within normal operation so we should increase the thresholds to make sure we only alert when we need to.

[Trello Card](https://trello.com/c/wbVUh0QM/444-switch-on-dgu-pagerduty-alerts)