### PR TITLE
use ec2_sd_configs to find prometheis and node_exporters

### DIFF
--- a/terraform/modules/prom-ec2/paas-config/main.tf
+++ b/terraform/modules/prom-ec2/paas-config/main.tf
@@ -2,7 +2,6 @@ data "template_file" "prometheus_config_template" {
   template = "${file("${path.module}/prometheus.conf.tpl")}"
 
   vars {
-    alertmanager_dns_names = "${join(",", formatlist("\"%s\"", var.alertmanager_dns_names))}"
     external_alertmanagers = "${join(",", formatlist("\"%s\"", var.external_alertmanager_names))}"
 
     environment = "${var.environment}"

--- a/terraform/modules/prom-ec2/paas-config/main.tf
+++ b/terraform/modules/prom-ec2/paas-config/main.tf
@@ -2,10 +2,10 @@ data "template_file" "prometheus_config_template" {
   template = "${file("${path.module}/prometheus.conf.tpl")}"
 
   vars {
-    alertmanager_dns_names    = "${join(",", formatlist("\"%s\"", var.alertmanager_dns_names))}"
-    external_alertmanagers    = "${join(",", formatlist("\"%s\"", var.external_alertmanager_names))}"
-    prometheus_addresses      = "${join(",", formatlist("\"%s:9090\"", aws_route53_record.prom_ec2_a_record.*.fqdn))}"
-    prometheus_node_addresses = "${join(",", formatlist("\"%s:9100\"", aws_route53_record.prom_ec2_a_record.*.fqdn))}"
+    alertmanager_dns_names = "${join(",", formatlist("\"%s\"", var.alertmanager_dns_names))}"
+    external_alertmanagers = "${join(",", formatlist("\"%s\"", var.external_alertmanager_names))}"
+
+    environment = "${var.environment}"
   }
 }
 

--- a/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
+++ b/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
@@ -23,6 +23,11 @@ scrape_configs:
       - source_labels: ['__meta_ec2_tag_Job']
         regex: 'prometheus'
         action: keep
+      - source_labels: ['__meta_ec2_availability_zone']
+        target_label: availability_zone
+      - source_labels: ['__meta_ec2_instance_id']
+        replacement: '$1:9090'
+        target_label: instance
   - job_name: paas-targets
     scheme: http
     proxy_url: 'http://localhost:8080'
@@ -43,3 +48,8 @@ scrape_configs:
       - source_labels: ['__meta_ec2_tag_Job']
         regex: '.+'
         action: keep
+      - source_labels: ['__meta_ec2_availability_zone']
+        target_label: availability_zone
+      - source_labels: ['__meta_ec2_instance_id']
+        replacement: '$1:9100'
+        target_label: instance

--- a/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
+++ b/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
@@ -61,7 +61,7 @@ scrape_configs:
         regex: '${environment}'
         action: keep
       - source_labels: ['__meta_ec2_tag_Job']
-        regex: '.+'
+        regex: 'prometheus'
         action: keep
       - source_labels: ['__meta_ec2_availability_zone']
         target_label: availability_zone

--- a/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
+++ b/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
@@ -4,8 +4,13 @@ global:
 alerting:
   alertmanagers:
   - scheme: http
-    static_configs:
-      - targets: [${alertmanager_dns_names}]
+    ec2_sd_configs:
+      - region: eu-west-1
+        port: 9093
+    relabel_configs:
+      - source_labels: ['__meta_ec2_tag_Name']
+        regex: '${environment}-ecs-instance'
+        action: keep
   - scheme: https
     static_configs:
       - targets: [${external_alertmanagers}]
@@ -35,8 +40,18 @@ scrape_configs:
       - files: ['/etc/prometheus/targets/*.json']
         refresh_interval: 30s
   - job_name: alertmanager
-    static_configs:
-      - targets: [${alertmanager_dns_names}]
+    ec2_sd_configs:
+      - region: eu-west-1
+        port: 9093
+    relabel_configs:
+      - source_labels: ['__meta_ec2_tag_Name']
+        regex: '${environment}-ecs-instance'
+        action: keep
+      - source_labels: ['__meta_ec2_availability_zone']
+        target_label: availability_zone
+      - source_labels: ['__meta_ec2_instance_id']
+        replacement: '$1:9093'
+        target_label: instance
   - job_name: prometheus_node
     ec2_sd_configs:
       - region: eu-west-1

--- a/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
+++ b/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
@@ -13,8 +13,16 @@ rule_files:
   - "/etc/prometheus/alerts/*"
 scrape_configs:
   - job_name: prometheus
