### PR TITLE
Disable ssh outside of tests

### DIFF
--- a/terraform/modules/enclave/prometheus/.kitchen.yml
+++ b/terraform/modules/enclave/prometheus/.kitchen.yml
@@ -26,8 +26,6 @@ suites:
         backend: ssh
         sudo: true
         hosts_output: prometheus_dns
-        key_files:
-          - <%= ENV['SSH_KEY'] || "~/.ssh/id_rsa" %>
         controls:
           - operating_system
         user: <%= ENV['SSH_USER'] || "ubuntu" %>

--- a/terraform/modules/enclave/prometheus/environment-test.sh
+++ b/terraform/modules/enclave/prometheus/environment-test.sh
@@ -1,4 +1,3 @@
-export SSH_KEY="~/.ssh/id_rsa"
 export SSH_USER="ubuntu"
 # sets the test user to your git user name
 export TF_VAR_test_user=$(git config user.name | sed -E 's/[ ]+//g' | awk '{print tolower($0)}')

--- a/terraform/modules/enclave/prometheus/main.tf
+++ b/terraform/modules/enclave/prometheus/main.tf
@@ -8,6 +8,7 @@ locals {
 }
 
 resource "aws_key_pair" "ssh_key" {
+  count      = "${var.enable_ssh}"
   key_name   = "${var.environment}-prom-key"
   public_key = "${file("~/.ssh/id_rsa.pub")}"
 }
@@ -23,7 +24,7 @@ resource "aws_instance" "prometheus" {
 
   associate_public_ip_address = "${local.enable_public_ip}"
 
-  key_name = "${aws_key_pair.ssh_key.key_name}"
+  key_name = "${var.enable_ssh ? aws_key_pair.ssh_key.key_name : ""}"
 
   vpc_security_group_ids = ["${var.vpc_security_groups}", "${aws_security_group.allow_prometheus.id}"]
 

--- a/terraform/projects/enclave/paas-production/prometheus/main.tf
+++ b/terraform/projects/enclave/paas-production/prometheus/main.tf
@@ -72,7 +72,7 @@ module "prometheus" {
 
   # Production
   target_vpc = "vpc-0cdd9631927b526ce"
-  enable_ssh = true
+  enable_ssh = false
 
   product        = "${local.product}"
   environment    = "${local.environment}"

--- a/terraform/projects/enclave/paas-staging/prometheus/main.tf
+++ b/terraform/projects/enclave/paas-staging/prometheus/main.tf
@@ -63,7 +63,7 @@ module "prometheus" {
 
   # Staging
   target_vpc = "vpc-0bbf4123f5b385806"
-  enable_ssh = true
+  enable_ssh = false
 
   product        = "${local.product}"
   environment    = "${local.environment}"


### PR DESCRIPTION
Now that we have Session Manager, we don't need ssh access, so we can
close these security group rules and remove these ssh keys.

We still need ssh support in tests for inspec to gain access to check
resources on the machines, so I've left the `enable_ssh` variable as
configurable and left it to `true` in tests.
