### PR TITLE
fix kitchen terraform

### DIFF
--- a/terraform/modules/enclave/prometheus/test/prometheus-paas/prometheus.tf
+++ b/terraform/modules/enclave/prometheus/test/prometheus-paas/prometheus.tf
@@ -28,7 +28,7 @@ module "paas-config" {
 
   environment              = "${local.environment}"
   prometheus_config_bucket = "${module.prometheus.s3_config_bucket}"
-  alertmanager_dns_names   = "${join("\",\"", local.active_alertmanager_private_fqdns)}"
+  alertmanager_dns_names   = "${local.active_alertmanager_private_fqdns}"
   alerts_path              = "${path.module}/../../../../../projects/app-ecs-services/config/alerts/"
 
   prom_private_ips  = "${module.prometheus.private_ip_addresses}"


### PR DESCRIPTION
We refactored alertmanager_dns_names in a263c59 but forgot about this
usage of it.

