### PR TITLE
Remove database subnets because we have no database

### DIFF
--- a/terraform/modules/infra-networking/main.tf
+++ b/terraform/modules/infra-networking/main.tf
@@ -65,10 +65,11 @@ module "vpc" {
   cidr = "10.0.0.0/16"
 
   # subnets assumes 3 AZs although 3AZs are not implemented elsewhere
-  azs              = "${data.aws_availability_zones.available.names}"
-  private_subnets  = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  public_subnets   = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
-  database_subnets = ["10.0.201.0/24", "10.0.202.0/24", "10.0.203.0/24"]
+  azs             = "${data.aws_availability_zones.available.names}"
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+
+  create_database_subnet_group = false
 
   enable_nat_gateway = true
   single_nat_gateway = "${var.dev_environment == "true" ? true : false }"


### PR DESCRIPTION
Plan:

```
Terraform will perform the following actions:

  - module.infra-networking.module.vpc.aws_db_subnet_group.database

  - module.infra-networking.module.vpc.aws_route_table_association.database

  - module.infra-networking.module.vpc.aws_route_table_association.database[1]

  - module.infra-networking.module.vpc.aws_route_table_association.database[2]

  - module.infra-networking.module.vpc.aws_subnet.database

  - module.infra-networking.module.vpc.aws_subnet.database[1]

  - module.infra-networking.module.vpc.aws_subnet.database[2]
```