### PR TITLE
improve session manager README

### DIFF
--- a/terraform/modules/enclave/README.md
+++ b/terraform/modules/enclave/README.md
@@ -55,7 +55,8 @@ Once this is done you can view Prometheus on http://localhost:9090.
 
 To try it out for yourself, either start a session in the SSM session
 manager web console, or [install the session manager CLI
-plugin][session-manager-install], then run:
+plugin][session-manager-install], then run (using the `instance_ids`
+output from the terraform apply):
 
     aws-vault exec gds-tech-ops -- aws ssm start-session --target $INSTANCE_ID
 

--- a/terraform/projects/enclave/paas-production/prometheus/main.tf
+++ b/terraform/projects/enclave/paas-production/prometheus/main.tf
@@ -112,3 +112,7 @@ output "public_ips" {
 output "public_dns" {
   value = "[\n    ${join("\n    ", formatlist("%s:9090", module.prometheus.prometheus_public_dns))}\n]"
 }
+
+output "instance_ids" {
+  value = "[\n    ${join("\n    ", module.prometheus.prometheus_instance_id)}\n]"
+}

--- a/terraform/projects/enclave/paas-staging/prometheus/main.tf
+++ b/terraform/projects/enclave/paas-staging/prometheus/main.tf
@@ -102,3 +102,7 @@ output "public_ips" {
 output "public_dns" {
   value = "[\n    ${join("\n    ", formatlist("%s:9090", module.prometheus.prometheus_public_dns))}\n]"
 }
+
+output "instance_ids" {
+  value = "[\n    ${join("\n    ", module.prometheus.prometheus_instance_id)}\n]"
+}


### PR DESCRIPTION
# Why I am making this change

I was deploying #190 and it was hard to work out what instance ids i should be using to start a session manager session.

# What approach I took

We should output the instance ids, the same way we output the public
DNS names, because the instance id is how we get shell access with
session manager
