### PR TITLE
Save money as we don't need m4.large for a dev stack

### DIFF
--- a/terraform/projects/enclave/dm-test-stack/prometheus/main.tf
+++ b/terraform/projects/enclave/dm-test-stack/prometheus/main.tf
@@ -65,7 +65,6 @@ module "prometheus" {
   environment    = "${local.environment}"
   config_bucket  = "${local.config_bucket}"
   targets_bucket = "gds-prometheus-targets-${local.environment}"
-  instance_size  = "m4.large"
 
   prometheus_public_fqdns = "${data.terraform_remote_state.app_ecs_albs.prom_public_record_fqdns}"
 


### PR DESCRIPTION
Will use the default t2.medium instead