### PR TITLE
Fix broken tf

### DIFF
--- a/terraform/projects/enclave/dm-test-stack/prometheus/main.tf
+++ b/terraform/projects/enclave/dm-test-stack/prometheus/main.tf
@@ -22,7 +22,7 @@ provider "aws" {
   allowed_account_ids = ["047969882937"]
 }
 
-data "terraform_remote_state" "network" {
+data "terraform_remote_state" "infra_networking" {
   backend = "s3"
 
   config {
@@ -68,8 +68,8 @@ module "prometheus" {
 
   prometheus_public_fqdns = "${data.terraform_remote_state.app_ecs_albs.prom_public_record_fqdns}"
 
-  subnet_ids          = "${data.terraform_remote_state.network.public_subnets}"
-  availability_zones  = "${data.terraform_remote_state.network.subnets_by_az}"
+  subnet_ids          = "${data.terraform_remote_state.infra_networking.public_subnets}"
+  availability_zones  = "${data.terraform_remote_state.infra_networking.subnets_by_az}"
   vpc_security_groups = ["${data.terraform_remote_state.sg.monitoring_external_sg_id}"]
   region              = "eu-west-1"
 }
@@ -80,8 +80,8 @@ module "paas-config" {
   environment              = "${local.environment}"
   prometheus_config_bucket = "${module.prometheus.s3_config_bucket}"
   prom_private_ips         = "${module.prometheus.private_ip_addresses}"
-  private_zone_id          = "${data.terraform_remote_state.network.private_zone_id}"
-  private_subdomain        = "${data.terraform_remote_state.network.private_subdomain}"
+  private_zone_id          = "${data.terraform_remote_state.infra_networking.private_zone_id}"
+  private_subdomain        = "${data.terraform_remote_state.infra_networking.private_subdomain}"
   alertmanager_dns_names   = "${join("\",\"", local.active_alertmanager_private_fqdns)}"
   alerts_path              = "../../../../projects/app-ecs-services/config/alerts/"
 

--- a/terraform/projects/enclave/paas-production/prometheus/main.tf
+++ b/terraform/projects/enclave/paas-production/prometheus/main.tf
@@ -22,7 +22,7 @@ provider "aws" {
   allowed_account_ids = ["455214962221"]
 }
 
-data "terraform_remote_state" "network" {
+data "terraform_remote_state" "infra_networking" {
   backend = "s3"
 
   config {
@@ -83,8 +83,8 @@ module "prometheus" {
 
   prometheus_public_fqdns = "${data.terraform_remote_state.app_ecs_albs.prom_public_record_fqdns}"
 
-  subnet_ids          = "${data.terraform_remote_state.network.public_subnets}"
-  availability_zones  = "${data.terraform_remote_state.network.subnets_by_az}"
+  subnet_ids          = "${data.terraform_remote_state.infra_networking.public_subnets}"
+  availability_zones  = "${data.terraform_remote_state.infra_networking.subnets_by_az}"
   vpc_security_groups = ["${data.terraform_remote_state.sg.monitoring_external_sg_id}"]
   region              = "eu-west-1"
 }
@@ -98,8 +98,8 @@ module "paas-config" {
   alerts_path              = "../../../../projects/app-ecs-services/config/alerts/"
 
   prom_private_ips  = "${module.prometheus.private_ip_addresses}"
-  private_zone_id   = "${data.terraform_remote_state.network.private_zone_id}"
-  private_subdomain = "${data.terraform_remote_state.network.private_subdomain}"
+  private_zone_id   = "${data.terraform_remote_state.infra_networking.private_zone_id}"
+  private_subdomain = "${data.terraform_remote_state.infra_networking.private_subdomain}"
 
   paas_proxy_sg_id = "${data.terraform_remote_state.sg.alertmanager_external_sg_id}"
   prometheus_sg_id = "${module.prometheus.ec2_instance_prometheus_sg}"

--- a/terraform/projects/enclave/paas-staging/prometheus/main.tf
+++ b/terraform/projects/enclave/paas-staging/prometheus/main.tf
@@ -22,7 +22,7 @@ provider "aws" {
   allowed_account_ids = ["027317422673"]
 }
 
-data "terraform_remote_state" "network" {
+data "terraform_remote_state" "infra_networking" {
   backend = "s3"
 
   config {
@@ -73,8 +73,8 @@ module "prometheus" {
 
   prometheus_public_fqdns = "${data.terraform_remote_state.app_ecs_albs.prom_public_record_fqdns}"
 
-  subnet_ids          = "${data.terraform_remote_state.network.public_subnets}"
-  availability_zones  = "${data.terraform_remote_state.network.subnets_by_az}"
+  subnet_ids          = "${data.terraform_remote_state.infra_networking.public_subnets}"
+  availability_zones  = "${data.terraform_remote_state.infra_networking.subnets_by_az}"
   vpc_security_groups = ["${data.terraform_remote_state.sg.monitoring_external_sg_id}"]
   region              = "eu-west-1"
 }
@@ -88,8 +88,8 @@ module "paas-config" {
   alerts_path              = "../../../../projects/app-ecs-services/config/alerts/"
 
   prom_private_ips  = "${module.prometheus.private_ip_addresses}"
-  private_zone_id   = "${data.terraform_remote_state.network.private_zone_id}"
-  private_subdomain = "${data.terraform_remote_state.network.private_subdomain}"
+  private_zone_id   = "${data.terraform_remote_state.infra_networking.private_zone_id}"
+  private_subdomain = "${data.terraform_remote_state.infra_networking.private_subdomain}"
 
   paas_proxy_sg_id = "${data.terraform_remote_state.sg.alertmanager_external_sg_id}"
   prometheus_sg_id = "${module.prometheus.ec2_instance_prometheus_sg}"

--- a/terraform/projects/infra-networking-dev/main.tf
+++ b/terraform/projects/infra-networking-dev/main.tf
@@ -81,3 +81,8 @@ output "private_subdomain" {
   value       = "${module.infra-networking.private_subdomain}"
   description = "This is the subdomain for private zone"
 }
+
+output "subnets_by_az" {
+  value       = "${module.infra-networking.subnets_by_az}"
+  description = "Map of availability zones to private subnets"
+}

--- a/terraform/projects/infra-networking-production/main.tf
+++ b/terraform/projects/infra-networking-production/main.tf
@@ -80,3 +80,8 @@ output "private_subdomain" {
   value       = "${module.infra-networking.private_subdomain}"
   description = "This is the subdomain for private zone"
 }
+
+output "subnets_by_az" {
+  value       = "${module.infra-networking.subnets_by_az}"
+  description = "Map of availability zones to private subnets"
+}

--- a/terraform/projects/infra-networking-staging/main.tf
+++ b/terraform/projects/infra-networking-staging/main.tf
@@ -80,3 +80,8 @@ output "private_subdomain" {
   value       = "${module.infra-networking.private_subdomain}"
   description = "This is the subdomain for private zone"
 }
+
+output "subnets_by_az" {
+  value       = "${module.infra-networking.subnets_by_az}"
+  description = "Map of availability zones to private subnets"
+}


### PR DESCRIPTION
The `subnets_by_az` output was being used by the "enclave" terraform.  This means prometheus-ec2 deploys are currently broken with a weird `value of 'count' cannot be computed` error.