### PR TITLE
Increase enclave instance size from t2.medium to m4.large

### DIFF
--- a/terraform/projects/enclave/dm-test-stack/prometheus/main.tf
+++ b/terraform/projects/enclave/dm-test-stack/prometheus/main.tf
@@ -65,6 +65,7 @@ module "prometheus" {
   environment    = "${local.environment}"
   config_bucket  = "${local.config_bucket}"
   targets_bucket = "gds-prometheus-targets-${local.environment}"
+  instance_size  = "m4.large"
 
   prometheus_public_fqdns = "${data.terraform_remote_state.app_ecs_albs.prom_public_record_fqdns}"
 

--- a/terraform/projects/enclave/paas-production/prometheus/main.tf
+++ b/terraform/projects/enclave/paas-production/prometheus/main.tf
@@ -66,6 +66,7 @@ module "prometheus" {
   environment    = "${local.environment}"
   config_bucket  = "${local.config_bucket}"
   targets_bucket = "gds-prometheus-targets"
+  instance_size  = "m4.large"
 
   prometheus_public_fqdns = "${data.terraform_remote_state.app_ecs_albs.prom_public_record_fqdns}"
 

--- a/terraform/projects/enclave/paas-staging/prometheus/main.tf
+++ b/terraform/projects/enclave/paas-staging/prometheus/main.tf
@@ -66,6 +66,7 @@ module "prometheus" {
   environment    = "${local.environment}"
   config_bucket  = "${local.config_bucket}"
   targets_bucket = "gds-prometheus-targets-${local.environment}"
+  instance_size  = "m4.large"
 
   prometheus_public_fqdns = "${data.terraform_remote_state.app_ecs_albs.prom_public_record_fqdns}"
 


### PR DESCRIPTION
https://trello.com/c/8iVx15jf/630-bump-ec2-prom-instance-size-to-m4large

# Why I am making this change

We're standardising sizing of our prometheus across instances 

# What approach I took

We've only done this for our own Prom instances not the Verify environment for the time being

Paired with @matthewcullum-gds and @idavidmcdonald 
