### PR TITLE
Use new alb features for redirect and fixed response

### DIFF
--- a/terraform/modules/app-ecs-albs/main.tf
+++ b/terraform/modules/app-ecs-albs/main.tf
@@ -321,8 +321,13 @@ resource "aws_lb_listener" "prometheus_listener_https" {
   certificate_arn   = "${aws_acm_certificate.monitoring_cert.arn}"
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.prometheus_tg.0.arn}"
-    type             = "forward"
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Not found"
+      status_code  = "404"
+    }
   }
 }
 

--- a/terraform/modules/prom-ec2/prometheus/cloud.conf
+++ b/terraform/modules/prom-ec2/prometheus/cloud.conf
@@ -90,10 +90,6 @@ write_files:
           return 200 "Static health check";
         }
 
-        if ($http_x_forwarded_proto = 'http') {
-          return 301 https://$host$request_uri;
-        }
-
         location / {
           proxy_pass  http://localhost:9090;
           proxy_set_header X-Real-IP $remote_addr;

--- a/terraform/projects/app-ecs-albs-dev/main.tf
+++ b/terraform/projects/app-ecs-albs-dev/main.tf
@@ -11,7 +11,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 1.14.1"
+  version = "~> 1.51.0"
   region  = "${var.aws_region}"
 }
 

--- a/terraform/projects/app-ecs-albs-production/main.tf
+++ b/terraform/projects/app-ecs-albs-production/main.tf
@@ -10,7 +10,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 1.14.1"
+  version = "~> 1.51.0"
   region  = "${var.aws_region}"
 }
 

--- a/terraform/projects/app-ecs-albs-staging/main.tf
+++ b/terraform/projects/app-ecs-albs-staging/main.tf
@@ -10,7 +10,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 1.14.1"
+  version = "~> 1.51.0"
   region  = "${var.aws_region}"
 }
 


### PR DESCRIPTION
# Why I am making this change

Since the terraform aws provider 1.33.0, there has been support for `redirect` and `fixed-response` actions in load balancers.  That means we can take some functionality out of nginx.

# What approach I took

The load balancers now handle redirecting http->https, and issue a 404 if they don't recognise the host header.

Note that this will cause our EC2 Prometheis to be rebuilt, because it changes cloud.conf.