### PR TITLE
fix deprecation warning

### DIFF
--- a/terraform/modules/enclave/prometheus/test/prometheus-paas/main.tf
+++ b/terraform/modules/enclave/prometheus/test/prometheus-paas/main.tf
@@ -49,9 +49,12 @@ module "vpc" {
 }
 
 resource "aws_route53_zone" "private" {
-  vpc_id        = "${module.vpc.vpc_id}"
   name          = "${local.private_subdomain_name}"
   force_destroy = true
+
+  vpc {
+    vpc_id = "${module.vpc.vpc_id}"
+  }
 }
 
 resource "aws_security_group" "permit_internet_access" {


### PR DESCRIPTION
`vpc_id` is deprecated, to be replaced with a `vpc` block that contains
a `vpc_id` and an optional `vpc_region`.

https://www.terraform.io/docs/providers/aws/r/route53_zone.html#vpc_id
