### PR TITLE
change file_sd targets alert so that it actually works

### DIFF
--- a/terraform/projects/app-ecs-services/config/alerts/observe-alerts.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/observe-alerts.yml
@@ -37,7 +37,7 @@ groups:
     # and the package available for Ubunutu 18.04 Bionic Beaver machines on EC2 prometheus stacks is '2.1.0+ds'. 
     # If this changes this alert will need to be updated to ensure that it doesn't fire unless it is supported in that version of prometheus.
     # 
-    expr: (count(prometheus_sd_file_mtime_seconds) or count(up)*0) < 1 and count(prometheus_build_info{version="2.1.0+ds"}) == 0
+    expr: (count(prometheus_sd_file_mtime_seconds) or count(up)*0) < 1 and count(prometheus_build_info{version=~"2\\.4.*"})
     for: 10s
     labels:
         product: "prometheus"


### PR DESCRIPTION
The previous version of this alert failed because `count` never
returns 0 -- it returns no series at all.

I fixed this by changing the negative check (prometheus is not
2.1.0+ds) to a positive check (prometheus is 2.4.x)

