### PR TITLE
hotfix: allow prometheus to scrape other prometheis

### DIFF
--- a/terraform/modules/enclave/prometheus/main.tf
+++ b/terraform/modules/enclave/prometheus/main.tf
@@ -105,6 +105,15 @@ resource "aws_security_group_rule" "allow_prometheus_private" {
   source_security_group_id = "${var.source_security_group}"
 }
 
+resource "aws_security_group_rule" "allow_prometheus_self" {
+  security_group_id        = "${aws_security_group.allow_prometheus.id}"
+  type                     = "ingress"
+  from_port                = 9090
+  to_port                  = 9090
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_security_group.allow_prometheus.id}"
+}
+
 resource "aws_security_group_rule" "allow_prometheus_node_exporter" {
   security_group_id        = "${aws_security_group.allow_prometheus.id}"
   type                     = "ingress"


### PR DESCRIPTION
The previous commits in #212 that tightened up the security group
rules had the unintended effect of preventing each prometheus from
scraping each other prometheus.

To fix this we need to explicitly allow connections on 9090 from the
prometheus security group to itself.

Deployed and tested in staging.