### PR TITLE
Remove infra-security-groups from setup.sh deploy list

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -8,8 +8,8 @@ TERRAFORMBACKVARS=$(pwd)/stacks/${ENV}.backend
 TERRAFORMTFVARS=$(pwd)/stacks/${ENV}.tfvars
 ROOTPROJ=$(pwd)
 TERRAFORMPROJ=$(pwd)/terraform/projects/
-declare -a COMPONENTS=("infra-security-groups" "app-ecs-instances" "app-ecs-albs" "app-ecs-services")
-declare -a COMPONENTSDESTROY=("app-ecs-services" "app-ecs-albs" "app-ecs-instances" "infra-security-groups")
+declare -a COMPONENTS=("app-ecs-instances" "app-ecs-albs" "app-ecs-services")
+declare -a COMPONENTSDESTROY=("app-ecs-services" "app-ecs-albs" "app-ecs-instances")
 
 
 ############ Actions #################


### PR DESCRIPTION
- It's now modularized and deployable via terraform commands directly.