### PR TITLE
fix kitchen tests

### DIFF
--- a/terraform/modules/enclave/prometheus/main.tf
+++ b/terraform/modules/enclave/prometheus/main.tf
@@ -24,7 +24,7 @@ resource "aws_instance" "prometheus" {
 
   associate_public_ip_address = "${local.enable_public_ip}"
 
-  key_name = "${var.enable_ssh ? format("$s-prom-key", var.environment) : ""}"
+  key_name = "${var.enable_ssh ? format("%s-prom-key", var.environment) : ""}"
 
   vpc_security_group_ids = ["${var.vpc_security_groups}", "${aws_security_group.allow_prometheus.id}"]
 

--- a/terraform/modules/enclave/prometheus/test/integration/paas/controls/aws_cloud_resources.rb
+++ b/terraform/modules/enclave/prometheus/test/integration/paas/controls/aws_cloud_resources.rb
@@ -18,7 +18,6 @@ ENV['AWS_REGION'] = 'eu-west-1'
 control "aws_cloud_resources" do
   describe aws_ec2_instance(prometheus_instance_id) do
     its('tags') { should include(key: 'ManagedBy', value: 'terraform')}
-    its('image_id') { should eq 'ami-0ee06eb8d6eebcde0' }
     its('root_device_type') { should eq 'ebs'}
     its('root_device_name') { should eq '/dev/sda1'}
     its('architecture') { should eq 'x86_64'}

--- a/terraform/modules/enclave/prometheus/test/prometheus-paas/prometheus.tf
+++ b/terraform/modules/enclave/prometheus/test/prometheus-paas/prometheus.tf
@@ -29,7 +29,7 @@ module "paas-config" {
   environment              = "${local.environment}"
   prometheus_config_bucket = "${module.prometheus.s3_config_bucket}"
   alertmanager_dns_names   = "${local.active_alertmanager_private_fqdns}"
-  alerts_path              = "${path.module}/../../../../../projects/app-ecs-services/config/alerts/"
+  alerts_path              = "${path.module}/../../../../../modules/app-ecs-services/config/alerts/"
 
   prom_private_ips  = "${module.prometheus.private_ip_addresses}"
   private_zone_id   = "${aws_route53_zone.private.zone_id}"


### PR DESCRIPTION
3 fixes:

 - typo in a format string in main.tf
 - missed directory change from projects/ to modules/ in prometheus.tf
 - removed test on explicit AMI

The third one deserves some explanation: we used to specify a specific
AMI, but that meant we would not keep up to date with updated
ubuntu images from canonical.

Now that we use the `ami` module to search for the most recent
official canonical AMI, this test doesn't feel useful.  It's
particularly not a test of the `prometheus` module which just uses
whatever AMI you tell it to - if anything, the only thing I think we
could test is whether the common/ami module really does return an AMI
which is an official ubuntu one.  But I think that'd be overkill.