-    static_configs:
-      - targets: [${prometheus_addresses}]
+    ec2_sd_configs:
+      - region: eu-west-1
+        port: 9090
+    relabel_configs:
+      - source_labels: ['__meta_ec2_tag_Environment']
+        regex: '${environment}'
+        action: keep
+      - source_labels: ['__meta_ec2_tag_Job']
+        regex: 'prometheus'
+        action: keep
   - job_name: paas-targets
     scheme: http
     proxy_url: 'http://localhost:8080'
@@ -25,5 +33,13 @@ scrape_configs:
     static_configs:
       - targets: [${alertmanager_dns_names}]
   - job_name: prometheus_node
-    static_configs:
-      - targets: [${prometheus_node_addresses}]
+    ec2_sd_configs:
+      - region: eu-west-1
+        port: 9100
+    relabel_configs:
+      - source_labels: ['__meta_ec2_tag_Environment']
+        regex: '${environment}'
+        action: keep
+      - source_labels: ['__meta_ec2_tag_Job']
+        regex: '.+'
+        action: keep

--- a/terraform/modules/prom-ec2/paas-config/variables.tf
+++ b/terraform/modules/prom-ec2/paas-config/variables.tf
@@ -1,9 +1,3 @@
-variable "alertmanager_dns_names" {
-  type        = "list"
-  default     = []
-  description = "alertmanagers to send alerts to on local network (via http)"
-}
-
 variable "external_alertmanager_names" {
   type        = "list"
   default     = []

--- a/terraform/modules/prom-ec2/paas-config/variables.tf
+++ b/terraform/modules/prom-ec2/paas-config/variables.tf
@@ -10,6 +10,7 @@ variable "external_alertmanager_names" {
   description = "external alertmanagers to send alerts to (via https)"
 }
 
+variable "environment" {}
 variable "prometheus_config_bucket" {}
 variable "alerts_path" {}
 variable "private_zone_id" {}

--- a/terraform/modules/prom-ec2/prometheus/main.tf
+++ b/terraform/modules/prom-ec2/prometheus/main.tf
@@ -33,6 +33,7 @@ resource "aws_instance" "prometheus" {
     Environment = "${var.environment}"
     Product     = "${var.product}"
     ManagedBy   = "terraform"
+    Job         = "prometheus"
   }
 }
 

