### PR TITLE
[untested] Tighten prom ec2 sg rules

### DIFF
--- a/terraform/modules/enclave/prometheus/main.tf
+++ b/terraform/modules/enclave/prometheus/main.tf
@@ -96,12 +96,13 @@ resource "aws_security_group_rule" "allow_prometheus" {
 }
 
 resource "aws_security_group_rule" "allow_prometheus_private" {
-  security_group_id = "${aws_security_group.allow_prometheus.id}"
-  type              = "ingress"
-  from_port         = 9090
-  to_port           = 9090
-  protocol          = "tcp"
-  cidr_blocks       = ["10.0.0.0/16"]
+  count                    = "${var.source_security_group == "" ? 0 : 1}"
+  security_group_id        = "${aws_security_group.allow_prometheus.id}"
+  type                     = "ingress"
+  from_port                = 9090
+  to_port                  = 9090
+  protocol                 = "tcp"
+  source_security_group_id = "${var.source_security_group}"
 }
 
 resource "aws_security_group_rule" "allow_prometheus_node_exporter" {

--- a/terraform/modules/enclave/prometheus/main.tf
+++ b/terraform/modules/enclave/prometheus/main.tf
@@ -105,12 +105,12 @@ resource "aws_security_group_rule" "allow_prometheus_private" {
 }
 
 resource "aws_security_group_rule" "allow_prometheus_node_exporter" {
-  security_group_id = "${aws_security_group.allow_prometheus.id}"
-  type              = "ingress"
-  from_port         = 9100
-  to_port           = 9100
-  protocol          = "tcp"
-  cidr_blocks       = ["10.0.0.0/16"]
+  security_group_id        = "${aws_security_group.allow_prometheus.id}"
+  type                     = "ingress"
+  from_port                = 9100
+  to_port                  = 9100
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_security_group.allow_prometheus.id}"
 }
 
 resource "aws_security_group" "allow_prometheus" {

--- a/terraform/modules/enclave/prometheus/variables.tf
+++ b/terraform/modules/enclave/prometheus/variables.tf
@@ -31,8 +31,15 @@ variable "product" {}
 variable "environment" {}
 
 variable "vpc_security_groups" {
-  type    = "list"
-  default = []
+  type        = "list"
+  default     = []
+  description = "Security groups to attach to the prometheus instances"
+}
+
+variable "source_security_group" {
+  type        = "string"
+  default     = ""
+  description = "Security group which should be allowed to access port 9090 on the prometheus instances"
 }
 
 variable "enable_ssh" {

--- a/terraform/projects/enclave/dm-test-stack/prometheus/main.tf
+++ b/terraform/projects/enclave/dm-test-stack/prometheus/main.tf
@@ -68,10 +68,11 @@ module "prometheus" {
 
   prometheus_public_fqdns = "${data.terraform_remote_state.app_ecs_albs.prom_public_record_fqdns}"
 
-  subnet_ids          = "${data.terraform_remote_state.infra_networking.public_subnets}"
-  availability_zones  = "${data.terraform_remote_state.infra_networking.subnets_by_az}"
-  vpc_security_groups = ["${data.terraform_remote_state.infra_security_groups.monitoring_external_sg_id}"]
-  region              = "eu-west-1"
+  subnet_ids            = "${data.terraform_remote_state.infra_networking.public_subnets}"
+  availability_zones    = "${data.terraform_remote_state.infra_networking.subnets_by_az}"
+  vpc_security_groups   = ["${data.terraform_remote_state.infra_security_groups.monitoring_external_sg_id}"]
+  source_security_group = "${data.terraform_remote_state.infra_security_groups.monitoring_internal_sg_id}"
+  region                = "eu-west-1"
 }
 
 module "paas-config" {

--- a/terraform/projects/enclave/issy/prometheus/main.tf
+++ b/terraform/projects/enclave/issy/prometheus/main.tf
@@ -67,6 +67,7 @@ module "prometheus" {
   subnet_ids              = "${data.terraform_remote_state.infra_networking.public_subnets}"
   availability_zones      = "${data.terraform_remote_state.infra_networking.subnets_by_az}"
   vpc_security_groups     = ["${data.terraform_remote_state.infra_security_groups.monitoring_external_sg_id}"]
+  source_security_group   = "${data.terraform_remote_state.infra_security_groups.monitoring_internal_sg_id}"
   region                  = "eu-west-1"
 }
 

--- a/terraform/projects/enclave/paas-production/prometheus/main.tf
+++ b/terraform/projects/enclave/paas-production/prometheus/main.tf
@@ -83,10 +83,11 @@ module "prometheus" {
 
   prometheus_public_fqdns = "${data.terraform_remote_state.app_ecs_albs.prom_public_record_fqdns}"
 
-  subnet_ids          = "${data.terraform_remote_state.infra_networking.private_subnets}"
-  availability_zones  = "${data.terraform_remote_state.infra_networking.subnets_by_az}"
-  vpc_security_groups = ["${data.terraform_remote_state.infra_security_groups.monitoring_external_sg_id}"]
-  region              = "eu-west-1"
+  subnet_ids            = "${data.terraform_remote_state.infra_networking.private_subnets}"
+  availability_zones    = "${data.terraform_remote_state.infra_networking.subnets_by_az}"
+  vpc_security_groups   = ["${data.terraform_remote_state.infra_security_groups.monitoring_external_sg_id}"]
+  source_security_group = "${data.terraform_remote_state.infra_security_groups.monitoring_internal_sg_id}"
+  region                = "eu-west-1"
 }
 
 module "paas-config" {

--- a/terraform/projects/enclave/paas-staging/prometheus/main.tf
+++ b/terraform/projects/enclave/paas-staging/prometheus/main.tf
@@ -73,10 +73,11 @@ module "prometheus" {
 
   prometheus_public_fqdns = "${data.terraform_remote_state.app_ecs_albs.prom_public_record_fqdns}"
 
-  subnet_ids          = "${data.terraform_remote_state.infra_networking.private_subnets}"
-  availability_zones  = "${data.terraform_remote_state.infra_networking.subnets_by_az}"
-  vpc_security_groups = ["${data.terraform_remote_state.infra_security_groups.monitoring_external_sg_id}"]
-  region              = "eu-west-1"
+  subnet_ids            = "${data.terraform_remote_state.infra_networking.private_subnets}"
+  availability_zones    = "${data.terraform_remote_state.infra_networking.subnets_by_az}"
+  vpc_security_groups   = ["${data.terraform_remote_state.infra_security_groups.monitoring_external_sg_id}"]
+  source_security_group = "${data.terraform_remote_state.infra_security_groups.monitoring_internal_sg_id}"
+  region                = "eu-west-1"
 }
 
 module "paas-config" {


### PR DESCRIPTION
# Why I am making this change

We had some pretty lax security group rules which allowed all traffic from the whole VPC.  We should be more specific with security group rules.

# What approach I took

Allow the caller of the `prometheus` module to specify a source security group which is allowed to access port 9090.

Warning: this code is untested.  The kitchen tests don't exercise the code path because they allow us to hit prometheus directly.  I'm not really sure how to test it - suggestions, anyone?