### PR TITLE
Update alerts.yml to ignore RE_Observe_No_FileSd_Targets alerts on EC2 prom

### DIFF
--- a/terraform/projects/app-ecs-services/config/alerts/alerts.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/alerts.yml
@@ -28,10 +28,16 @@ groups:
     # zero using the `or count(up)*0` expression.
     # This idea taken from: https://www.robustperception.io/existential-issues-with-metrics/
     #
-    # Note also that this alert will only fire if there are *no* file_sd targets.
+    # Notes:
+    # - this alert will only fire if there are *no* file_sd targets.
     # This is useful if we only have one source of file_sd config, but might not be
     # if we have multiple ways of receiving file_sd configs and only one of them breaks.
-    expr: (count(prometheus_sd_file_mtime_seconds) or count(up)*0) < 1
+    # - a condition has been added to ensure that it does not trigger on prometheus build versions matching '2.1.0+ds'
+    # Reason for this is because that version does not have the metric 'prometheus_sd_file_mtime_seconds' available so will always trigger 
+    # and the package available for Ubunutu 18.04 Bionic Beaver machines on EC2 prometheus stacks is '2.1.0+ds'. 
+    # If this changes this alert will need to be updated to ensure that it doesn't fire unless it is supported in that version of prometheus.
+    # 
+    expr: (count(prometheus_sd_file_mtime_seconds) or count(up)*0) < 1 and count(prometheus_build_info{version="2.1.0+ds"}) == 0
     for: 10s
     labels:
         product: "prometheus"


### PR DESCRIPTION
# Why I am making this change

Currently the alert `RE_Observe_No_FileSd_Targets` will always trigger as the metric `prometheus_sd_file_mtime_seconds` is not available in the prometheus version `2.1.0+ds` package available for `Ubunutu 18.04 Bionic Beaver` machines. This will update that alert to ensure that it will be ignored for prometheis running `2.1.0+ds` as it doesn't support it.

# What approach I took

We decided to update the alert to ignore the version of prometheus used on the EC2 prometheus stack as a quick way to prevent the alert from being triggered, but this also means that the EC2 prometheus won't alert when there are no PaaS targets available.

This is just a short term fix as we will need to look at upgrading prometheus to a later version, or we will have to look at changing the PromQL to be backwards compatible so that we get alerts on EC2 prometheis for when PaaS targets are not available for scraping.