### PR TITLE
migrate to re-secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ go get github.com/camptocamp/terraform-provider-pass
 GOBIN=~/.terraform.d/plugins/darwin_amd64 go install github.com/camptocamp/terraform-provider-pass
 ```
 
+You will also need to clone the re-secrets repo into `~/.password-store/re-secrets`:
+
+    git clone git@github.com:alphagov/re-secrets.git ~/.password-store/re-secrets
 
 ### Developing with the `Makefile` or `setup.sh` shell script
 

--- a/terraform/projects/app-ecs-services/main.tf
+++ b/terraform/projects/app-ecs-services/main.tf
@@ -79,11 +79,7 @@ provider "template" {
 }
 
 provider "pass" {
-  store_dir = "~/.reng-pass"
-
-  # This pulls reng-pass from git to make sure we're using the most up to date credentials.
-  # If `reng-pass git pull` fails ten terraform will fail. Git fail for various
-  # reasons so if this becomes flakey we can set this to false and update reng-pass manually.
+  store_dir     = "~/.password-store/re-secrets/observe"
   refresh_store = true
 }
 


### PR DESCRIPTION
# Why I am making this change

We have moved our secrets from
alphagov/reliability-engineering-credentials to
alphagov/re-secrets (see alphagov/re-secrets#2).  We should now fetch
our secrets from the new repo rather than the old.

# What approach I took

I'd really like to have got rid of the `store_dir` line (and use the
default $PASSWORD_STORE_DIR value) but this only works if there is a
`~/.password-store/.gpg-id` file - and fails in a nonobvious way if
this file is not present.  So, at least for the moment, let's continue
to specify store_dir as a subdirectory of the whole.

