### PR TITLE
Fix terraform evaluation

### DIFF
--- a/terraform/projects/app-ecs-services/prometheus-service.tf
+++ b/terraform/projects/app-ecs-services/prometheus-service.tf
@@ -111,7 +111,7 @@ data "template_file" "prometheus_config_file" {
     # set the prometheis_total to 3 in order to set up ec2 as prom-3
     prometheus_dns_names = "${
       local.num_azs < 3 ? "${join("\",\"", local.active_prometheus_private_fqdns)}" :
-      join("\",\"", concat(slice(local.active_prometheus_private_fqdns, 0, 2),
+      join("\",\"", concat(slice(local.active_prometheus_private_fqdns, 0, local.num_azs - 1),
         list("prom-ec2-3.${data.terraform_remote_state.infra_networking.private_subdomain}:9090")))
     }"
 


### PR DESCRIPTION
# Why I am making this change

- as terraform evaluates an entire expression we need to ensure that there are enough elements in the slice to avoid triggering an error message

# What approach I took

This was missed in the original fix, this time I manually created a dev stack with 1, 2 and 3  prometheis totals to make sure that it works.