### PR TITLE
Add alert for the older version of prometheus

### DIFF
--- a/terraform/projects/app-ecs-services/config/alerts/observe-alerts.yml
+++ b/terraform/projects/app-ecs-services/config/alerts/observe-alerts.yml
@@ -2,7 +2,7 @@ groups:
 - name: RE_Observe
   rules:
   - alert: RE_Observe_Grafana_Down
-    expr: up{job="grafana-paas"} == 0 
+    expr: up{job="grafana-paas"} == 0
     for: 5m
     labels:
         product: "prometheus"
@@ -39,7 +39,7 @@ groups:
     annotations:
         summary: "Instance {{ $labels.instance }} disk {{ $labels.mountpoint }} is predicted to fill in 72h"
         runbook: "https://re-team-manual.cloudapps.digital/observe-support.html#re-observe-prometheus-disk-predicted-to-fill"
-  - alert: RE_Observe_No_FileSd_Targets
+  - alert: RE_Observe_No_FileSd_Targets_ECS
     # this expression is a little weird - count() has no value instead of 0 if there are no
     # matching metrics.  But no value isn't less than 1 so we aren't able to trigger an alert
     # that a regular count() is zero.  So we force missing values to be equal to
@@ -51,10 +51,10 @@ groups:
     # This is useful if we only have one source of file_sd config, but might not be
     # if we have multiple ways of receiving file_sd configs and only one of them breaks.
     # - a condition has been added to ensure that it does not trigger on prometheus build versions matching '2.1.0+ds'
-    # Reason for this is because that version does not have the metric 'prometheus_sd_file_mtime_seconds' available so will always trigger 
-    # and the package available for Ubunutu 18.04 Bionic Beaver machines on EC2 prometheus stacks is '2.1.0+ds'. 
+    # Reason for this is because that version does not have the metric 'prometheus_sd_file_mtime_seconds' available so will always trigger
+    # and the package available for Ubunutu 18.04 Bionic Beaver machines on EC2 prometheus stacks is '2.1.0+ds'.
     # If this changes this alert will need to be updated to ensure that it doesn't fire unless it is supported in that version of prometheus.
-    # 
+    #
     expr: (count(prometheus_sd_file_mtime_seconds) or count(up)*0) < 1 and count(prometheus_build_info{version=~"2\\.4.*"})
     for: 10s
     labels:
@@ -64,6 +64,18 @@ groups:
         summary: "No file_sd targets detected"
         description: "No file_sd targets were detected.  Is there a problem accessing the targets bucket?"
         runbook: "https://re-team-manual.cloudapps.digital/observe-support.html#re-observe-no-filesd-targets"
+
+  - alert: RE_Observe_No_FileSd_Targets_EC2
+    expr: (count(prometheus_sd_file_timestamp) or count(up)*0) < 1 and count(prometheus_build_info{version=~"2\\.1.*"})
+    for: 10s
+    labels:
+        product: "prometheus"
+        severity: "page"
+    annotations:
+        summary: "No file_sd targets detected"
+        description: "No file_sd targets were detected.  Is there a problem accessing the targets bucket?"
+        runbook: "https://re-team-manual.cloudapps.digital/observe-support.html#re-observe-no-filesd-targets"
+
 
 # this can be improved however maybe this is something we need to focus on in Q2 when working on the support plan
 


### PR DESCRIPTION
# Why I am making this change

We want to move all of our prometheis over to EC2. For the time being this means that we will need to run an older version of prometheus in parallel. This means that we need to add an alert for the older version of prometheus because of a metric name change between 2.1.1 (EC2) and 2.4.3 (ECS)

https://trello.com/c/ZM1sMbn6/655-finish-migrating-prometheus-to-ec2

# What approach I took

This adds an extra alert. The original alert with the new name can be deleted once we move over our two remaining prometheus instances, this alert can also be refactored at that time to remove the version check. 
