### PR TITLE
Change eu-west-2 to eu-west-1

### DIFF
--- a/terraform/modules/enclave/README.md
+++ b/terraform/modules/enclave/README.md
@@ -13,8 +13,9 @@ We deploy using raw Terraform commands, scoped per environment.  We also run tes
 Follow these steps to run infrastructure tests:
 
 1. Navigate to `terraform/modules/enclave/prometheus`
-2. `bundle install` - install all dependencies to your environment.
-3. `aws-vault exec <your gds-tech-ops profile> -- kitchen <action> <optional target>` this is the general command that you can use in order to run the environment.
+2. `source environment-test.sh`
+3. `bundle install` - install all dependencies to your environment.
+4. `aws-vault exec <your gds-tech-ops profile> -- kitchen <action> <optional target>` this is the general command that you can use in order to run the environment.
   - actions
     - `test` - use this action to run through the tests unless you are developing the tests themselves.
     - `create`, `converge`, `verify` these are the three actions that can used in order to spin up a stack and test. The converge can be executed multiple times to test changes.

--- a/terraform/modules/enclave/prometheus/cloud.conf
+++ b/terraform/modules/enclave/prometheus/cloud.conf
@@ -62,12 +62,8 @@ write_files:
   - content: ''
     path: '/etc/apt/sources.list'
 
-bootcmd:
-  - "if [ '${egress_proxy}' ]; then echo 'writing proxy config' && echo 'Acquire::http::Proxy \"http://${egress_proxy}\";' > /etc/apt/apt.conf.d/05proxy; fi"
-
 runcmd:
   - "if [ -n '${logstash_host}' ]; then /root/setup_filebeat.sh; fi"
-  - "if [ '${aws_ec2_ip}' ]; then echo '${aws_ec2_ip} ec2.eu-west-1.amazonaws.com' >> /etc/hosts; fi"
   - [bash, -c, "/root/format_disk.sh"]
   - [bash, -c, "mount /dev/xvdh /mnt"]
   - [bash, -c, "chown -R prometheus /mnt/"]

--- a/terraform/modules/enclave/prometheus/cloud.conf
+++ b/terraform/modules/enclave/prometheus/cloud.conf
@@ -1,10 +1,4 @@
 #cloud-config
-apt_preserve_sources_list: true
-apt_sources:
- - source: "deb [arch=amd64] http://www.mirrorservice.org/sites/archive.ubuntu.com/ubuntu bionic main restricted universe multiverse"
- - source: "deb [arch=amd64] http://www.mirrorservice.org/sites/archive.ubuntu.com/ubuntu bionic-security main restricted universe multiverse"
- - source: "deb [arch=amd64] http://www.mirrorservice.org/sites/archive.ubuntu.com/ubuntu bionic-updates main restricted universe multiverse"
-
 package_update: true
 package_upgrade: true
 packages: ['prometheus', 'prometheus-node-exporter', 'awscli', 'inotify-tools']
@@ -58,9 +52,6 @@ write_files:
       update-rc.d filebeat enable 5
     path: /root/setup_filebeat.sh
     permissions: 0755
-# Remove the default ubuntu repositories from the sources list
-  - content: ''
-    path: '/etc/apt/sources.list'
 
 runcmd:
   - "if [ -n '${logstash_host}' ]; then /root/setup_filebeat.sh; fi"

--- a/terraform/modules/enclave/prometheus/cloud.conf
+++ b/terraform/modules/enclave/prometheus/cloud.conf
@@ -67,7 +67,7 @@ bootcmd:
 
 runcmd:
   - "if [ -n '${logstash_host}' ]; then /root/setup_filebeat.sh; fi"
-  - "if [ '${aws_ec2_ip}' ]; then echo '${aws_ec2_ip} ec2.eu-west-2.amazonaws.com' >> /etc/hosts; fi"
+  - "if [ '${aws_ec2_ip}' ]; then echo '${aws_ec2_ip} ec2.eu-west-1.amazonaws.com' >> /etc/hosts; fi"
   - [bash, -c, "/root/format_disk.sh"]
   - [bash, -c, "mount /dev/xvdh /mnt"]
   - [bash, -c, "chown -R prometheus /mnt/"]

--- a/terraform/modules/enclave/prometheus/main.tf
+++ b/terraform/modules/enclave/prometheus/main.tf
@@ -66,8 +66,6 @@ data "template_file" "user_data_script" {
 
   vars {
     config_bucket     = "${aws_s3_bucket.prometheus_config.id}"
-    egress_proxy      = "${var.egress_proxy}"
-    aws_ec2_ip        = "${var.ec2_endpoint_ips[0]}"
     region            = "${var.region}"
     targets_bucket    = "${var.targets_bucket}"
     alerts_bucket     = "${aws_s3_bucket.prometheus_config.id}"

--- a/terraform/modules/enclave/prometheus/test/integration/paas/controls/operating_system.rb
+++ b/terraform/modules/enclave/prometheus/test/integration/paas/controls/operating_system.rb
@@ -1,5 +1,5 @@
 control "operating_system" do
-  
+
   describe os.family do
     it { should eq 'debian' }
   end
@@ -46,11 +46,6 @@ control "operating_system" do
     it { should be_mounted }
     its('device') { should eq  '/dev/xvdh' }
     its('type') { should eq  'ext4' }
-  end
-
-  describe apt('http://www.mirrorservice.org/sites/archive.ubuntu.com/ubuntu') do
-    it { should exist }
-    it { should be_enabled }
   end
 
   describe file('/etc/apt/apt.conf.d/05proxy') do

--- a/terraform/modules/enclave/prometheus/variables.tf
+++ b/terraform/modules/enclave/prometheus/variables.tf
@@ -46,17 +46,8 @@ variable "enable_ssh" {
   default = false
 }
 
-variable "ec2_endpoint_ips" {
-  type    = "list"
-  default = [""]
-}
-
 variable "region" {
   default = "eu-west-1"
-}
-
-variable "egress_proxy" {
-  default = ""
 }
 
 variable "allowed_cidrs" {

--- a/terraform/modules/enclave/prometheus/variables.tf
+++ b/terraform/modules/enclave/prometheus/variables.tf
@@ -52,7 +52,7 @@ variable "ec2_endpoint_ips" {
 }
 
 variable "region" {
-  default = "eu-west-2"
+  default = "eu-west-1"
 }
 
 variable "egress_proxy" {


### PR DESCRIPTION
We no longer deploy prometheus to verify-perf-a in eu-west-2
and therefore we no longer need to run kitchen tests in
eu-west-2 either. Everything now should run in eu-west-1 so our
code should reflect that. I've grepped the code for 'eu-west-2' and also 'london' and these
are the only things I could find.

I've also removed other verify specific code that is no longer used.