### PR TITLE
hotfix: specify module paths in app-ecs-services

### DIFF
--- a/terraform/modules/app-ecs-services/nginx-auth-proxy.tf
+++ b/terraform/modules/app-ecs-services/nginx-auth-proxy.tf
@@ -66,6 +66,6 @@ resource "aws_s3_bucket_object" "nginx-auth-proxy" {
 resource "aws_s3_bucket_object" "nginx-htpasswd" {
   bucket = "${aws_s3_bucket.config_bucket.id}"
   key    = "prometheus/nginx-auth-proxy/conf.d/.htpasswd"
-  source = "config/vhosts/.htpasswd"
+  source = "${path.module}/config/vhosts/.htpasswd"
   etag   = "${md5(file("${path.module}/config/vhosts/.htpasswd"))}"
 }

--- a/terraform/modules/app-ecs-services/paas-proxy.tf
+++ b/terraform/modules/app-ecs-services/paas-proxy.tf
@@ -39,6 +39,6 @@ resource "aws_ecs_service" "paas_proxy_service" {
 resource "aws_s3_bucket_object" "nginx-paas-proxy" {
   bucket = "${aws_s3_bucket.config_bucket.id}"
   key    = "prometheus/paas-proxy/conf.d/prometheus-paas-proxy.conf"
-  source = "config/vhosts/paas-proxy.conf"
+  source = "${path.module}/config/vhosts/paas-proxy.conf"
   etag   = "${md5(file("${path.module}/config/vhosts/paas-proxy.conf"))}"
 }


### PR DESCRIPTION
`terraform plan` worked fine, but when I tried to `terraform apply`, i
got an error that it couldn't find these files.  Grr, I thought the
whole point of a plan was to give you confidence that the apply would
work.

I've already deployed this, this PR is just to capture what I did.