### PR TITLE
Remove alerts with deprecated label

### DIFF
--- a/terraform/projects/app-ecs-services/config/alerts/registers-alerts.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/registers-alerts.yml
@@ -1,17 +1,6 @@
 groups:
 - name: Registers
   rules:
-  - alert: Registers_AppRequestsExcess5xx_old
-    expr: sum by(app) (rate(requests{org="openregister", exported_space="prod", status_range="5xx"}[5m])) / sum by(app) (rate(requests{org="openregister", exported_space="prod"}[5m])) >= 0.25
-    for: 120s
-    labels:
-        product: "registers"
-    annotations:
-        summary: "App {{ $labels.app }} has too many 5xx errors"
-        description: "App {{ $labels.app }} has 5xx errors in excess of 25% of total requests"
-        dashboard_orj: https://grafana-paas.cloudapps.digital/d/vkxcsHvmz/orj?refresh=1m&orgId=1
-        dashboard_registers: https://grafana-paas.cloudapps.digital/d/sljj3z6zk/registers?orgId=1
-
   - alert: Registers_AppRequestsExcess5xx
     expr: sum by(app) (rate(requests{org="openregister", space="prod", status_range="5xx"}[5m])) / sum by(app) (rate(requests{org="openregister", space="prod"}[5m])) >= 0.25
     for: 120s
@@ -23,16 +12,6 @@ groups:
         dashboard_orj: https://grafana-paas.cloudapps.digital/d/vkxcsHvmz/orj?refresh=1m&orgId=1
         dashboard_registers: https://grafana-paas.cloudapps.digital/d/sljj3z6zk/registers?orgId=1
 
-  - alert: Registers_InstanceDiskSpaceExceeded_old
-    expr: disk_utilization{org="openregister",exported_space="prod"} > 80
-    for: 300s
-    labels:
-        product: "registers"
-    annotations:
-        summary: "App {{ $labels.app }} has exceeded 80% disk space usage for 5 minutes"
-        description: "Not enough free disk space. This should not normally happen because PaaS apps should be stateless. If the usage is legitimate you can raise the disk quota."
-        cloud_foundry_docs: https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#disk-quota
-
   - alert: Registers_InstanceDiskSpaceExceeded
     expr: disk_utilization{org="openregister",space="prod"} > 80
     for: 300s
@@ -42,17 +21,6 @@ groups:
         summary: "App {{ $labels.app }} has exceeded 80% disk space usage for 5 minutes"
         description: "Not enough free disk space. This should not normally happen because PaaS apps should be stateless. If the usage is legitimate you can raise the disk quota."
         cloud_foundry_docs: https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#disk-quota
-
-  - alert: Registers_InstanceCPUExceeded_old
-    expr: avg_over_time(cpu{org="openregister",exported_space="prod"}[5m]) > 80
-    for: 300s
-    labels:
-        product: "registers"
-    annotations:
-        summary: "5 minute moving average of CPU for {{ $labels.app }} has exceeded 80% for 5 minutes"
-        description: "CPU is higher than normal. Check prometheus source graph to investigate any anomalies. If persistent, consider scaling up the app."
-        dashboard_orj: https://grafana-paas.cloudapps.digital/d/vkxcsHvmz/orj?refresh=1m&orgId=1
-        dashboard_registers: https://grafana-paas.cloudapps.digital/d/sljj3z6zk/registers?orgId=1
 
   - alert: Registers_InstanceCPUExceeded
     expr: avg_over_time(cpu{org="openregister",space="prod"}[5m]) > 80


### PR DESCRIPTION
We've deprecated the `exported_space` label