### PR TITLE
Downsize ECS instances to t2.medium

### DIFF
--- a/terraform/projects/app-ecs-instances/main.tf
+++ b/terraform/projects/app-ecs-instances/main.tf
@@ -26,7 +26,7 @@ variable "prometheis_total" {
 variable "ecs_instance_type" {
   type        = "string"
   description = "ECS container instance type"
-  default     = "m4.large"
+  default     = "t2.medium"
 }
 
 variable "ecs_instance_root_size" {


### PR DESCRIPTION
# Why I am making this change

Now the ECS instances don't run Prometheus, we don't need them to be `m4.large`. From graphs of CPU and memory across the ECS cluster over the past week, there's a significant drop in memory and CPU.

We think we can get away with t2.medium. If we hit the CPU credits problem then we can bump them.

(Paired with @kentsanggds.)

# Screenshots

<img width="1920" alt="screen shot 2018-10-26 at 17 03 45 2" src="https://user-images.githubusercontent.com/355033/47578782-39777880-d942-11e8-86b0-afe03b8204f1.png">
<img width="1920" alt="screen shot 2018-10-26 at 17 04 17 2" src="https://user-images.githubusercontent.com/355033/47578816-4b591b80-d942-11e8-8d5c-98624e22fe48.png">
