### PR TITLE
Revert "add security group description"

### DIFF
--- a/terraform/modules/enclave/prometheus/main.tf
+++ b/terraform/modules/enclave/prometheus/main.tf
@@ -114,9 +114,8 @@ resource "aws_security_group_rule" "allow_prometheus_node_exporter" {
 }
 
 resource "aws_security_group" "allow_prometheus" {
-  name        = "${var.product}-${var.environment}-sg"
-  vpc_id      = "${var.target_vpc}"
-  description = "Allows access to prometheus and node_exporter ports"
+  name   = "${var.product}-${var.environment}-sg"
+  vpc_id = "${var.target_vpc}"
 }
 
 resource "aws_s3_bucket" "prometheus_config" {


### PR DESCRIPTION
Reverts alphagov/prometheus-aws-configuration-beta#207

You can't change a security group description without destroying and recreating it.  Which makes deploying this change pretty difficult. 🤯