### PR TITLE
Added new grafana down alert.

### DIFF
--- a/terraform/projects/app-ecs-services/config/alerts/observe-alerts.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/observe-alerts.yml
@@ -1,6 +1,16 @@
 groups:
 - name: RE_Observe
   rules:
+  - alert: RE_Observe_Grafana_Down
+    expr: up{job="grafana-paas"} == 0 
+    for: 5m
+    labels:
+        product: "prometheus"
+        severity: "page"
+    annotations:
+        summary: "Prometheus is not able to scrape Grafana"
+        description: "Prometheus has not successfully scraped {{ $labels.job }} in the last 5 minutes. https://grafana-paas.cloudapps.digital/ may be down."
+        runbook: "https://re-team-manual.cloudapps.digital/observe-support.html#re-observe-grafana-down"
   - alert: RE_Observe_AlertManager_Below_Threshold
     expr: up{job="alertmanager"} == 0 and ignoring(instance) sum without(instance) (up{job="alertmanager"}) <= 1
     for: 10s

--- a/terraform/projects/app-ecs-services/templates/alertmanager.tpl
+++ b/terraform/projects/app-ecs-services/templates/alertmanager.tpl
@@ -19,6 +19,10 @@ route:
   - receiver: "registers-zendesk"
     match:
       product: "registers"
+  - receiver: "re-observe-pagerduty"
+    match:
+      product: "prometheus"
+      severity: "page"
 
 receivers:
 - name: "re-observe-pagerduty"


### PR DESCRIPTION
# Why I am making this change

We currently have no alerting for grafana

# What approach I took

This alert measures whether Prometheus has been able to scrape data from
grafana, and alerts after 5 mins of being unable to do so. 

https://trello.com/c/L3TFMNbQ/629-write-alert-for-grafana-down

Query tested in Prometheus

Paired with @JonathanHallam 