### PR TITLE
EC2 Prometheus to alert manager ECS

### DIFF
--- a/terraform/modules/enclave/paas-config/main.tf
+++ b/terraform/modules/enclave/paas-config/main.tf
@@ -2,8 +2,10 @@ data "template_file" "prometheus_config_template" {
   template = "${file("${path.module}/prometheus.conf.tpl")}"
 
   vars {
-    prometheus_dns_names = "${var.prometheus_dns_names}"
-    environment          = "${var.environment}"
+    prometheus_dns_names   = "${var.prometheus_dns_names}"
+    environment            = "${var.environment}"
+    alertmanager_dns_names = "${var.alertmanager_dns_names}"
+    prometheus_dns_nodes   = "${var.prometheus_dns_nodes}"
   }
 }
 
@@ -12,4 +14,25 @@ resource "aws_s3_bucket_object" "prometheus_config" {
   key     = "prometheus/prometheus.yml"
   content = "${data.template_file.prometheus_config_template.rendered}"
   etag    = "${md5(data.template_file.prometheus_config_template.rendered)}"
+}
+
+resource "aws_s3_bucket_object" "alerts-config" {
+  bucket = "${var.prometheus_config_bucket}"
+  key    = "prometheus/alerts/observe-alerts.yml"
+  source = "${var.alerts_path}observe-alerts.yml"
+  etag   = "${md5(file("${var.alerts_path}observe-alerts.yml"))}"
+}
+
+resource "aws_s3_bucket_object" "alerts-data-gov-uk-config" {
+  bucket = "${var.prometheus_config_bucket}"
+  key    = "prometheus/alerts/data-gov-uk-alerts.yml"
+  source = "${var.alerts_path}data-gov-uk-alerts.yml"
+  etag   = "${md5(file("${var.alerts_path}data-gov-uk-alerts.yml"))}"
+}
+
+resource "aws_s3_bucket_object" "alerts-registers-config" {
+  bucket = "${var.prometheus_config_bucket}"
+  key    = "prometheus/alerts/registers-alerts.yml"
+  source = "${var.alerts_path}registers-alerts.yml"
+  etag   = "${md5(file("${var.alerts_path}registers-alerts.yml"))}"
 }

--- a/terraform/modules/enclave/paas-config/prometheus.conf.tpl
+++ b/terraform/modules/enclave/paas-config/prometheus.conf.tpl
@@ -1,6 +1,13 @@
 global:
   scrape_interval: 30s
   evaluation_interval: 30s
+alerting:
+  alertmanagers:
+  - scheme: http
+    static_configs:
+      - targets: ["${alertmanager_dns_names}"]
+rule_files:
+  - "/etc/prometheus/alerts/*"
 scrape_configs:
   - job_name: prometheus
     static_configs:
@@ -11,3 +18,9 @@ scrape_configs:
     file_sd_configs:
       - files: ['/etc/prometheus/targets/*.json']
         refresh_interval: 30s
+  - job_name: alertmanagers
+    static_configs:
+      - targets: ["${alertmanager_dns_names}"]
+  - job_name: prometheus_node
+    static_configs:
+      - targets: ["${prometheus_dns_nodes}"]

--- a/terraform/modules/enclave/paas-config/prometheus.conf.tpl
+++ b/terraform/modules/enclave/paas-config/prometheus.conf.tpl
@@ -18,7 +18,7 @@ scrape_configs:
     file_sd_configs:
       - files: ['/etc/prometheus/targets/*.json']
         refresh_interval: 30s
-  - job_name: alertmanagers
+  - job_name: alertmanager
     static_configs:
       - targets: ["${alertmanager_dns_names}"]
   - job_name: prometheus_node

--- a/terraform/modules/enclave/paas-config/variables.tf
+++ b/terraform/modules/enclave/paas-config/variables.tf
@@ -1,3 +1,6 @@
 variable "prometheus_dns_names" {}
+variable "prometheus_dns_nodes" {}
+variable "alertmanager_dns_names" {}
 variable "prometheus_config_bucket" {}
 variable "environment" {}
+variable "alerts_path" {}

--- a/terraform/modules/enclave/prometheus/cloud.conf
+++ b/terraform/modules/enclave/prometheus/cloud.conf
@@ -27,6 +27,12 @@ write_files:
     content: |
         # if targets bucket exists then sync it, otherwise this cron runs but has no effect
         * * * * * root [ "${targets_bucket}" != "" ] && aws s3 sync s3://${targets_bucket}/active/ /etc/prometheus/targets --region=${region}
+  - owner: root:root
+    path: /etc/cron.d/alerts_pull
+    permissions: 0755
+    content: |
+        # if alerts bucket exists then sync it, otherwise this cron runs but has no effect
+        * * * * * root [ "${alerts_bucket}" != "" ] && aws s3 sync s3://${alerts_bucket}/prometheus/alerts/ /etc/prometheus/alerts --region=${region}
   - content: |
        #!/bin/bash
        if file -s /dev/xvdh | grep -q "/dev/xvdh: data"; then

--- a/terraform/modules/enclave/prometheus/main.tf
+++ b/terraform/modules/enclave/prometheus/main.tf
@@ -93,6 +93,15 @@ resource "aws_security_group_rule" "allow_prometheus_private" {
   security_group_id = "${aws_security_group.allow_prometheus.id}"
   type              = "ingress"
   from_port         = 9090
+  to_port           = 9090
+  protocol          = "tcp"
+  cidr_blocks       = ["10.0.0.0/16"]
+}
+
+resource "aws_security_group_rule" "allow_prometheus_node_exporter" {
+  security_group_id = "${aws_security_group.allow_prometheus.id}"
+  type              = "ingress"
+  from_port         = 9100
   to_port           = 9100
   protocol          = "tcp"
   cidr_blocks       = ["10.0.0.0/16"]

--- a/terraform/modules/enclave/prometheus/main.tf
+++ b/terraform/modules/enclave/prometheus/main.tf
@@ -66,6 +66,7 @@ data "template_file" "user_data_script" {
     aws_ec2_ip     = "${var.ec2_endpoint_ips[0]}"
     region         = "${var.region}"
     targets_bucket = "${var.targets_bucket}"
+    alerts_bucket  = "${aws_s3_bucket.prometheus_config.id}"
   }
 }
 
@@ -92,7 +93,7 @@ resource "aws_security_group_rule" "allow_prometheus_private" {
   security_group_id = "${aws_security_group.allow_prometheus.id}"
   type              = "ingress"
   from_port         = 9090
-  to_port           = 9090
+  to_port           = 9100
   protocol          = "tcp"
   cidr_blocks       = ["10.0.0.0/16"]
 }


### PR DESCRIPTION
# Why I am making this change

In this PR we aim to enable Prometheus to access ECS alert managers which means that it will be able to scrape ECS alert managers and also send alerts when triggered to it. This will allow us to run EC2 based Prometheus and have it integrate with ECS alert managers which will give us to have the ability to fire alerts based on the metrics collected by the EC2 prometheus.

# What approach I took

- We have had to add some outputs that we can use in order to target the ECS services. These were extracted using remote_state and the given as input into Prometheus. 
- Add a cronjob to the Prometheus cloud config to enable the ability to grab alerts from a remote bucket via the sync method. - Upload alerts in the ECS project to the remote bucket in the EC2 stack. 
- Use s3 bucket ID in order to reference bucket this reduces errors. 

Additionally, metrics from node_exporters are now being scraped.