### PR TITLE
Don't hardcode admin CIDRs

### DIFF
--- a/terraform/modules/prom-ec2/prometheus/cloud.conf
+++ b/terraform/modules/prom-ec2/prometheus/cloud.conf
@@ -104,13 +104,7 @@ write_files:
         real_ip_header X-Forwarded-For;
         set_real_ip_from 10.0.0.0/8;
         set_real_ip_from 127.0.0.1/32;
-        allow 213.86.153.212/32;
-        allow 213.86.153.213/32;
-        allow 213.86.153.214/32;
-        allow 213.86.153.235/32;
-        allow 213.86.153.236/32;
-        allow 213.86.153.237/32;
-        allow 85.133.67.244/32;
+        ${allowed_cidrs}
         deny all;
       }
     path: /etc/nginx/sites-enabled/auth-proxy

--- a/terraform/modules/prom-ec2/prometheus/main.tf
+++ b/terraform/modules/prom-ec2/prometheus/main.tf
@@ -72,6 +72,7 @@ data "template_file" "user_data_script" {
     prom_external_url   = "https://${var.prometheus_public_fqdns[count.index]}"
     logstash_host       = "${var.logstash_host}"
     prometheus_htpasswd = "${var.prometheus_htpasswd}"
+    allowed_cidrs       = "${join("\n        ",formatlist("allow %s;", var.allowed_cidrs))}"
   }
 }
 


### PR DESCRIPTION
We only want to define them once and pass them as a variable.
Some slightly nasty space characters needed to ensure the
yaml comes out correctly indented but I couldn't see any other
way around this.