### PR TITLE
Direct traffic to EC2 prom-3

### DIFF
--- a/terraform/modules/enclave/paas-config/main.tf
+++ b/terraform/modules/enclave/paas-config/main.tf
@@ -1,3 +1,12 @@
+resource "aws_security_group_rule" "allow_ec2_prometheus_access_paas_proxy" {
+  type                     = "ingress"
+  to_port                  = 8080
+  from_port                = 8080
+  protocol                 = "tcp"
+  security_group_id        = "${var.paas_proxy_sg_id}"
+  source_security_group_id = "${var.prometheus_sg_id}"
+}
+
 data "template_file" "prometheus_config_template" {
   template = "${file("${path.module}/prometheus.conf.tpl")}"
 

--- a/terraform/modules/enclave/paas-config/variables.tf
+++ b/terraform/modules/enclave/paas-config/variables.tf
@@ -1,16 +1,17 @@
-variable "prometheus_dns_names" {
-  type = "list"
-}
-
 variable "prometheus_dns_nodes" {}
 variable "alertmanager_dns_names" {}
 variable "prometheus_config_bucket" {}
 variable "environment" {}
 variable "alerts_path" {}
 variable "private_zone_id" {}
+variable "private_subdomain" {}
+variable "paas_proxy_sg_id" {}
+variable "prometheus_sg_id" {}
 
 variable "prom_private_ips" {
   type = "list"
 }
 
-variable "private_subdomain" {}
+variable "prometheus_dns_names" {
+  type = "list"
+}

--- a/terraform/modules/enclave/paas-config/variables.tf
+++ b/terraform/modules/enclave/paas-config/variables.tf
@@ -1,6 +1,16 @@
-variable "prometheus_dns_names" {}
+variable "prometheus_dns_names" {
+  type = "list"
+}
+
 variable "prometheus_dns_nodes" {}
 variable "alertmanager_dns_names" {}
 variable "prometheus_config_bucket" {}
 variable "environment" {}
 variable "alerts_path" {}
+variable "private_zone_id" {}
+
+variable "prom_private_ips" {
+  type = "list"
+}
+
+variable "private_subdomain" {}

--- a/terraform/modules/enclave/prometheus/cloud.conf
+++ b/terraform/modules/enclave/prometheus/cloud.conf
@@ -13,7 +13,7 @@ write_files:
   - owner: root:root
     path: /etc/default/prometheus
     permissions: 0444
-    content: 'ARGS="--storage.tsdb.path=\"/mnt/\""'
+    content: 'ARGS="--storage.tsdb.path=\"/mnt/\" --web.external-url=${prom_external_url}"'
   - owner: root:root
     path: /etc/cron.d/config_pull
     permissions: 0755

--- a/terraform/modules/enclave/prometheus/output.tf
+++ b/terraform/modules/enclave/prometheus/output.tf
@@ -1,7 +1,3 @@
-output "cloudinit-script" {
-  value = "${data.template_file.user_data_script.rendered}"
-}
-
 output "public_ip_address" {
   value = "${aws_instance.prometheus.*.public_ip}"
 }

--- a/terraform/modules/enclave/prometheus/output.tf
+++ b/terraform/modules/enclave/prometheus/output.tf
@@ -6,7 +6,7 @@ output "public_ip_address" {
   value = "${aws_instance.prometheus.*.public_ip}"
 }
 
-output "private_ip_address" {
+output "private_ip_addresses" {
   value = "${aws_instance.prometheus.*.private_ip}"
 }
 

--- a/terraform/modules/enclave/prometheus/variables.tf
+++ b/terraform/modules/enclave/prometheus/variables.tf
@@ -72,3 +72,7 @@ variable "config_bucket" {}
 variable "targets_bucket" {
   default = ""
 }
+
+variable "prometheus_public_fqdns" {
+  type = "list"
+}

--- a/terraform/projects/app-ecs-services/nginx-auth-proxy.tf
+++ b/terraform/projects/app-ecs-services/nginx-auth-proxy.tf
@@ -49,7 +49,7 @@ data "template_file" "nginx-auth-proxy-config-file" {
     alertmanager_3_dns_name = "${data.terraform_remote_state.app_ecs_albs.alerts_private_record_fqdns.2}"
     prometheus_1_dns_name   = "${data.terraform_remote_state.app_ecs_albs.prom_private_record_fqdns.0}"
     prometheus_2_dns_name   = "${data.terraform_remote_state.app_ecs_albs.prom_private_record_fqdns.1}"
-    prometheus_3_dns_name   = "${data.terraform_remote_state.app_ecs_albs.prom_private_record_fqdns.2}"
+    prometheus_3_dns_name   = "prom-ec2-3.${data.terraform_remote_state.infra_networking.private_subdomain}:9090"
   }
 }
 

--- a/terraform/projects/app-ecs-services/prometheus-service.tf
+++ b/terraform/projects/app-ecs-services/prometheus-service.tf
@@ -106,7 +106,7 @@ data "template_file" "prometheus_config_file" {
 
   vars {
     alertmanager_dns_names = "${join("\",\"", local.active_alertmanager_private_fqdns)}"
-    prometheus_dns_names   = "${join("\",\"", local.active_prometheus_private_fqdns)}"
+    prometheus_dns_names   = "${join("\",\"", concat(slice(local.active_prometheus_private_fqdns, 0, 2), list("prom-ec2-3.${data.terraform_remote_state.infra_networking.private_subdomain}:9090")))}"
     paas_proxy_dns_name    = "${data.terraform_remote_state.app_ecs_albs.paas_proxy_private_record_fqdn}"
   }
 }

