### PR TITLE
Fix kitchen tests

### DIFF
--- a/terraform/modules/enclave/prometheus/test/prometheus-paas/main.tf
+++ b/terraform/modules/enclave/prometheus/test/prometheus-paas/main.tf
@@ -4,10 +4,10 @@ locals {
   product     = "test-paas"
   environment = "${local.product}-${var.test_user}"
 
-  private_subdomain_name = "${var.test_user}.monitoring.private"
-
-  availability_zones                = "${zipmap(var.az_zones_avalible,module.vpc.public_subnets_cidr_blocks)}"
   active_alertmanager_private_fqdns = ["alert-1.private.test.com", "alert-2.private.test.com", "alert-3.private.test.com"]
+  availability_zones                = "${zipmap(data.aws_availability_zones.available.names, local.private_subnets_cidr_blocks)}"
+  private_subdomain_name            = "${var.test_user}.monitoring.private"
+  private_subnets_cidr_blocks       = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
 }
 
 # Providers
@@ -34,7 +34,7 @@ module "vpc" {
 
   # subnets assumes 3 AZs although 3AZs are not implemented elsewhere
   azs              = "${data.aws_availability_zones.available.names}"
-  private_subnets  = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  private_subnets  = "${local.private_subnets_cidr_blocks}"
   public_subnets   = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
   database_subnets = ["10.0.201.0/24", "10.0.202.0/24", "10.0.203.0/24"]
 

--- a/terraform/modules/enclave/prometheus/test/prometheus-paas/variables.tf
+++ b/terraform/modules/enclave/prometheus/test/prometheus-paas/variables.tf
@@ -1,6 +1,9 @@
-variable "az_zones_avalible" {
-  type    = "list"
-  default = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+variable "prometheus_public_fqdns" {
+  default = [
+    "prom-1.test.gov.uk",
+    "prom-2.test.gov.uk",
+    "prom-3.test.gov.uk",
+  ]
 }
 
 variable "test_user" {}

--- a/terraform/modules/enclave/prometheus/test/prometheus-verify/prometheus.tf
+++ b/terraform/modules/enclave/prometheus/test/prometheus-verify/prometheus.tf
@@ -14,6 +14,8 @@ module "prometheus" {
   environment   = "${local.environment}"
   config_bucket = "${local.environment}"
 
+  prometheus_public_fqdns = ["prometheus-hub-perf-a-dmz.ida.digital.cabinet-office.gov.uk", "prometheus-hub-perf-a-dmz.ida.digital.cabinet-office.gov.uk"]
+
   subnet_ids          = "${module.network.subnet_ids}"
   availability_zones  = "${module.network.availability_zones}"
   vpc_security_groups = ["${module.network.security_groups}", "${aws_security_group.permit_internet_access.id}"]


### PR DESCRIPTION
# Why I am making this change

The kitchen tests were broken as they are not run as part of a dev process. 
I've updated the tests so that they pass but have not added any extra tests.

# What approach I took

Had to move the `private_subnets_cidr_blocks` to local as terraform wasn't able to calculate the count causing the tests to be aborted.