### PR TITLE
Use cf_app_instance query parameter

### DIFF
--- a/terraform/modules/app-ecs-services/config/vhosts/paas-proxy.conf
+++ b/terraform/modules/app-ecs-services/config/vhosts/paas-proxy.conf
@@ -4,7 +4,7 @@ server {
   location / {
     proxy_pass https://$host$uri;
     proxy_ssl_server_name on;
-    proxy_set_header X-CF-APP-INSTANCE $arg_cf_app_guid:$arg_cf_app_instance_index;
+    proxy_set_header X-CF-APP-INSTANCE $arg_cf_app_instance;
     proxy_set_header Authorization "Bearer $arg_cf_app_guid";
   }
 


### PR DESCRIPTION
After alphagov/cf_app_discovery#27 introduced the `cf_app_instance`
query parameter, we should use it in our paas-proxy config.

This will allow us to get rid of the `cf_app_instance_index`
parameter.  We still need `cf_app_guid` for the Bearer auth, but it
could go in future.

