### PR TITLE
use --delete everywhere with aws s3 sync

### DIFF
--- a/terraform/projects/app-ecs-services/task-definitions/alertmanager-server.json
+++ b/terraform/projects/app-ecs-services/task-definitions/alertmanager-server.json
@@ -43,7 +43,7 @@
         "containerPath": "/configs"
       }
     ],
-    "command": ["s3", "sync", "s3://${config_bucket}/alertmanager", "/configs/alertmanager"],
+    "command": ["s3", "sync", "--delete", "s3://${config_bucket}/alertmanager", "/configs/alertmanager"],
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {

--- a/terraform/projects/app-ecs-services/task-definitions/config_updater.json
+++ b/terraform/projects/app-ecs-services/task-definitions/config_updater.json
@@ -35,7 +35,7 @@
         "containerPath": "/configs"
       }
     ],
-    "command": ["s3", "sync", "s3://${config_bucket}/prometheus", "/configs"],
+    "command": ["s3", "sync", "--delete", "s3://${config_bucket}/prometheus", "/configs"],
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {
@@ -57,7 +57,7 @@
         "containerPath": "/configs"
       }
     ],
-    "command": ["s3", "sync", "s3://${config_bucket}/alertmanager", "/configs/alertmanager"],
+    "command": ["s3", "sync", "--delete", "s3://${config_bucket}/alertmanager", "/configs/alertmanager"],
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {

--- a/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json
+++ b/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json
@@ -48,7 +48,7 @@
         "containerPath": "/configs"
       }
     ],
-    "command": ["s3", "sync", "s3://${config_bucket}/prometheus", "/configs"],
+    "command": ["s3", "sync", "--delete", "s3://${config_bucket}/prometheus", "/configs"],
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {


### PR DESCRIPTION
# Why I am making this change

There's a current problem with ECS prometheus having duplicated alerts.  The cause
is a bunch of stale config files left behind on the filesystem, after they've been removed
from the config bucket.  The fix is to add `--delete` to our `aws s3 sync` calls.

# What approach I took

We've previously dealt with this piecemeal in commits like ed50dc19.
This commit finds all remaining uses of `aws s3 sync` and adds
`--delete` to them.
