### PR TITLE
Alert on predicted disk usage hitting 0GB over 72 hours

### DIFF
--- a/terraform/projects/app-ecs-services/config/alerts/observe-alerts.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/observe-alerts.yml
@@ -21,6 +21,14 @@ groups:
         summary: "Service is below the expected instance Threshold"
         description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}."
         runbook: "https://re-team-manual.cloudapps.digital/observe-support.html#re-observe-prometheus-below-threshold"
+  - alert: RE_Observe_PrometheusDiskPredictedToFill
+    expr: predict_linear(node_filesystem_avail{ mountpoint="/mnt", job="prometheus_node" }[12h], 3 * 86400) <= 0
+    labels:
+        product: "prometheus"
+        severity: "ticket"
+    annotations:
+        summary: "Instance {{ $labels.instance }} disk {{ $labels.mountpoint }} is predicted to fill in 72h"
+        runbook: "https://re-team-manual.cloudapps.digital/observe-support.html#re-observe-prometheus-disk-predicted-to-fill"
   - alert: RE_Observe_No_FileSd_Targets
     # this expression is a little weird - count() has no value instead of 0 if there are no
     # matching metrics.  But no value isn't less than 1 so we aren't able to trigger an alert


### PR DESCRIPTION
# Why we're making this change

We need to know if our Prometheis' EBS disk (where the data is stored) fills up. This uses `predict_linear` to predict disk usage hitting 0 across the next 72 hours (to account for us not being here on weekends to deal with it).

# What approach we took

Using `predict_linear` is better than a set threshold of eg 80%, as things could grow consistently or very quickly due to a misbehaving or broken service, and an 80% threshold doesn't give us much room to react.

We picked a range vector of 12 hours because by looking at [the graph](https://prom-3.monitoring.gds-reliability.engineering/graph?g0.range_input=1d&g0.expr=node_filesystem_avail%7B%20mountpoint%3D%22%2Fmnt%22%20%7D&g0.tab=0) we see that Prometheus periodically cleans up after itself, twice in a twelve hour period. Picking a shorter range like 1 hour would cause this to fire as the disk space decreases around cleanup time.

We based this alert syntax on https://www.robustperception.io/reduce-noise-from-disk-space-alerts.

(Paired with @idavidmcdonald.)