### PR TITLE
Auth proxy albs

### DIFF
--- a/terraform/modules/prom-ec2/prometheus/variables.tf
+++ b/terraform/modules/prom-ec2/prometheus/variables.tf
@@ -83,3 +83,8 @@ variable "prometheus_htpasswd" {
   default     = ""
   description = "Contents of basic auth .htpasswd file for NGINX to allow access from Grafana"
 }
+
+variable "prometheus_target_group_arns" {
+  type    = "list"
+  default = []
+}

--- a/terraform/projects/app-ecs-albs-dev/main.tf
+++ b/terraform/projects/app-ecs-albs-dev/main.tf
@@ -6,6 +6,7 @@ terraform {
   backend "s3" {
     bucket = "re-observe-dev"
     key    = "app-ecs-albs-modular.tfstate"
+    region = "eu-west-1"
   }
 }
 

--- a/terraform/projects/app-ecs-albs-dev/main.tf
+++ b/terraform/projects/app-ecs-albs-dev/main.tf
@@ -72,3 +72,7 @@ output "alerts_private_record_fqdns" {
   value       = "${module.app-ecs-albs.alerts_private_record_fqdns}"
   description = "Alertmanagers private DNS FQDNs"
 }
+
+output "prometheus_target_group_arns" {
+  value = "${module.app-ecs-albs.prometheus_target_group_ids}"
+}

--- a/terraform/projects/app-ecs-instances-dev/main.tf
+++ b/terraform/projects/app-ecs-instances-dev/main.tf
@@ -4,6 +4,7 @@ terraform {
   backend "s3" {
     bucket = "re-observe-dev"
     key    = "app-ecs-instances-modular.tfstate"
+    region = "eu-west-1"
   }
 }
 

--- a/terraform/projects/infra-security-groups-dev/main.tf
+++ b/terraform/projects/infra-security-groups-dev/main.tf
@@ -42,7 +42,7 @@ module "infra-security-groups" {
 
   aws_region          = "${var.aws_region}"
   stack_name          = "module-refactor"
-  remote_state_bucket = "observe-dev"
+  remote_state_bucket = "${var.remote_state_bucket}"
   project             = "${var.project}"
 }
 

--- a/terraform/projects/prom-ec2/paas-dev/main.tf
+++ b/terraform/projects/prom-ec2/paas-dev/main.tf
@@ -78,7 +78,8 @@ module "prometheus" {
   region                = "eu-west-1"
 
   # basic auth password is 'hello world'
-  prometheus_htpasswd = "grafana:$6$DoATHwJM$ws9EPPNpFe6fmKgBPa/3CX3C4f1F1cHi/pnxjYrGR3y652gIRtTzgl/ZFCLiRfa9/1jfgRBsNITelo1JNiiJD/"
+  prometheus_htpasswd          = "grafana:$6$DoATHwJM$ws9EPPNpFe6fmKgBPa/3CX3C4f1F1cHi/pnxjYrGR3y652gIRtTzgl/ZFCLiRfa9/1jfgRBsNITelo1JNiiJD/"
+  prometheus_target_group_arns = "${data.terraform_remote_state.app_ecs_albs.prometheus_target_group_arns}"
 }
 
 module "paas-config" {

--- a/terraform/projects/prom-ec2/paas-production/main.tf
+++ b/terraform/projects/prom-ec2/paas-production/main.tf
@@ -92,7 +92,8 @@ module "prometheus" {
   source_security_group = "${data.terraform_remote_state.infra_security_groups.monitoring_internal_sg_id}"
   region                = "eu-west-1"
 
-  prometheus_htpasswd = "${data.pass_password.prometheus_htpasswd.password}"
+  prometheus_htpasswd          = "${data.pass_password.prometheus_htpasswd.password}"
+  prometheus_target_group_arns = "${data.terraform_remote_state.app_ecs_albs.prometheus_target_group_arns}"
 }
 
 module "paas-config" {


### PR DESCRIPTION
Add new load balancer to directly present prometheus

This new load balancer and associated listeners, rules and target group
directly present the EC2 Prometheis, via their auth-nginx proxy (ie on port 80),
without going via ECS at all.

This doesn't change any traffic - all public traffic still goes via the old load balancer and ECS nginx.