### PR TITLE
Reinstate the Project tag for infra-networking resources

### DIFF
--- a/terraform/modules/infra-networking/main.tf
+++ b/terraform/modules/infra-networking/main.tf
@@ -36,13 +36,15 @@ variable "prometheus_subdomain" {
   default     = "monitoring"
 }
 
+variable "project" {}
+
 # locals
 # --------------------------------------------------------------
 
 locals {
   default_tags = {
     Terraform = "true"
-    Project   = "infra-networking"
+    Project   = "${var.project}"
   }
 
   shared_dev_subdomain_name = "dev.gds-reliability.engineering"

--- a/terraform/projects/infra-networking-dev/main.tf
+++ b/terraform/projects/infra-networking-dev/main.tf
@@ -28,14 +28,22 @@ variable "prometheus_subdomain" {
 variable "stack_name" {
   type        = "string"
   description = "Unique name for this collection of resources"
-  default     = "ecs-monitoring"
+  default     = "dev"
+}
+
+variable "project" {
+  type        = "string"
+  description = "Which project, in which environment, we're running"
+  default     = "infra-networking-dev"
 }
 
 module "infra-networking" {
   source = "../../modules/infra-networking"
 
-  dev_environment      = true
-  stack_name           = "monitoring"
+  dev_environment = true
+
+  project              = "${var.project}"
+  stack_name           = "${var.stack_name}"
   prometheus_subdomain = "${var.prometheus_subdomain}"
 }
 

--- a/terraform/projects/infra-networking-production/main.tf
+++ b/terraform/projects/infra-networking-production/main.tf
@@ -19,6 +19,12 @@ variable "prometheus_subdomain" {
   default     = "monitoring"
 }
 
+variable "project" {
+  type        = "string"
+  description = "Which project, in which environment, we're running"
+  default     = "infra-networking-production"
+}
+
 variable "aws_region" {
   type        = "string"
   description = "The AWS region to use."
@@ -37,6 +43,7 @@ module "infra-networking" {
   dev_environment      = false
   stack_name           = "${var.stack_name}"
   prometheus_subdomain = "${var.prometheus_subdomain}"
+  project              = "${var.project}"
 }
 
 output "vpc_id" {

--- a/terraform/projects/infra-networking-staging/main.tf
+++ b/terraform/projects/infra-networking-staging/main.tf
@@ -31,12 +31,19 @@ variable "prometheus_subdomain" {
   default     = "monitoring-staging"
 }
 
+variable "project" {
+  type        = "string"
+  description = "Which project, in which environment, we're running"
+  default     = "infra-networking-staging"
+}
+
 module "infra-networking" {
   source = "../../modules/infra-networking"
 
   dev_environment      = false
-  stack_name           = "staging"
+  stack_name           = "${var.stack_name}"
   prometheus_subdomain = "${var.prometheus_subdomain}"
+  project              = "${var.project}"
 }
 
 output "vpc_id" {


### PR DESCRIPTION
- We accidentally removed this in the refactor, for all environments.
- We removed Environment too, but this is now implicit in the Project
  value as there's a project per environment.