### PR TITLE
Resize EBS volume from 20 - 21gb

### DIFF
--- a/terraform/modules/enclave/prometheus/main.tf
+++ b/terraform/modules/enclave/prometheus/main.tf
@@ -50,7 +50,7 @@ resource "aws_ebs_volume" "prometheus-disk" {
   count = "${length(keys(var.availability_zones))}"
 
   availability_zone = "${element(keys(var.availability_zones), count.index)}"
-  size              = "20"
+  size              = "21"
 
   tags {
     Name = "prometheus-disk"


### PR DESCRIPTION
# Why I am making this change

There was a test done on staging to bump the sizes which has made deploys difficult. Resizing the disk is the easiest way to circumvent this.
