### PR TITLE
Add config_updater task definition

### DIFF
--- a/terraform/projects/app-ecs-services/config-updater.tf
+++ b/terraform/projects/app-ecs-services/config-updater.tf
@@ -1,0 +1,81 @@
+resource "aws_iam_role" "config_task_iam_role" {
+  name = "${var.stack_name}-config-updater-task"
+  path = "/"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+data "aws_iam_policy_document" "config_policy_doc" {
+  statement {
+    sid = "GetConfigFiles"
+
+    resources = ["arn:aws:s3:::${aws_s3_bucket.config_bucket.id}/prometheus/*", "arn:aws:s3:::${aws_s3_bucket.config_bucket.id}/alertmanager/*"]
+
+    actions = [
+      "s3:Get*",
+    ]
+  }
+
+  statement {
+    sid = "ListConfigBucket"
+
+    resources = ["arn:aws:s3:::${aws_s3_bucket.config_bucket.id}"]
+
+    actions = [
+      "s3:List*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "config_task_policy" {
+  name   = "${var.stack_name}-config-task-policy"
+  path   = "/"
+  policy = "${data.aws_iam_policy_document.config_policy_doc.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "config_policy_attachment" {
+  role       = "${aws_iam_role.config_task_iam_role.name}"
+  policy_arn = "${aws_iam_policy.config_task_policy.arn}"
+}
+
+resource "aws_ecs_service" "config_updater" {
+  name            = "${var.stack_name}-config-updater"
+  cluster         = "${var.stack_name}-ecs-monitoring"
+  task_definition = "${aws_ecs_task_definition.config_updater.arn}"
+  desired_count   = "${length(data.terraform_remote_state.app_ecs_instances.available_azs)}"
+}
+
+data "template_file" "config_updater_defn" {
+  template = "${file("task-definitions/config_updater.json")}"
+
+  vars {
+    log_group     = "${aws_cloudwatch_log_group.task_logs.name}"
+    region        = "${var.aws_region}"
+    config_bucket = "${aws_s3_bucket.config_bucket.id}"
+  }
+}
+
+resource "aws_ecs_task_definition" "config_updater" {
+  family                = "${var.stack_name}-config-updater"
+  container_definitions = "${data.template_file.config_updater_defn.rendered}"
+  task_role_arn         = "${aws_iam_role.config_task_iam_role.arn}"
+
+  volume {
+    name      = "config-from-s3"
+    host_path = "/ecs/config-from-s3"
+  }
+}

--- a/terraform/projects/app-ecs-services/paas-proxy.tf
+++ b/terraform/projects/app-ecs-services/paas-proxy.tf
@@ -8,31 +8,9 @@ data "template_file" "paas_proxy_container_defn" {
   }
 }
 
-resource "aws_iam_role" "paas_proxy_task_iam_role" {
-  name = "${var.stack_name}-paas-proxy-task"
-  path = "/"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "ecs-tasks.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
-}
-
 resource "aws_ecs_task_definition" "paas_proxy" {
   family                = "${var.stack_name}-paas-proxy"
   container_definitions = "${data.template_file.paas_proxy_container_defn.rendered}"
-  task_role_arn         = "${aws_iam_role.paas_proxy_task_iam_role.arn}"
 
   volume {
     name      = "paas-proxy"

--- a/terraform/projects/app-ecs-services/task-definitions/config_updater.json
+++ b/terraform/projects/app-ecs-services/task-definitions/config_updater.json
@@ -1,29 +1,5 @@
 [
   {
-    "name": "s3-updater-targets",
-    "image": "mesosphere/aws-cli",
-    "cpu": 40,
-    "memory": 256,
-    "essential": true,
-    "mountPoints": [
-      {
-        "sourceVolume": "config-from-s3",
-        "containerPath": "/configs"
-      }
-    ],
-    "command": [
-      "s3", "sync", "--delete", "s3://${targets_bucket}/active", "/configs/targets"
-    ],
-    "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${log_group}",
-        "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "s3-targets-"
-      }
-    }
-  },
-  {
     "name": "s3-updater-config",
     "image": "mesosphere/aws-cli",
     "cpu": 128,


### PR DESCRIPTION
# Why I am making this change

This config_udpater task definition was left out which would mean that nginx config updates would not be picked up, which would impact dev stacks as nginx would not have any config files to start with.

This only affects stacks created from scratch so didn't affect staging or production because those stacks already have nginx configs set up.

This does not impact prometheis running in EC2 as it gets the targets configs in the user_data script.
