### PR TITLE
Add -t (target) parameter functionality to deploy script.

### DIFF
--- a/deploy_enclave.sh
+++ b/deploy_enclave.sh
@@ -54,7 +54,7 @@ pushd "terraform/projects/enclave/${ENCLAVE}/${STATE}"
     fi
     if [ "${TERRAFORM_ACTION}" == "apply" ] 
     then
-        aws-vault exec ${PROFILE} -- terraform plan --out "${planfile}"
+        aws-vault exec ${PROFILE} -- terraform plan -target $TARGET --out "${planfile}"
         echo "Do you wish to apply plan?"
         select yn in "yes" "no"; do
             case $yn in


### PR DESCRIPTION
# Why I am making this change

Although the current deploy_enclave script accepts a -t paramter there
is no code behind it. This changes the script so that it only builds the
thing targeted.

# What approach I took

Script has been modified locally and I have deployed to single instances of my test stack.
