### PR TITLE
Use `prom-ec2-x` private DNS for prometheus node exporter targets

### DIFF
--- a/terraform/modules/enclave/paas-config/main.tf
+++ b/terraform/modules/enclave/paas-config/main.tf
@@ -11,10 +11,11 @@ data "template_file" "prometheus_config_template" {
   template = "${file("${path.module}/prometheus.conf.tpl")}"
 
   vars {
-    prometheus_dns_names   = "${join("\",\"", concat(slice(var.prometheus_dns_names, 0, 2), list("prom-ec2-3.${var.private_subdomain}:9090")))}"
-    environment            = "${var.environment}"
-    alertmanager_dns_names = "${var.alertmanager_dns_names}"
-    prometheus_dns_nodes   = "${var.prometheus_dns_nodes}"
+    environment = "${var.environment}"
+
+    alertmanager_dns_names    = "${var.alertmanager_dns_names}"
+    prometheus_dns_names      = "${join("\",\"", concat(slice(var.prometheus_dns_names, 0, 2), list("prom-ec2-3.${var.private_subdomain}:9090")))}"
+    prometheus_node_addresses = "${join("\",\"", formatlist("%s:9100", aws_route53_record.prom_ec2_a_record.*.fqdn))}"
   }
 }
 

--- a/terraform/modules/enclave/paas-config/prometheus.conf.tpl
+++ b/terraform/modules/enclave/paas-config/prometheus.conf.tpl
@@ -23,4 +23,4 @@ scrape_configs:
       - targets: ["${alertmanager_dns_names}"]
   - job_name: prometheus_node
     static_configs:
-      - targets: ["${prometheus_dns_nodes}"]
+      - targets: ["${prometheus_node_addresses}"]

--- a/terraform/modules/enclave/paas-config/variables.tf
+++ b/terraform/modules/enclave/paas-config/variables.tf
@@ -1,4 +1,3 @@
-variable "prometheus_dns_nodes" {}
 variable "alertmanager_dns_names" {}
 variable "prometheus_config_bucket" {}
 variable "environment" {}

--- a/terraform/projects/enclave/dm-test-stack/prometheus/main.tf
+++ b/terraform/projects/enclave/dm-test-stack/prometheus/main.tf
@@ -77,10 +77,8 @@ module "prometheus" {
 module "paas-config" {
   source = "../../../../modules/enclave/paas-config"
 
-  environment          = "${local.environment}"
-  prometheus_dns_names = "${data.terraform_remote_state.app_ecs_albs.prom_private_record_fqdns}"
-
-  prometheus_dns_nodes     = "${join("\",\"", formatlist("%s:9100", module.prometheus.prometheus_private_dns))}"
+  environment              = "${local.environment}"
+  prometheus_dns_names     = "${data.terraform_remote_state.app_ecs_albs.prom_private_record_fqdns}"
   prometheus_config_bucket = "${module.prometheus.s3_config_bucket}"
   prom_private_ips         = "${module.prometheus.private_ip_addresses}"
   private_zone_id          = "${data.terraform_remote_state.network.private_zone_id}"

--- a/terraform/projects/enclave/paas-production/prometheus/main.tf
+++ b/terraform/projects/enclave/paas-production/prometheus/main.tf
@@ -81,7 +81,6 @@ module "paas-config" {
 
   environment              = "${local.environment}"
   prometheus_dns_names     = "${data.terraform_remote_state.app_ecs_albs.prom_private_record_fqdns}"
-  prometheus_dns_nodes     = "${join("\",\"", formatlist("%s:9100", module.prometheus.prometheus_private_dns))}"
   prometheus_config_bucket = "${module.prometheus.s3_config_bucket}"
   alertmanager_dns_names   = "${join("\",\"", local.active_alertmanager_private_fqdns)}"
   alerts_path              = "../../../../projects/app-ecs-services/config/alerts/"

--- a/terraform/projects/enclave/paas-staging/prometheus/main.tf
+++ b/terraform/projects/enclave/paas-staging/prometheus/main.tf
@@ -81,7 +81,6 @@ module "paas-config" {
 
   environment              = "${local.environment}"
   prometheus_dns_names     = "${data.terraform_remote_state.app_ecs_albs.prom_private_record_fqdns}"
-  prometheus_dns_nodes     = "${join("\",\"", formatlist("%s:9100", module.prometheus.prometheus_private_dns))}"
   prometheus_config_bucket = "${module.prometheus.s3_config_bucket}"
   alertmanager_dns_names   = "${join("\",\"", local.active_alertmanager_private_fqdns)}"
   alerts_path              = "../../../../projects/app-ecs-services/config/alerts/"


### PR DESCRIPTION
We were previously using the EC2 instance private DNS, for
example `ip-10-0-101-79.eu-west-1.compute.internal` as part of the
address for our prometheus node exporter targets. The downside of
this is that you could not tell which prometheus it referred to,
for example is it prom-1, prom-2 or prom-3. By swapping to use
the FQDN's produced by our private zone records we can get
prettier addresses, for example
prom-ec2-1.dm-test-stack.monitoring.private

As we want this consistently across all our stacks that monitor the
PaaS (including dev stacks) there is no longer a need to have
`prometheus_dns_nodes` as a variable for the paas-config` module.

We can also name our variable that get's passed into the template
more accurately as it is not a DNS name but a full address.

## Before
![image](https://user-images.githubusercontent.com/7228605/46880354-5428f800-ce40-11e8-8497-fff2682af968.png)


## After
![image](https://user-images.githubusercontent.com/7228605/46880337-4bd0bd00-ce40-11e8-8e03-b96e6c58acdc.png)
