### PR TITLE
install and run the amazon ssm agent on our ECS instances

### DIFF
--- a/terraform/projects/app-ecs-instances/instance-user-data.tpl
+++ b/terraform/projects/app-ecs-instances/instance-user-data.tpl
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Set any ECS agent configuration options
 echo "ECS_CLUSTER=${cluster_name}" >> /etc/ecs/ecs.config
+yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
 yum install -y ecs-init
-start ecs
+start amazon-ssm-agent ecs
 service docker start


### PR DESCRIPTION
Doing this so that we can get Session Manager working for our ECS
instances.

Based on
https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-manual-agent-install.html

Note that because we run the ECS-optimized AMI, the SSM agent doesn't
come by default:

> You must manually install SSM Agent on other versions of Linux,
> including non-base images like Amazon ECS-Optimized AMIs.

