### PR TITLE
Increase the Prometheus retention time for log files.

### DIFF
--- a/terraform/modules/enclave/prometheus/cloud.conf
+++ b/terraform/modules/enclave/prometheus/cloud.conf
@@ -13,7 +13,7 @@ write_files:
   - owner: root:root
     path: /etc/default/prometheus
     permissions: 0444
-    content: 'ARGS="--storage.tsdb.path=\"/mnt/\" --web.external-url=${prom_external_url}"'
+    content: 'ARGS="--storage.tsdb.path=\"/mnt/\" --web.external-url=${prom_external_url} --storage.tsdb.retention=60d"'
   - owner: root:root
     path: /etc/cron.d/config_pull
     permissions: 0755


### PR DESCRIPTION
# Why I am making this change

Default Prometheus retention for logs is 15d. We are increasing this
to 60 days. The should increase the usefulness of our SLIs.

# What approach I took

Change has been implemented and deployed on my test stack. Prometheus may not be the right place to store data for very long periods, but we can quickly and cheaply store data for longer than 15 days, to make our SLIs more helpful.