### PR TITLE
add sample prometheus config for generating an alert

### DIFF
--- a/tools/prometheus-configs/send-an-alert/prometheus.yml
+++ b/tools/prometheus-configs/send-an-alert/prometheus.yml
@@ -1,0 +1,30 @@
+#
+# This config exists as a demonstration of generating an alert with particular
+# labels and sending to an alertmanager.
+#
+# We add env:local-dev as an external_label to make clear what's going
+# on in the alertmanager
+#
+# Just run `prometheus` without any arguments from this directory.
+global:
+  scrape_interval: 30s
+  evaluation_interval: 30s
+  external_labels:
+    env: local-dev
+
+rule_files:
+  - 'rules/*'
+
+alerting:
+  alertmanagers:
+  # # Here is an example configuration for sending to a specific alertmanager:
+  # # it is commented out by default to avoid annoying the support person
+  # - scheme: https
+  #   static_configs:
+  #   - targets:
+  #     - 'alertman.cluster.re-managed-observe-staging.aws.ext.govsvc.uk'
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]

--- a/tools/prometheus-configs/send-an-alert/rules/alerts.yml
+++ b/tools/prometheus-configs/send-an-alert/rules/alerts.yml
@@ -1,0 +1,11 @@
+---
+groups:
+- name: MyGroup
+  rules:
+  - alert: AlwaysAlert
+    expr: 1
+    labels:
+      severity: page
+      product: prometheus
+    annotations:
+      summary: "This is a test alert that always fires."


### PR DESCRIPTION
# Why I am making this change

It's not trivial to deliberately generate an alert to test an alertmanager out, but one way to do it is to have a local prometheus that always alerts and point it at the alertmanager in question.

# What approach I took

This PR just adds an example prometheus config to show how to do this.