### PR TITLE
Revert "Now all Prometheis are on EC2, use prom-n instead of prom-ec2-n"

### DIFF
--- a/terraform/modules/enclave/paas-config/main.tf
+++ b/terraform/modules/enclave/paas-config/main.tf
@@ -14,16 +14,16 @@ data "template_file" "prometheus_config_template" {
     environment = "${var.environment}"
 
     alertmanager_dns_names    = "${var.alertmanager_dns_names}"
-    prometheus_addresses      = "${join("\",\"", formatlist("%s:9090", aws_route53_record.prom_a_record.*.fqdn))}"
-    prometheus_node_addresses = "${join("\",\"", formatlist("%s:9100", aws_route53_record.prom_a_record.*.fqdn))}"
+    prometheus_addresses      = "${join("\",\"", formatlist("%s:9090", aws_route53_record.prom_ec2_a_record.*.fqdn))}"
+    prometheus_node_addresses = "${join("\",\"", formatlist("%s:9100", aws_route53_record.prom_ec2_a_record.*.fqdn))}"
   }
 }
 
-resource "aws_route53_record" "prom_a_record" {
+resource "aws_route53_record" "prom_ec2_a_record" {
   count = 3
 
   zone_id = "${var.private_zone_id}"
-  name    = "prom-${count.index + 1}"
+  name    = "prom-ec2-${count.index + 1}"
   type    = "A"
   ttl     = 300
 

--- a/terraform/projects/app-ecs-services/nginx-auth-proxy.tf
+++ b/terraform/projects/app-ecs-services/nginx-auth-proxy.tf
@@ -47,9 +47,9 @@ data "template_file" "nginx-auth-proxy-config-file" {
     alertmanager_1_dns_name = "${data.terraform_remote_state.app_ecs_albs.alerts_private_record_fqdns.0}"
     alertmanager_2_dns_name = "${data.terraform_remote_state.app_ecs_albs.alerts_private_record_fqdns.1}"
     alertmanager_3_dns_name = "${data.terraform_remote_state.app_ecs_albs.alerts_private_record_fqdns.2}"
-    prometheus_1_address    = "prom-1.${data.terraform_remote_state.infra_networking.private_subdomain}:9090"
-    prometheus_2_address    = "prom-2.${data.terraform_remote_state.infra_networking.private_subdomain}:9090"
-    prometheus_3_address    = "prom-3.${data.terraform_remote_state.infra_networking.private_subdomain}:9090"
+    prometheus_1_address    = "prom-ec2-1.${data.terraform_remote_state.infra_networking.private_subdomain}:9090"
+    prometheus_2_address    = "prom-ec2-2.${data.terraform_remote_state.infra_networking.private_subdomain}:9090"
+    prometheus_3_address    = "prom-ec2-3.${data.terraform_remote_state.infra_networking.private_subdomain}:9090"
   }
 }
 


### PR DESCRIPTION
Reverts alphagov/prometheus-aws-configuration-beta#176

As with #180, this didn't work how I thought it worked _at all_. There are multiple places where we define `prom-1` DNS (enclave and `app-ecs-albs`). To work through this all methodically (thanks @idavidmcdonald for the explanation of why things I thought to be unrelated were changing), we're reverting this PR, redeploying Staging to its previous state, and starting again.