### PR TITLE
Make AWS Session Manager available on EC2 prometheus

### DIFF
--- a/terraform/modules/common/ami/main.tf
+++ b/terraform/modules/common/ami/main.tf
@@ -1,5 +1,9 @@
 ## Variables
 
+locals {
+  canonical_account_id = "099720109477"
+}
+
 ## Data sources
 
 data "aws_ami" "ecs_optimized" {
@@ -18,8 +22,33 @@ data "aws_ami" "ecs_optimized" {
   owners = ["amazon"]
 }
 
+data "aws_ami" "ubuntu_bionic" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["${local.canonical_account_id}"]
+}
+
 ## Outputs
 
 output "ecs_optimized_ami_id" {
   value = "${data.aws_ami.ecs_optimized.id}"
+}
+
+output "ubuntu_bionic_ami_id" {
+  value = "${data.aws_ami.ubuntu_bionic.id}"
 }

--- a/terraform/modules/common/ami/main.tf
+++ b/terraform/modules/common/ami/main.tf
@@ -2,7 +2,7 @@
 
 ## Data sources
 
-data "aws_ami" "source" {
+data "aws_ami" "ecs_optimized" {
   most_recent = true
 
   filter {
@@ -20,6 +20,6 @@ data "aws_ami" "source" {
 
 ## Outputs
 
-output "ami_id" {
-  value = "${data.aws_ami.source.id}"
+output "ecs_optimized_ami_id" {
+  value = "${data.aws_ami.ecs_optimized.id}"
 }

--- a/terraform/modules/enclave/README.md
+++ b/terraform/modules/enclave/README.md
@@ -52,3 +52,13 @@ To ssh to the instance, with an ssh tunnel to view the web interface (using the 
     ssh ubuntu@<ip_from_output> -L 9090:localhost:9090
 
 Once this is done you can view Prometheus on http://localhost:9090.
+
+To try it out for yourself, either start a session in the SSM session
+manager web console, or [install the session manager CLI
+plugin][session-manager-install], then run:
+
+    aws-vault exec gds-tech-ops -- aws ssm start-session --target $INSTANCE_ID
+
+where `$INSTANCE_ID` is an id of an AWS EC2 prometheus instance.
+
+[session-manager-install]: https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html

--- a/terraform/modules/enclave/prometheus/iam.tf
+++ b/terraform/modules/enclave/prometheus/iam.tf
@@ -69,3 +69,8 @@ resource "aws_iam_role_policy_attachment" "iam_policy" {
   role       = "${aws_iam_role.prometheus_role.name}"
   policy_arn = "${aws_iam_policy.prometheus_instance_profile.arn}"
 }
+
+resource "aws_iam_role_policy_attachment" "session_manager_access" {
+  role       = "${aws_iam_role.prometheus_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+}

--- a/terraform/modules/enclave/prometheus/test/prometheus-paas/prometheus.tf
+++ b/terraform/modules/enclave/prometheus/test/prometheus-paas/prometheus.tf
@@ -1,8 +1,11 @@
+module "ami" {
+  source = "../../../../common/ami"
+}
+
 module "prometheus" {
   source = "../../../prometheus"
 
-  # Canonicals Ubunutu 18.04 Bionic Beaver in eu-west-1
-  ami_id     = "ami-0ee06eb8d6eebcde0"
+  ami_id     = "${module.ami.ubuntu_bionic_ami_id}"
   target_vpc = "${module.vpc.vpc_id}"
   enable_ssh = true
 

--- a/terraform/modules/jumpbox/main.tf
+++ b/terraform/modules/jumpbox/main.tf
@@ -79,7 +79,7 @@ resource "aws_security_group_rule" "allow_all_egress" {
 }
 
 resource "aws_instance" "instance" {
-  ami           = "${module.ami.ami_id}"
+  ami           = "${module.ami.ecs_optimized_ami_id}"
   subnet_id     = "${var.subnet_id}"
   instance_type = "t2.small"
 

--- a/terraform/projects/app-ecs-instances/main.tf
+++ b/terraform/projects/app-ecs-instances/main.tf
@@ -153,7 +153,7 @@ module "ecs_instance" {
   # Launch configuration
   lc_name = "${var.stack_name}-ecs-instances"
 
-  image_id      = "${module.ami.ami_id}"
+  image_id      = "${module.ami.ecs_optimized_ami_id}"
   instance_type = "${var.ecs_instance_type}"
 
   security_groups = ["${data.terraform_remote_state.infra_security_groups.monitoring_internal_sg_id}",

--- a/terraform/projects/enclave/paas-production/prometheus/main.tf
+++ b/terraform/projects/enclave/paas-production/prometheus/main.tf
@@ -61,11 +61,14 @@ data "pass_password" "logstash_endpoint" {
   path = "logit/prometheus-paas-logstash-endpoint-prod"
 }
 
+module "ami" {
+  source = "../../../../modules/common/ami"
+}
+
 module "prometheus" {
   source = "../../../../modules/enclave/prometheus"
 
-  # Canonicals Ubunutu 18.04 Bionic Beaver in eu-west-1
-  ami_id = "ami-0ee06eb8d6eebcde0"
+  ami_id = "${module.ami.amazon_ubuntu_bionic_ami_id}"
 
   # Production
   target_vpc = "vpc-0cdd9631927b526ce"

--- a/terraform/projects/enclave/paas-staging/prometheus/main.tf
+++ b/terraform/projects/enclave/paas-staging/prometheus/main.tf
@@ -52,11 +52,14 @@ data "terraform_remote_state" "app_ecs_albs" {
   }
 }
 
+module "ami" {
+  source = "../../../../modules/common/ami"
+}
+
 module "prometheus" {
   source = "../../../../modules/enclave/prometheus"
 
-  # Canonicals Ubunutu 18.04 Bionic Beaver in eu-west-1
-  ami_id = "ami-0ee06eb8d6eebcde0"
+  ami_id = "${module.ami.ubuntu_bionic_ami_id}"
 
   # Staging
   target_vpc = "vpc-0bbf4123f5b385806"


### PR DESCRIPTION
# Why I am making this change

Currently, you can only ssh to a box if you created it yourself.  If we use AWS Session Manager, we can control shell access using IAM policies, which means we can all access shell without having to manage ssh keys.

We should also be able to get rid of jumpboxes.

# What approach I took

- upgrade to latest ubuntu AMI to get the latest SSM agent
- allow SSM to access the prometheus instances

that's it! 🎉 