### PR TITLE
Add auth proxy onto Prometheus EC2 instance

### DIFF
--- a/terraform/modules/prom-ec2/prometheus/.kitchen.yml
+++ b/terraform/modules/prom-ec2/prometheus/.kitchen.yml
@@ -28,6 +28,7 @@ suites:
         hosts_output: prometheus_dns
         controls:
           - operating_system
+          - prometheus
         user: <%= ENV['SSH_USER'] || "ubuntu" %>
     excludes:
       - west2

--- a/terraform/modules/prom-ec2/prometheus/cloud.conf
+++ b/terraform/modules/prom-ec2/prometheus/cloud.conf
@@ -101,8 +101,6 @@ write_files:
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
-        resolver 10.0.0.2 valid=10s;
-
         satisfy any;
         auth_basic "Prometheus";
         auth_basic_user_file /etc/nginx/conf.d/.htpasswd;

--- a/terraform/modules/prom-ec2/prometheus/cloud.conf
+++ b/terraform/modules/prom-ec2/prometheus/cloud.conf
@@ -75,8 +75,54 @@ write_files:
       }
     path: /etc/nginx/sites-enabled/paas-proxy
     permissions: 0644
+  - content: |
+      ${prometheus_htpasswd}
+    path: /etc/nginx/conf.d/.htpasswd
+    owner: www-data:www-data
+    permissions: 0600
+  - content: |
+      server {
+        listen 80 default_server;
+
+        location /health {
+          # This location is not protected by basic auth because of
+          # https://stackoverflow.com/questions/40447376/auth-basic-within-location-block-doesnt-work-when-return-is-specified
+          return 200 "Static health check";
+        }
+
+        if ($http_x_forwarded_proto = 'http') {
+          return 301 https://$host$request_uri;
+        }
+
+        location / {
+          proxy_pass  http://localhost:9090;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header Host $host;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        resolver 10.0.0.2 valid=10s;
+
+        satisfy any;
+        auth_basic "Prometheus";
+        auth_basic_user_file /etc/nginx/conf.d/.htpasswd;
+
+        real_ip_header X-Forwarded-For;
+        set_real_ip_from 10.0.0.0/8;
+        set_real_ip_from 127.0.0.1/32;
+        allow 213.86.153.212/32;
+        allow 213.86.153.213/32;
+        allow 213.86.153.214/32;
+        allow 213.86.153.235/32;
+        allow 213.86.153.236/32;
+        allow 213.86.153.237/32;
+        allow 85.133.67.244/32;
+        deny all;
+      }
+    path: /etc/nginx/sites-enabled/auth-proxy
 
 runcmd:
+  - rm /etc/nginx/sites-enabled/default
   - "if [ -n '${logstash_host}' ]; then /root/setup_filebeat.sh; fi"
   - [bash, -c, "/root/format_disk.sh"]
   - [bash, -c, "mount /dev/xvdh /mnt"]

--- a/terraform/modules/prom-ec2/prometheus/main.tf
+++ b/terraform/modules/prom-ec2/prometheus/main.tf
@@ -65,12 +65,13 @@ data "template_file" "user_data_script" {
   template = "${file("${path.module}/cloud.conf")}"
 
   vars {
-    config_bucket     = "${aws_s3_bucket.prometheus_config.id}"
-    region            = "${var.region}"
-    targets_bucket    = "${var.targets_bucket}"
-    alerts_bucket     = "${aws_s3_bucket.prometheus_config.id}"
-    prom_external_url = "https://${var.prometheus_public_fqdns[count.index]}"
-    logstash_host     = "${var.logstash_host}"
+    config_bucket       = "${aws_s3_bucket.prometheus_config.id}"
+    region              = "${var.region}"
+    targets_bucket      = "${var.targets_bucket}"
+    alerts_bucket       = "${aws_s3_bucket.prometheus_config.id}"
+    prom_external_url   = "https://${var.prometheus_public_fqdns[count.index]}"
+    logstash_host       = "${var.logstash_host}"
+    prometheus_htpasswd = "${var.prometheus_htpasswd}"
   }
 }
 

--- a/terraform/modules/prom-ec2/prometheus/test/integration/paas/controls/operating_system.rb
+++ b/terraform/modules/prom-ec2/prometheus/test/integration/paas/controls/operating_system.rb
@@ -68,10 +68,6 @@ control "operating_system" do
     it { should be_running }
   end
 
-  describe package('nginx') do
-    it { should be_installed }
-  end
-
   describe package('prometheus') do
     it { should be_installed }
   end

--- a/terraform/modules/prom-ec2/prometheus/test/integration/paas/controls/operating_system.rb
+++ b/terraform/modules/prom-ec2/prometheus/test/integration/paas/controls/operating_system.rb
@@ -27,6 +27,19 @@ control "operating_system" do
     its('processes') {should include 'nginx'}
   end
 
+  describe http('http://localhost/health') do
+    its('status') {should cmp 200}
+    its('body') {should cmp 'Static health check'}
+  end
+
+  describe http('http://localhost/') do
+    its('status') {should cmp 401}
+  end
+
+  describe http('http://localhost/'), auth: {user: 'grafana', pass: 'hello world'} do
+    its('status') {should_not cmp 401}
+  end
+
   describe port(8080) do
     it { should be_listening }
     its('processes') {should include 'nginx'}

--- a/terraform/modules/prom-ec2/prometheus/test/integration/paas/controls/operating_system.rb
+++ b/terraform/modules/prom-ec2/prometheus/test/integration/paas/controls/operating_system.rb
@@ -22,6 +22,11 @@ control "operating_system" do
     its('mode')  { should cmp '0755'}
   end
 
+  describe port(80) do
+    it { should be_listening }
+    its('processes') {should include 'nginx'}
+  end
+
   describe port(8080) do
     it { should be_listening }
     its('processes') {should include 'nginx'}

--- a/terraform/modules/prom-ec2/prometheus/test/integration/paas/controls/operating_system.rb
+++ b/terraform/modules/prom-ec2/prometheus/test/integration/paas/controls/operating_system.rb
@@ -36,7 +36,7 @@ control "operating_system" do
     its('status') {should cmp 401}
   end
 
-  describe http('http://localhost/'), auth: {user: 'grafana', pass: 'hello world'} do
+  describe http('http://localhost/', auth: {user: 'grafana', pass: 'hello world'}) do
     its('status') {should_not cmp 401}
   end
 

--- a/terraform/modules/prom-ec2/prometheus/test/integration/paas/controls/operating_system.rb
+++ b/terraform/modules/prom-ec2/prometheus/test/integration/paas/controls/operating_system.rb
@@ -1,65 +1,8 @@
-control "operating_system" do
+# generic tests we would expect of every node
 
+control "operating_system" do
   describe os.family do
     it { should eq 'debian' }
-  end
-
-  describe file('/etc/cron.d/config_pull') do
-    its('owner') { should eq 'root' }
-    its('group') { should eq 'root' }
-    its('mode')  { should cmp '0755'}
-  end
-
-  describe file('/root/format_disk.sh') do
-    its('owner') { should eq 'root' }
-    its('group') { should eq 'root' }
-    its('mode')  { should cmp '0755'}
-  end
-
-  describe file('/root/watch_prometheus_dir') do
-    its('owner') { should eq 'root' }
-    its('group') { should eq 'root' }
-    its('mode')  { should cmp '0755'}
-  end
-
-  describe port(80) do
-    it { should be_listening }
-    its('processes') {should include 'nginx'}
-  end
-
-  describe http('http://localhost/health') do
-    its('status') {should cmp 200}
-    its('body') {should cmp 'Static health check'}
-  end
-
-  describe http('http://localhost/') do
-    its('status') {should cmp 401}
-  end
-
-  describe http('http://localhost/', auth: {user: 'grafana', pass: 'hello world'}) do
-    its('status') {should_not cmp 401}
-  end
-
-  describe port(8080) do
-    it { should be_listening }
-    its('processes') {should include 'nginx'}
-  end
-
-  describe port(9090) do
-    it { should be_listening }
-    its('processes') {should include 'prometheus'}
-  end
-
-  describe service('nginx') do
-    it { should be_installed }
-    it { should be_enabled }
-    it { should be_running }
-  end
-
-  describe service('prometheus') do
-    it { should be_installed }
-    it { should be_enabled }
-    it { should be_running }
   end
 
   describe service('prometheus-node-exporter') do
@@ -68,21 +11,12 @@ control "operating_system" do
     it { should be_running }
   end
 
-  describe package('prometheus') do
-    it { should be_installed }
-  end
-
   describe package('prometheus-node-exporter') do
     it { should be_installed }
   end
 
-  describe mount('/mnt') do
-    it { should be_mounted }
-    its('device') { should eq  '/dev/xvdh' }
-    its('type') { should eq  'ext4' }
-  end
-
-  describe directory('/etc/prometheus/targets') do
-    it { should exist }
+  describe port(9100) do
+    it { should be_listening }
+    its('processes') {should include 'prometheus-node'}
   end
 end

--- a/terraform/modules/prom-ec2/prometheus/test/integration/paas/controls/prometheus.rb
+++ b/terraform/modules/prom-ec2/prometheus/test/integration/paas/controls/prometheus.rb
@@ -1,0 +1,79 @@
+control "prometheus" do
+
+  # basic prometheus functionality
+  describe package('prometheus') do
+    it { should be_installed }
+  end
+
+  describe service('prometheus') do
+    it { should be_installed }
+    it { should be_enabled }
+    it { should be_running }
+  end
+
+  describe port(9090) do
+    it { should be_listening }
+    its('processes') {should include 'prometheus'}
+  end
+
+  # prometheus backing storage
+  describe mount('/mnt') do
+    it { should be_mounted }
+    its('device') { should eq  '/dev/xvdh' }
+    its('type') { should eq  'ext4' }
+  end
+
+  describe file('/root/format_disk.sh') do
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('mode')  { should cmp '0755'}
+  end
+
+  # prometheus configuration for scraping the paas
+  describe file('/etc/cron.d/config_pull') do
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('mode')  { should cmp '0755'}
+  end
+
+  describe file('/root/watch_prometheus_dir') do
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('mode')  { should cmp '0755'}
+  end
+
+  describe directory('/etc/prometheus/targets') do
+    it { should exist }
+  end
+
+  # http proxy for managing X-Cf-App-Instance headers
+  describe port(8080) do
+    it { should be_listening }
+    its('processes') {should include 'nginx'}
+  end
+
+  # nginx fronting prometheus with auth
+  describe port(80) do
+    it { should be_listening }
+    its('processes') {should include 'nginx'}
+  end
+
+  describe http('http://localhost/health') do
+    its('status') {should cmp 200}
+    its('body') {should cmp 'Static health check'}
+  end
+
+  describe http('http://localhost/') do
+    its('status') {should cmp 401}
+  end
+
+  describe http('http://localhost/', auth: {user: 'grafana', pass: 'hello world'}) do
+    its('status') {should_not cmp 401}
+  end
+
+  describe service('nginx') do
+    it { should be_installed }
+    it { should be_enabled }
+    it { should be_running }
+  end
+end

--- a/terraform/modules/prom-ec2/prometheus/test/prometheus-paas/prometheus.tf
+++ b/terraform/modules/prom-ec2/prometheus/test/prometheus-paas/prometheus.tf
@@ -21,6 +21,9 @@ module "prometheus" {
   availability_zones = "${local.availability_zones}"
 
   vpc_security_groups = ["${aws_security_group.permit_internet_access.id}"]
+
+  # basic auth password is 'hello world'
+  prometheus_htpasswd = "grafana:$6$DoATHwJM$ws9EPPNpFe6fmKgBPa/3CX3C4f1F1cHi/pnxjYrGR3y652gIRtTzgl/ZFCLiRfa9/1jfgRBsNITelo1JNiiJD/"
 }
 
 module "paas-config" {

--- a/terraform/modules/prom-ec2/prometheus/variables.tf
+++ b/terraform/modules/prom-ec2/prometheus/variables.tf
@@ -78,3 +78,8 @@ variable "prometheus_public_fqdns" {
 variable "logstash_host" {
   default = ""
 }
+
+variable "prometheus_htpasswd" {
+  default = ""
+  description = "Basic auth htpasswd to be configured for NGINX to allow access from Grafana"
+}

--- a/terraform/modules/prom-ec2/prometheus/variables.tf
+++ b/terraform/modules/prom-ec2/prometheus/variables.tf
@@ -80,6 +80,6 @@ variable "logstash_host" {
 }
 
 variable "prometheus_htpasswd" {
-  default = ""
-  description = "Basic auth htpasswd to be configured for NGINX to allow access from Grafana"
+  default     = ""
+  description = "Contents of basic auth .htpasswd file for NGINX to allow access from Grafana"
 }

--- a/terraform/projects/prom-ec2/paas-production/prometheus/main.tf
+++ b/terraform/projects/prom-ec2/paas-production/prometheus/main.tf
@@ -61,6 +61,10 @@ data "pass_password" "logstash_endpoint" {
   path = "logit/prometheus-paas-logstash-endpoint-prod"
 }
 
+data "pass_password" "prometheus_htpasswd" {
+  path = "observe/prometheus-basic-auth-htpasswd"
+}
+
 module "ami" {
   source = "../../../../modules/common/ami"
 }
@@ -88,6 +92,8 @@ module "prometheus" {
   vpc_security_groups   = ["${data.terraform_remote_state.infra_security_groups.monitoring_external_sg_id}"]
   source_security_group = "${data.terraform_remote_state.infra_security_groups.monitoring_internal_sg_id}"
   region                = "eu-west-1"
+
+  prometheus_htpasswd = "${data.pass_password.prometheus_htpasswd.password}"
 }
 
 module "paas-config" {

--- a/terraform/projects/prom-ec2/paas-staging/prometheus/main.tf
+++ b/terraform/projects/prom-ec2/paas-staging/prometheus/main.tf
@@ -52,6 +52,15 @@ data "terraform_remote_state" "app_ecs_albs" {
   }
 }
 
+provider "pass" {
+  store_dir     = "~/.password-store/re-secrets/observe"
+  refresh_store = true
+}
+
+data "pass_password" "prometheus_htpasswd" {
+  path = "observe/prometheus-basic-auth-htpasswd"
+}
+
 module "ami" {
   source = "../../../../modules/common/ami"
 }
@@ -78,6 +87,8 @@ module "prometheus" {
   vpc_security_groups   = ["${data.terraform_remote_state.infra_security_groups.monitoring_external_sg_id}"]
   source_security_group = "${data.terraform_remote_state.infra_security_groups.monitoring_internal_sg_id}"
   region                = "eu-west-1"
+
+  prometheus_htpasswd = "${data.pass_password.prometheus_htpasswd.password}"
 }
 
 module "paas-config" {


### PR DESCRIPTION
https://trello.com/c/xJtxfsxa/790-migrate-auth-proxy-off-ecs

Adds another nginx vhost for the auth proxy. The auth proxy is the same
in functionality to the one that we will be replacing currently running
in ECS.

Removes the default vhost as this would also try and run on port 80.

The vhosts file is fairly different from the original auth-proxy
vhosts file because previously we needed to have different
locations for each of prom 1-3 and alertmanager 1-3 but because
this lives on the box it does not need to be aware of which application
it is fronting and always proxies traffic to a single location -
port 9090 where Prometheus is exposed.

We had to change the password that is being used for basic auth. On
nginx-alpine docker image it came with bcrypt but our ubuntu image
does not. We solved this problem by using a SHA-512 hashing algorithm.
We took this opportunity to pick a new password, generate it's
htpasswd and store it in the re-secrets password (for added security
given that SHA-512 may not be as secure as bcrypt so we won't put
it into a public repo).

Note, this commit does not actually start any user requests going
through the auth-proxy running on the EC2 instances but is a halfway
step of getting there. The later step will be to redirect user
traffics to port 80 on the instance with appropriate changes to
load balancers and DNS.

TODO:
- Should we be good and pull out the hardcoded IPs from the cloud.conf? Probably...
- Add test for basic auth?