### PR TITLE
use cf_app_instance arg

### DIFF
--- a/terraform/modules/app-ecs-services/config/vhosts/paas-proxy.conf
+++ b/terraform/modules/app-ecs-services/config/vhosts/paas-proxy.conf
@@ -2,9 +2,13 @@ server {
   listen 8080;
 
   location / {
+    set $cleaned_header $arg_cf_app_instance;
+    if ($arg_cf_app_instance ~* "^(.*)%3A(.*)$") {
+      set $cleaned_header $1:$2;
+    }
     proxy_pass https://$host$uri;
     proxy_ssl_server_name on;
-    proxy_set_header X-CF-APP-INSTANCE $arg_cf_app_guid:$arg_cf_app_instance_index;
+    proxy_set_header X-CF-APP-INSTANCE $cleaned_header;
     proxy_set_header Authorization "Bearer $arg_cf_app_guid";
   }
 


### PR DESCRIPTION
This is a retry of #230.  #230 failed because it took the URL-encoded
query parameter and passed it through as the header to cloud foundry.
Because gorouter didn't recognise the instance identifier when it had
`%3A` in place of `:`, it returned a 404 and a failed scrape.

This fix is fugly -- we explicitly search for the `%3A` string -- but
I can't find a way to just get the unescaped value of a query argument
in nginx.  :(