--- a/terraform/projects/enclave/dm-test-stack/prometheus/main.tf
+++ b/terraform/projects/enclave/dm-test-stack/prometheus/main.tf
@@ -1,0 +1,101 @@
+locals {
+  product                           = "paas"
+  environment                       = "dm-test-stack"
+  config_bucket                     = "gdsobserve-${local.product}-${local.environment}-config-store"
+  active_alertmanager_private_fqdns = "${slice(data.terraform_remote_state.app_ecs_albs.alerts_private_record_fqdns, 0,
+ 3)}"
+}
+
+terraform {
+  required_version = "= 0.11.7"
+
+  backend "s3" {
+    bucket  = "govukobserve-tfstate-prom-enclave-dm-test-stack"
+    key     = "prometheus.tfstate"
+    encrypt = true
+    region  = "eu-west-1"
+  }
+}
+
+provider "aws" {
+  region              = "eu-west-1"
+  allowed_account_ids = ["047969882937"]
+}
+
+data "terraform_remote_state" "network" {
+  backend = "s3"
+
+  config {
+    bucket = "${local.environment}"
+    key    = "infra-networking.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "sg" {
+  backend = "s3"
+
+  config {
+    bucket = "${local.environment}"
+    key    = "infra-security-groups.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "app_ecs_albs" {
+  backend = "s3"
+
+  config {
+    bucket = "${local.environment}"
+    key    = "app-ecs-albs.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+module "prometheus" {
+  source = "../../../../modules/enclave/prometheus"
+
+  # Canonicals Ubunutu 18.04 Bionic Beaver in eu-west-1
+  ami_id = "ami-0ee06eb8d6eebcde0"
+
+  target_vpc = "vpc-e3c39685"
+  enable_ssh = true
+
+  product        = "${local.product}"
+  environment    = "${local.environment}"
+  config_bucket  = "${local.config_bucket}"
+  targets_bucket = "gds-prometheus-targets-${local.environment}"
+
+  subnet_ids          = "${data.terraform_remote_state.network.public_subnets}"
+  availability_zones  = "${data.terraform_remote_state.network.subnets_by_az}"
+  vpc_security_groups = ["${data.terraform_remote_state.sg.monitoring_external_sg_id}"]
+  region              = "eu-west-1"
+}
+
+module "paas-config" {
+  source = "../../../../modules/enclave/paas-config"
+
+  environment              = "${local.environment}"
+  prometheus_dns_names     = "${join("\",\"", formatlist("%s:9090", module.prometheus.prometheus_private_dns))}"
+  prometheus_dns_nodes     = "${join("\",\"", formatlist("%s:9100", module.prometheus.prometheus_private_dns))}"
+  prometheus_config_bucket = "${module.prometheus.s3_config_bucket}"
+  alertmanager_dns_names   = "${join("\",\"", local.active_alertmanager_private_fqdns)}"
+  alerts_path              = "../../../../projects/app-ecs-services/config/alerts/"
+}
+
+resource "aws_security_group_rule" "allow_ec2_prometheus_access_paas_proxy" {
+  type                     = "ingress"
+  to_port                  = 8080
+  from_port                = 8080
+  protocol                 = "tcp"
+  security_group_id        = "${data.terraform_remote_state.sg.alertmanager_external_sg_id}"
+  source_security_group_id = "${module.prometheus.ec2_instance_prometheus_sg}"
+}
+
+output "public_ips" {
+  value = "${module.prometheus.public_ip_address}"
+}
+
+output "public_dns" {
+  value = "[\n    ${join("\n    ", formatlist("%s:9090", module.prometheus.prometheus_public_dns))}\n]"
+}

