### PR TITLE
Revert "Use cf_app_instance query parameter"

### DIFF
--- a/terraform/modules/app-ecs-services/config/vhosts/paas-proxy.conf
+++ b/terraform/modules/app-ecs-services/config/vhosts/paas-proxy.conf
@@ -4,7 +4,7 @@ server {
   location / {
     proxy_pass https://$host$uri;
     proxy_ssl_server_name on;
-    proxy_set_header X-CF-APP-INSTANCE $arg_cf_app_instance;
+    proxy_set_header X-CF-APP-INSTANCE $arg_cf_app_guid:$arg_cf_app_instance_index;
     proxy_set_header Authorization "Bearer $arg_cf_app_guid";
   }
 


### PR DESCRIPTION
Reverts alphagov/prometheus-aws-configuration-beta#230

The deploy broke when going to staging; we're not sure why, but we're pushing this out to see if it fixes it