### PR TITLE
Fix broken enclave

### DIFF
--- a/terraform/modules/enclave/prometheus/output.tf
+++ b/terraform/modules/enclave/prometheus/output.tf
@@ -6,7 +6,7 @@ output "public_ip_address" {
   value = "${aws_instance.prometheus.*.public_ip}"
 }
 
-output "private_ip_address" {
+output "private_ip_addresses" {
   value = "${aws_instance.prometheus.*.private_ip}"
 }
 

--- a/terraform/modules/enclave/verify-dns/main.tf
+++ b/terraform/modules/enclave/verify-dns/main.tf
@@ -4,7 +4,7 @@ data "aws_route53_zone" "private_hosted_zone" {
 }
 
 resource "aws_route53_record" "prometheus" {
-  count = "{var.prometheus_private_ip_count}"
+  count = 2
 
   zone_id = "${data.aws_route53_zone.private_hosted_zone.zone_id}"
   name    = "${var.hostname_prefix}-${count.index + 1}.${data.aws_route53_zone.private_hosted_zone.name}"

--- a/terraform/modules/enclave/verify-dns/variables.tf
+++ b/terraform/modules/enclave/verify-dns/variables.tf
@@ -6,11 +6,6 @@ variable "target_vpc" {
   description = "The VPC which contains the hosted zone which will be updated"
 }
 
-variable "prometheus_private_ip_count" {
-  description = "Terrafrom cannot calculate the count of private ips when starting from nothing"
-  default     = "2"
-}
-
 variable "prometheus_private_ips" {
   description = "The list of instance ips which will have records created for them"
   type        = "list"

--- a/terraform/projects/enclave/verify-perf-a/prometheus/main.tf
+++ b/terraform/projects/enclave/verify-perf-a/prometheus/main.tf
@@ -63,7 +63,7 @@ module "verify-config" {
 module "private_dns" {
   source = "../../../../modules/enclave/verify-dns"
 
-  prometheus_private_ips = "${module.prometheus.private_ip_address}"
+  prometheus_private_ips = "${module.prometheus.private_ip_addresses}"
   hosted_zone_name       = "service.dmz"
   target_vpc             = "vpc-0067a6d5138a90c5e"
 }


### PR DESCRIPTION
# Why I am making this change

I was working with @ejrowley to deploy the changes introduced by #126 but there were some bugs -- particularly with the annoying terraform error "Error: aws_route53_record.prometheus: resource count must be an integer".

# What approach I took

Just hardcode the count for now.

(also, rename a variable to be clearer).