### PR TITLE
Update EC2 prom cloud.conf to keep in sync with s3

### DIFF
--- a/terraform/modules/enclave/prometheus/cloud.conf
+++ b/terraform/modules/enclave/prometheus/cloud.conf
@@ -26,13 +26,13 @@ write_files:
     permissions: 0755
     content: |
         # if targets bucket exists then sync it, otherwise this cron runs but has no effect
-        * * * * * root [ "${targets_bucket}" != "" ] && aws s3 sync s3://${targets_bucket}/active/ /etc/prometheus/targets --region=${region}
+        * * * * * root [ "${targets_bucket}" != "" ] && aws s3 sync s3://${targets_bucket}/active/ /etc/prometheus/targets --region=${region} --delete
   - owner: root:root
     path: /etc/cron.d/alerts_pull
     permissions: 0755
     content: |
         # if alerts bucket exists then sync it, otherwise this cron runs but has no effect
-        * * * * * root [ "${alerts_bucket}" != "" ] && aws s3 sync s3://${alerts_bucket}/prometheus/alerts/ /etc/prometheus/alerts --region=${region}
+        * * * * * root [ "${alerts_bucket}" != "" ] && aws s3 sync s3://${alerts_bucket}/prometheus/alerts/ /etc/prometheus/alerts --region=${region} --delete
   - content: |
        #!/bin/bash
        if file -s /dev/xvdh | grep -q "/dev/xvdh: data"; then


### PR DESCRIPTION
# Why I am making this change

If we don't keep it in sync whenever there is a rename of an alerts file there will be duplicate alerts. Also if targets are removed from the targets bucket they will not be removed from the folder which means that the target will still be scraped by prometheus

# What approach I took

Update the aws s3 sync to delete files that don't exist on s3, so that the files on the EC2 instance should match s3