### PR TITLE
[DO NOT MERGE] RFC: change alertmanager routing

### DIFF
--- a/terraform/projects/app-ecs-services/templates/alertmanager.tpl
+++ b/terraform/projects/app-ecs-services/templates/alertmanager.tpl
@@ -19,6 +19,21 @@ route:
   - receiver: "registers-zendesk"
     match:
       product: "registers"
+  - receiver: "dgu-pagerduty"
+    match:
+      org: "gds-data-discovery"
+  - receiver: "registers-zendesk"
+    match:
+      org: "openregister"
+  - match:
+      org: "gds-tech-ops"
+    routes:
+      - match:
+          severity: "ticket"
+        receiver: "re-observe-ticket-alert"
+      - match:
+          severity: "page"
+        receiver: "re-observe-pagerduty"
 
 receivers:
 - name: "re-observe-pagerduty"


### PR DESCRIPTION
This commit is a demo of how we might choose to do alertmanager
routing differently.

Currently, our alerting rules add a custom tag `product` and we use
alertmanager to route rules based on the `product` tag to a particular
team.

However, alerts inherit the labels from matched metrics, and there are
already lots of labels that would be useful for routing alerts.  For
example, the `org` label which shows which cloud foundry organisation
an alert originated within.

This shows how we might do routing based on `org` instead.  It also
adds an explicit route for the `re-observe-pagerduty` receiver, which
is currently the default receiver but has no explicit matcher
anywhere.

I've deliberately left the existing routing rules in place, because
it's an obvious way to manage a transition period from the old style
routing to the new style.

Before we consider merging this, however, we need to review our
existing alerts.  I've already spotted problems with two alerts which
would be incorrectly routed in the new scheme:

 - RE_Observe_Target_Down is an alert for the observe team, but it
   inherits the `org` label of the app which is failing to be scraped,
   so it would be routed to the team that owns the app, not to the
   observe team.
 - DataGovUk_ElasticSearchIndexSizeIncrease is an alert that
   aggregates using `max by(job)`, which causes all of the labels
   other than `job` to be removed.  This could be fixed by changing it
   to `max without (instance,name,host)` instead, and demonstrates why
   we generally prefer `without` over `by`.

