### PR TITLE
Add a check when creating buckets to stop false errors from EC2 deploys

### DIFF
--- a/deploy_enclave.sh
+++ b/deploy_enclave.sh
@@ -36,9 +36,12 @@ STATE=${STATE:-network}
 role="arn:aws:iam::170611269615:role/prometheus_deployer"
 role_session="test"
 
-if ! aws-vault exec ${PROFILE} -- aws s3api head-bucket --bucket ${bucket_name} 2>/dev/null ; then
-    echo "creating ${bucket_name}"
-    aws-vault exec ${PROFILE} -- aws s3api create-bucket --bucket="${bucket_name}" --region "${AWS_REGION}" --create-bucket-configuration LocationConstraint="${AWS_REGION}"
+# only check buckets for dev environments not paas-staging, paas-production or verify-perf-a
+if [[ ! "$ENCLAVE" =~ ^(paas-staging|paas-production|verify-perf-a)$ ]]; then
+    if ! aws-vault exec ${PROFILE} -- aws s3api head-bucket --bucket ${bucket_name} 2>/dev/null ; then
+        echo "creating ${bucket_name}"
+        aws-vault exec ${PROFILE} -- aws s3api create-bucket --bucket="${bucket_name}" --region "${AWS_REGION}" --create-bucket-configuration LocationConstraint="${AWS_REGION}"
+    fi
 fi
 
 planfile="tf-$(date +"%Y_%m_%d_%H:%I%S").plan"


### PR DESCRIPTION
# Why I am making this change

Problem experienced when deploying to staging or production enclave, you might experience some hanging or an error message reported by AWS but keying Enter and re applying the terraform will get the deploy to work.

# What approach I took

You don't really need to create the bucket for staging, production or verify-perf-a stacks so don't do the s3 bucket checks for them, just check on dev stacks.