--- a/terraform/projects/enclave/dm-test-stack/prometheus/main.tf
+++ b/terraform/projects/enclave/dm-test-stack/prometheus/main.tf
@@ -85,15 +85,9 @@ module "paas-config" {
   private_subdomain        = "${data.terraform_remote_state.network.private_subdomain}"
   alertmanager_dns_names   = "${join("\",\"", local.active_alertmanager_private_fqdns)}"
   alerts_path              = "../../../../projects/app-ecs-services/config/alerts/"
-}
 
-resource "aws_security_group_rule" "allow_ec2_prometheus_access_paas_proxy" {
-  type                     = "ingress"
-  to_port                  = 8080
-  from_port                = 8080
-  protocol                 = "tcp"
-  security_group_id        = "${data.terraform_remote_state.sg.alertmanager_external_sg_id}"
-  source_security_group_id = "${module.prometheus.ec2_instance_prometheus_sg}"
+  paas_proxy_sg_id = "${data.terraform_remote_state.sg.alertmanager_external_sg_id}"
+  prometheus_sg_id = "${module.prometheus.ec2_instance_prometheus_sg}"
 }
 
 output "public_ips" {

--- a/terraform/projects/enclave/dm-test-stack/prometheus/main.tf
+++ b/terraform/projects/enclave/dm-test-stack/prometheus/main.tf
@@ -66,6 +66,8 @@ module "prometheus" {
   config_bucket  = "${local.config_bucket}"
   targets_bucket = "gds-prometheus-targets-${local.environment}"
 
+  prometheus_public_fqdns = "${data.terraform_remote_state.app_ecs_albs.prom_public_record_fqdns}"
+
   subnet_ids          = "${data.terraform_remote_state.network.public_subnets}"
   availability_zones  = "${data.terraform_remote_state.network.subnets_by_az}"
   vpc_security_groups = ["${data.terraform_remote_state.sg.monitoring_external_sg_id}"]

--- a/terraform/projects/enclave/paas-production/prometheus/main.tf
+++ b/terraform/projects/enclave/paas-production/prometheus/main.tf
@@ -67,6 +67,8 @@ module "prometheus" {
   config_bucket  = "${local.config_bucket}"
   targets_bucket = "gds-prometheus-targets"
 
+  prometheus_public_fqdns = "${data.terraform_remote_state.app_ecs_albs.prom_public_record_fqdns}"
+
   subnet_ids          = "${data.terraform_remote_state.network.public_subnets}"
   availability_zones  = "${data.terraform_remote_state.network.subnets_by_az}"
   vpc_security_groups = ["${data.terraform_remote_state.sg.monitoring_external_sg_id}"]

--- a/terraform/projects/enclave/paas-production/prometheus/main.tf
+++ b/terraform/projects/enclave/paas-production/prometheus/main.tf
@@ -84,14 +84,19 @@ module "paas-config" {
   alerts_path              = "../../../../projects/app-ecs-services/config/alerts/"
 }
 
+resource "aws_security_group_rule" "allow_ec2_prometheus_access_paas_proxy" {
+  type                     = "ingress"
+  to_port                  = 8080
+  from_port                = 8080
+  protocol                 = "tcp"
+  security_group_id        = "${data.terraform_remote_state.sg.alertmanager_external_sg_id}"
+  source_security_group_id = "${module.prometheus.ec2_instance_prometheus_sg}"
+}
+
 output "public_ips" {
   value = "${module.prometheus.public_ip_address}"
 }
 
 output "public_dns" {
   value = "[\n    ${join("\n    ", formatlist("%s:9090", module.prometheus.prometheus_public_dns))}\n]"
-}
-
-output "ec2_instance_prometheus_sg" {
-  value = "${module.prometheus.ec2_instance_prometheus_sg}"
 }

--- a/terraform/projects/enclave/paas-production/prometheus/main.tf
+++ b/terraform/projects/enclave/paas-production/prometheus/main.tf
@@ -79,7 +79,7 @@ module "paas-config" {
   environment              = "${local.environment}"
   prometheus_dns_names     = "${join("\",\"", formatlist("%s:9090", module.prometheus.prometheus_private_dns))}"
   prometheus_dns_nodes     = "${join("\",\"", formatlist("%s:9100", module.prometheus.prometheus_private_dns))}"
-  prometheus_config_bucket = "${local.config_bucket}"
+  prometheus_config_bucket = "${module.prometheus.s3_config_bucket}"
   alertmanager_dns_names   = "${join("\",\"", local.active_alertmanager_private_fqdns)}"
   alerts_path              = "../../../../projects/app-ecs-services/config/alerts/"
 }

