### PR TITLE
Tweak RE_Observe_Target_Down alert timing

### DIFF
--- a/terraform/projects/app-ecs-services/config/alerts/observe-alerts.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/observe-alerts.yml
@@ -72,11 +72,11 @@ groups:
 
   - alert: RE_Observe_Target_Down
     expr: up{} == 0
-    for: 20m
+    for: 24h
     labels:
         product: "prometheus"
         severity: "ticket"
     annotations:
         summary: "{{ $labels.job }} target is down"
-        description: "One of the {{ $labels.job }} targets has been down for 20 minutes"
+        description: "One of the {{ $labels.job }} targets has been down for 24 hours"
         runbook: "https://re-team-manual.cloudapps.digital/observe-support.html#re-observe-target-down"


### PR DESCRIPTION
This has fired twice today and wasn't actionable either time.

I think we can bump this time period to be quite high and still get
the same value out of it that we would have had.

