### PR TITLE
Update zero downtime deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ aws-vault exec gds-prometheus-staging -- terraform plan
 
 To avoid all three instances being respun at the same time you can do one instance at a time using:
 
-```aws-vault exec aws_profile_name -- terraform apply -target=module.paas-config.aws_route53_record.prom_ec2_a_record[i] -target=module.prometheus.aws_volume_attachment.attach-prometheus-disk[i] -target=module.prometheus.aws_instance.prometheus[i]```
+```aws-vault exec aws_profile_name -- terraform apply -target=module.paas-config.aws_route53_record.prom_ec2_a_record[i] -target=module.prometheus.aws_volume_attachment.attach-prometheus-disk[i] -target=module.prometheus.aws_instance.prometheus[i] -target=module.prometheus.aws_lb_target_group_attachment.prom_target_group_attachment[i]```
+
+
 
 where `i` is `0`, `1` or `2`.
 


### PR DESCRIPTION
Since the introduction of our Prom EC2s being attached to load
balancers, these also need to be done one at a time during a
deploy which rolls the EC2 instances.