--- a/terraform/projects/enclave/paas-staging/prometheus/main.tf
+++ b/terraform/projects/enclave/paas-staging/prometheus/main.tf
@@ -84,14 +84,19 @@ module "paas-config" {
   alerts_path              = "../../../../projects/app-ecs-services/config/alerts/"
 }
 
+resource "aws_security_group_rule" "allow_ec2_prometheus_access_paas_proxy" {
+  type                     = "ingress"
+  to_port                  = 8080
+  from_port                = 8080
+  protocol                 = "tcp"
+  security_group_id        = "${data.terraform_remote_state.sg.alertmanager_external_sg_id}"
+  source_security_group_id = "${module.prometheus.ec2_instance_prometheus_sg}"
+}
+
 output "public_ips" {
   value = "${module.prometheus.public_ip_address}"
 }
 
 output "public_dns" {
   value = "[\n    ${join("\n    ", formatlist("%s:9090", module.prometheus.prometheus_public_dns))}\n]"
-}
-
-output "ec2_instance_prometheus_sg" {
-  value = "${module.prometheus.ec2_instance_prometheus_sg}"
 }

--- a/terraform/projects/enclave/paas-staging/prometheus/main.tf
+++ b/terraform/projects/enclave/paas-staging/prometheus/main.tf
@@ -77,20 +77,18 @@ module "paas-config" {
   source = "../../../../modules/enclave/paas-config"
 
   environment              = "${local.environment}"
-  prometheus_dns_names     = "${join("\",\"", formatlist("%s:9090", module.prometheus.prometheus_private_dns))}"
+  prometheus_dns_names     = "${data.terraform_remote_state.app_ecs_albs.prom_private_record_fqdns}"
   prometheus_dns_nodes     = "${join("\",\"", formatlist("%s:9100", module.prometheus.prometheus_private_dns))}"
   prometheus_config_bucket = "${module.prometheus.s3_config_bucket}"
   alertmanager_dns_names   = "${join("\",\"", local.active_alertmanager_private_fqdns)}"
   alerts_path              = "../../../../projects/app-ecs-services/config/alerts/"
-}
 
-resource "aws_security_group_rule" "allow_ec2_prometheus_access_paas_proxy" {
-  type                     = "ingress"
-  to_port                  = 8080
-  from_port                = 8080
-  protocol                 = "tcp"
-  security_group_id        = "${data.terraform_remote_state.sg.alertmanager_external_sg_id}"
-  source_security_group_id = "${module.prometheus.ec2_instance_prometheus_sg}"
+  prom_private_ips  = "${module.prometheus.private_ip_addresses}"
+  private_zone_id   = "${data.terraform_remote_state.network.private_zone_id}"
+  private_subdomain = "${data.terraform_remote_state.network.private_subdomain}"
+
+  paas_proxy_sg_id = "${data.terraform_remote_state.sg.alertmanager_external_sg_id}"
+  prometheus_sg_id = "${module.prometheus.ec2_instance_prometheus_sg}"
 }
 
 output "public_ips" {

--- a/terraform/projects/enclave/paas-staging/prometheus/main.tf
+++ b/terraform/projects/enclave/paas-staging/prometheus/main.tf
@@ -67,6 +67,8 @@ module "prometheus" {
   config_bucket  = "${local.config_bucket}"
   targets_bucket = "gds-prometheus-targets-${local.environment}"
 
+  prometheus_public_fqdns = "${data.terraform_remote_state.app_ecs_albs.prom_public_record_fqdns}"
+
   subnet_ids          = "${data.terraform_remote_state.network.public_subnets}"
   availability_zones  = "${data.terraform_remote_state.network.subnets_by_az}"
   vpc_security_groups = ["${data.terraform_remote_state.sg.monitoring_external_sg_id}"]

--- a/terraform/projects/enclave/paas-staging/prometheus/main.tf
+++ b/terraform/projects/enclave/paas-staging/prometheus/main.tf
@@ -79,7 +79,7 @@ module "paas-config" {
   environment              = "${local.environment}"
   prometheus_dns_names     = "${join("\",\"", formatlist("%s:9090", module.prometheus.prometheus_private_dns))}"
   prometheus_dns_nodes     = "${join("\",\"", formatlist("%s:9100", module.prometheus.prometheus_private_dns))}"
-  prometheus_config_bucket = "${local.config_bucket}"
+  prometheus_config_bucket = "${module.prometheus.s3_config_bucket}"
   alertmanager_dns_names   = "${join("\",\"", local.active_alertmanager_private_fqdns)}"
   alerts_path              = "../../../../projects/app-ecs-services/config/alerts/"
 }

