### PR TITLE
increase repeat_interval for tickets

### DIFF
--- a/terraform/projects/app-ecs-services/templates/alertmanager.tpl
+++ b/terraform/projects/app-ecs-services/templates/alertmanager.tpl
@@ -10,6 +10,7 @@ route:
   receiver: "re-observe-pagerduty"
   routes:
   - receiver: "re-observe-ticket-alert"
+    repeat_interval: 7d
     match:
       product: "prometheus"
       severity: "ticket"
@@ -17,6 +18,7 @@ route:
     match:
       product: "data-gov-uk"
   - receiver: "registers-zendesk"
+    repeat_interval: 7d
     match:
       product: "registers"
   - receiver: "re-observe-pagerduty"


### PR DESCRIPTION
# Why I am making this change

We had an issue where a ticket was created at 9am on a Sunday.  But with the default repeat_interval of 4 hours, we created loads and loads of duplicate tickets before someone came in on monday to fix it.

# What approach I took

Bump the repeat_interval to 7d for zendesk routes.