--- a/terraform/modules/prom-ec2/prometheus/test/prometheus-paas/prometheus.tf
+++ b/terraform/modules/prom-ec2/prometheus/test/prometheus-paas/prometheus.tf
@@ -32,7 +32,6 @@ module "paas-config" {
   environment = "${local.environment}"
 
   prometheus_config_bucket = "${module.prometheus.s3_config_bucket}"
-  alertmanager_dns_names   = "${local.active_alertmanager_private_fqdns}"
   alerts_path              = "${path.module}/../../../../../modules/app-ecs-services/config/alerts/"
 
   prom_private_ips  = "${module.prometheus.private_ip_addresses}"

--- a/terraform/modules/prom-ec2/prometheus/test/prometheus-paas/prometheus.tf
+++ b/terraform/modules/prom-ec2/prometheus/test/prometheus-paas/prometheus.tf
@@ -29,6 +29,8 @@ module "prometheus" {
 module "paas-config" {
   source = "../../../paas-config"
 
+  environment = "${local.environment}"
+
   prometheus_config_bucket = "${module.prometheus.s3_config_bucket}"
   alertmanager_dns_names   = "${local.active_alertmanager_private_fqdns}"
   alerts_path              = "${path.module}/../../../../../modules/app-ecs-services/config/alerts/"

--- a/terraform/projects/prom-ec2/paas-dev/main.tf
+++ b/terraform/projects/prom-ec2/paas-dev/main.tf
@@ -85,6 +85,8 @@ module "prometheus" {
 module "paas-config" {
   source = "../../../modules/prom-ec2/paas-config"
 
+  environment = "${local.environment}"
+
   prometheus_config_bucket = "${module.prometheus.s3_config_bucket}"
   alertmanager_dns_names   = "${local.active_alertmanager_private_fqdns}"
   alerts_path              = "../../../modules/app-ecs-services/config/alerts/"

--- a/terraform/projects/prom-ec2/paas-dev/main.tf
+++ b/terraform/projects/prom-ec2/paas-dev/main.tf
@@ -1,9 +1,7 @@
 locals {
-  product                           = "paas"
-  environment                       = "dev"
-  config_bucket                     = "gdsobserve-${local.product}-${local.environment}-config-store"
-  active_alertmanager_private_fqdns = "${slice(data.terraform_remote_state.app_ecs_albs.alerts_private_record_fqdns, 0,
- 3)}"
+  product       = "paas"
+  environment   = "dev"
+  config_bucket = "gdsobserve-${local.product}-${local.environment}-config-store"
 }
 
 terraform {
@@ -88,7 +86,6 @@ module "paas-config" {
   environment = "${local.environment}"
 
   prometheus_config_bucket = "${module.prometheus.s3_config_bucket}"
-  alertmanager_dns_names   = "${local.active_alertmanager_private_fqdns}"
   alerts_path              = "../../../modules/app-ecs-services/config/alerts/"
 
   prom_private_ips  = "${module.prometheus.private_ip_addresses}"

--- a/terraform/projects/prom-ec2/paas-production/main.tf
+++ b/terraform/projects/prom-ec2/paas-production/main.tf
@@ -99,6 +99,8 @@ module "prometheus" {
 module "paas-config" {
   source = "../../../modules/prom-ec2/paas-config"
 
+  environment = "${local.environment}"
+
   prometheus_config_bucket = "${module.prometheus.s3_config_bucket}"
   alertmanager_dns_names   = "${local.active_alertmanager_private_fqdns}"
   alerts_path              = "../../../modules/app-ecs-services/config/alerts/"

--- a/terraform/projects/prom-ec2/paas-production/main.tf
+++ b/terraform/projects/prom-ec2/paas-production/main.tf
@@ -1,9 +1,7 @@
 locals {
-  product                           = "paas"
-  environment                       = "production"
-  config_bucket                     = "gdsobserve-${local.product}-${local.environment}-config-store"
-  active_alertmanager_private_fqdns = "${slice(data.terraform_remote_state.app_ecs_albs.alerts_private_record_fqdns, 0,
- 3)}"
+  product       = "paas"
+  environment   = "production"
+  config_bucket = "gdsobserve-${local.product}-${local.environment}-config-store"
 }
 
 terraform {
@@ -102,7 +100,6 @@ module "paas-config" {
   environment = "${local.environment}"
 
   prometheus_config_bucket = "${module.prometheus.s3_config_bucket}"
-  alertmanager_dns_names   = "${local.active_alertmanager_private_fqdns}"
   alerts_path              = "../../../modules/app-ecs-services/config/alerts/"
 
   prom_private_ips  = "${module.prometheus.private_ip_addresses}"

--- a/terraform/projects/prom-ec2/paas-staging/main.tf
+++ b/terraform/projects/prom-ec2/paas-staging/main.tf
@@ -94,6 +94,8 @@ module "prometheus" {
 module "paas-config" {
   source = "../../../modules/prom-ec2/paas-config"
 
+  environment = "${local.environment}"
+
   prometheus_config_bucket    = "${module.prometheus.s3_config_bucket}"
   alertmanager_dns_names      = "${local.active_alertmanager_private_fqdns}"
   external_alertmanager_names = ["alertman.cluster.re-managed-observe-staging.aws.ext.govsvc.uk"]

--- a/terraform/projects/prom-ec2/paas-staging/main.tf
+++ b/terraform/projects/prom-ec2/paas-staging/main.tf
@@ -1,9 +1,7 @@
 locals {
-  product                           = "paas"
-  environment                       = "staging"
-  config_bucket                     = "gdsobserve-${local.product}-${local.environment}-config-store"
-  active_alertmanager_private_fqdns = "${slice(data.terraform_remote_state.app_ecs_albs.alerts_private_record_fqdns, 0,
- 3)}"
+  product       = "paas"
+  environment   = "staging"
+  config_bucket = "gdsobserve-${local.product}-${local.environment}-config-store"
 }
 
 terraform {
@@ -97,7 +95,6 @@ module "paas-config" {
   environment = "${local.environment}"
 
   prometheus_config_bucket    = "${module.prometheus.s3_config_bucket}"
-  alertmanager_dns_names      = "${local.active_alertmanager_private_fqdns}"
   external_alertmanager_names = ["alertman.cluster.re-managed-observe-staging.aws.ext.govsvc.uk"]
   alerts_path                 = "../../../modules/app-ecs-services/config/alerts/"
 


### PR DESCRIPTION
Instead of static_configs

Why? A few reasons:

 - we don't need to hardcode the number of prometheis into the prometheus.yml
 - we can use this in future for discovering alertmanager node_exporters to scrape
 - we can use this in future for discovering alertmanagers to send alerts to

We already had an instance policy that granted `ec2:Describe*` (from the verify-perf-a work, I imagine) so I didn't need to change any IAM stuff to get this to work.

Still to be done:

 - [x] fix the labels so we know which instance is `prom-1`