### PR TITLE
Add back the prom-ec2-n records for now

### DIFF
--- a/terraform/modules/enclave/paas-config/main.tf
+++ b/terraform/modules/enclave/paas-config/main.tf
@@ -19,6 +19,17 @@ data "template_file" "prometheus_config_template" {
   }
 }
 
+resource "aws_route53_record" "prom_ec2_a_record" {
+  count = 3
+
+  zone_id = "${var.private_zone_id}"
+  name    = "prom-ec2-${count.index + 1}"
+  type    = "A"
+  ttl     = 300
+
+  records = ["${element(var.prom_private_ips, count.index)}"]
+}
+
 resource "aws_route53_record" "prom_a_record" {
   count = 3
 


### PR DESCRIPTION
- Deploying the previous commit to staging broke stuff, because we
  didn't persist prom-ec2 records for zero-downtime deploys.