### PR TITLE
enable session manager access to ECS instances

### DIFF
--- a/terraform/projects/app-ecs-instances/ecs-iam-policy.tf
+++ b/terraform/projects/app-ecs-instances/ecs-iam-policy.tf
@@ -61,3 +61,8 @@ resource "aws_iam_role_policy_attachment" "ecs_instance_document_policy_attachme
   role       = "${aws_iam_role.instance_iam_role.name}"
   policy_arn = "${aws_iam_policy.ecs_instance_policy.arn}"
 }
+
+resource "aws_iam_role_policy_attachment" "session_manager_access" {
+  role       = "${aws_iam_role.instance_iam_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+}


### PR DESCRIPTION
Just like #190 but for ECS instances.  I suspect that, because we are
using an Amazon Linux AMI and we track the latest changes, we just
need to rebuild our instances to the latest AMI image to get the
latest SSM agent running, so all we need to do is grant SSM
permissions in IAM to the EC2 instance profile.

Once this is in place and working, we should be able to roll back our
use of ssh keys, jumpboxes, and other such things.  That should
hopefully remove a bunch of code.