--- a/terraform/projects/enclave/verify-perf-a/prometheus/main.tf
+++ b/terraform/projects/enclave/verify-perf-a/prometheus/main.tf
@@ -63,7 +63,7 @@ module "verify-config" {
 module "private_dns" {
   source = "../../../../modules/enclave/verify-dns"
 
-  prometheus_private_ips = "${module.prometheus.private_ip_address}"
+  prometheus_private_ips = "${module.prometheus.private_ip_addresses}"
   hosted_zone_name       = "service.dmz"
   target_vpc             = "vpc-0067a6d5138a90c5e"
 }

--- a/terraform/projects/enclave/verify-perf-a/prometheus/main.tf
+++ b/terraform/projects/enclave/verify-perf-a/prometheus/main.tf
@@ -47,6 +47,8 @@ module "prometheus" {
   environment   = "${local.environment}"
   config_bucket = "${local.config_bucket}"
 
+  prometheus_public_fqdns = ["prometheus-hub-perf-a-dmz.ida.digital.cabinet-office.gov.uk", "prometheus-hub-perf-a-dmz.ida.digital.cabinet-office.gov.uk"]
+
   subnet_ids          = "${data.terraform_remote_state.network.subnet_ids}"
   availability_zones  = "${data.terraform_remote_state.network.availability_zones}"
   vpc_security_groups = ["${data.terraform_remote_state.network.security_groups}"]

--- a/terraform/projects/infra-networking/main.tf
+++ b/terraform/projects/infra-networking/main.tf
@@ -167,6 +167,11 @@ output "private_zone_id" {
   description = "Route 53 Zone ID for the internal zone"
 }
 
+output "private_zone_name" {
+  value       = "${aws_route53_zone.private.name}"
+  description = "Route 53 Zone name for the internal zone"
+}
+
 output "private_subnets_ips" {
   value       = "${module.vpc.private_subnets_cidr_blocks}"
   description = "List of private subnet IPs"

--- a/terraform/projects/infra-security-groups/main.tf
+++ b/terraform/projects/infra-security-groups/main.tf
@@ -41,8 +41,6 @@ locals {
     Terraform = "true"
     Project   = "infra-security-groups"
   }
-
-  enclave_paas_prometheus_remote_state_bucket_name = "govukobserve-tfstate-prom-enclave-paas-${var.stack_name}"
 }
 
 # Resources
@@ -71,16 +69,6 @@ data "terraform_remote_state" "infra_networking" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "infra-networking.tfstate"
-    region = "${var.aws_region}"
-  }
-}
-
-data "terraform_remote_state" "enclave-paas-prometheus" {
-  backend = "s3"
-
-  config {
-    bucket = "${local.enclave_paas_prometheus_remote_state_bucket_name}"
-    key    = "prometheus.tfstate"
     region = "${var.aws_region}"
   }
 }
@@ -158,15 +146,6 @@ resource "aws_security_group_rule" "allow_prometheus_access_paas_proxy" {
   protocol                 = "tcp"
   security_group_id        = "${aws_security_group.alertmanager_external_sg.id}"
   source_security_group_id = "${aws_security_group.monitoring_internal_sg.id}"
-}
-
-resource "aws_security_group_rule" "allow_ec2_prometheus_access_paas_proxy" {
-  type                     = "ingress"
-  to_port                  = 8080
-  from_port                = 8080
-  protocol                 = "tcp"
-  security_group_id        = "${aws_security_group.alertmanager_external_sg.id}"
-  source_security_group_id = "${data.terraform_remote_state.enclave-paas-prometheus.ec2_instance_prometheus_sg}"
 }
 
 resource "aws_security_group_rule" "alertmanager_external_sg_egress_any_any" {


### PR DESCRIPTION
# Why I am making this change
https://trello.com/c/d9Oq70D0/562-expose-an-instance-of-the-new-prometheus-on-prom-3

We want to swap traffic from our ECS prom-3 to our EC2 prom-3. 

We will swap traffic for the other two prometheis at a later point.

# What approach I took
We added our first dev enclave project. This was decided during a mob session as the future way forward (at least for the short term) to enable us to develop locally against our ECS stack otherwise we would need to point our enclave at staging and risk breaking things there.

We removed reference for resources from our enclave in the ECS modules but we instead can use ECS resources in our enclave projects. This will mean we have no circular dependancies across our code (which existed before). Also it means eventually code will transition out of the ECS modules into the enclave modules.

