### PR TITLE
Add user data script with ECS agent to ECS instances

### DIFF
--- a/terraform/projects/app-ecs-instances/instance-user-data.tpl
+++ b/terraform/projects/app-ecs-instances/instance-user-data.tpl
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Set any ECS agent configuration options
+echo "ECS_CLUSTER=${cluster_name}" >> /etc/ecs/ecs.config
+yum install -y ecs-init
+start ecs
+service docker start

--- a/terraform/projects/app-ecs-instances/main.tf
+++ b/terraform/projects/app-ecs-instances/main.tf
@@ -139,6 +139,14 @@ resource "aws_ecs_cluster" "prometheus_cluster" {
   name = "${local.cluster_name}"
 }
 
+data "template_file" "instance_user_data" {
+  template = "${file("instance-user-data.tpl")}"
+
+  vars {
+    cluster_name = "${local.cluster_name}"
+  }
+}
+
 module "ami" {
   source = "../../modules/common/ami"
 }
@@ -168,6 +176,8 @@ module "ecs_instance" {
       volume_type = "gp2"
     },
   ]
+
+  user_data = "${data.template_file.instance_user_data.rendered}"
 
   # Auto scaling group
   asg_name                  = "${var.stack_name}-ecs-instance"


### PR DESCRIPTION
# Why I am making this change

We took out the user data script from the ECS instance because most of it was unnecessary due to EBS volumes no longer being attached but also accidentally took out the ECS agent, so this will put the agents back on the ECS instances
