### PR TITLE
Revert "use --delete everywhere with aws s3 sync"

### DIFF
--- a/terraform/projects/app-ecs-services/task-definitions/alertmanager-server.json
+++ b/terraform/projects/app-ecs-services/task-definitions/alertmanager-server.json
@@ -43,7 +43,7 @@
         "containerPath": "/configs"
       }
     ],
-    "command": ["s3", "sync", "--delete", "s3://${config_bucket}/alertmanager", "/configs/alertmanager"],
+    "command": ["s3", "sync", "s3://${config_bucket}/alertmanager", "/configs/alertmanager"],
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {

--- a/terraform/projects/app-ecs-services/task-definitions/config_updater.json
+++ b/terraform/projects/app-ecs-services/task-definitions/config_updater.json
@@ -35,7 +35,7 @@
         "containerPath": "/configs"
       }
     ],
-    "command": ["s3", "sync", "--delete", "s3://${config_bucket}/prometheus", "/configs"],
+    "command": ["s3", "sync", "s3://${config_bucket}/prometheus", "/configs"],
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {
@@ -57,7 +57,7 @@
         "containerPath": "/configs"
       }
     ],
-    "command": ["s3", "sync", "--delete", "s3://${config_bucket}/alertmanager", "/configs/alertmanager"],
+    "command": ["s3", "sync", "s3://${config_bucket}/alertmanager", "/configs/alertmanager"],
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {

--- a/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json
+++ b/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json
@@ -48,7 +48,7 @@
         "containerPath": "/configs"
       }
     ],
-    "command": ["s3", "sync", "--delete", "s3://${config_bucket}/prometheus", "/configs"],
+    "command": ["s3", "sync", "s3://${config_bucket}/prometheus", "/configs"],
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {


### PR DESCRIPTION
Reverts alphagov/prometheus-aws-configuration-beta#138

We suspect this is causing issues with file service discovery in production.  Reverting to see if it fixes the problems.