### PR TITLE
DO NOT MERGE: fix app-ecs-albs unclean apply problem

### DIFF
--- a/terraform/projects/app-ecs-albs/main.tf
+++ b/terraform/projects/app-ecs-albs/main.tf
@@ -125,7 +125,7 @@ resource "aws_lb" "monitoring_internal_alb" {
 # https://docs.aws.amazon.com/acm/latest/userguide/managed-renewal.html
 # If this fails, AWS will email associated with the AWS account
 resource "aws_acm_certificate" "monitoring_cert" {
-  domain_name               = "${data.terraform_remote_state.infra_networking.public_subdomain}"
+  domain_name               = "${replace(data.terraform_remote_state.infra_networking.public_subdomain,"/\\.$/","")}"
   validation_method         = "DNS"
   subject_alternative_names = ["${aws_route53_record.prom_alias.*.fqdn}", "${aws_route53_record.alerts_alias.*.fqdn}"]
 }


### PR DESCRIPTION
Something has changed, and now app-ecs-albs doesn't apply cleanly.
The problem is that the domain_name in
aws_acm_certificate.monitoring_cert has a trailing dot that apparently
used not to be there.

This commit is a massive hack to just remove the trailing dot with a
regular expression.  But we should probably find a way to avoid
outputting the dot in the first place.
