### PR TITLE
point prom-1.* DNS records at new load balancer

### DIFF
--- a/terraform/modules/app-ecs-albs/main.tf
+++ b/terraform/modules/app-ecs-albs/main.tf
@@ -139,8 +139,8 @@ resource "aws_route53_record" "prom_alias" {
   type    = "A"
 
   alias {
-    name                   = "${aws_lb.nginx_auth_external_alb.dns_name}"
-    zone_id                = "${aws_lb.nginx_auth_external_alb.zone_id}"
+    name                   = "${aws_lb.prometheus_alb.dns_name}"
+    zone_id                = "${aws_lb.prometheus_alb.zone_id}"
     evaluate_target_health = false
   }
 }


### PR DESCRIPTION
The new load balancer, which skips ECS and points directly at
prometheus, is ready to use.  This PR just points the DNS records for
prometheus at the new load balancer.
