### PR TITLE
Remove prom-n records from app-ecs-albs

### DIFF
--- a/terraform/projects/app-ecs-albs/main.tf
+++ b/terraform/projects/app-ecs-albs/main.tf
@@ -147,20 +147,6 @@ resource "aws_acm_certificate_validation" "monitoring_cert" {
   validation_record_fqdns = ["${aws_route53_record.monitoring_cert_validation.*.fqdn}"]
 }
 
-resource "aws_route53_record" "prom_alias" {
-  count = "${local.prom_records_count}"
-
-  zone_id = "${data.terraform_remote_state.infra_networking.public_zone_id}"
-  name    = "prom-${count.index + 1}"
-  type    = "A"
-
-  alias {
-    name                   = "${aws_lb.nginx_auth_external_alb.dns_name}"
-    zone_id                = "${aws_lb.nginx_auth_external_alb.zone_id}"
-    evaluate_target_health = false
-  }
-}
-
 resource "aws_route53_record" "alerts_alias" {
   count = "${local.alerts_records_count}"
 


### PR DESCRIPTION
- To prettify the switch of Prometheus from ECS to EC2, we want to
  deprecate the `prom-ec2-n` hosts in favour of `prom-n`. To do this, we
  have to have a multi-step process to ensure that the records are added
  and removed in the correct order with as little downtime as possible.
- This is step 1 of 4.