### PR TITLE
Add new ALB for ECS alertmanager

### DIFF
--- a/terraform/modules/app-ecs-albs/main.tf
+++ b/terraform/modules/app-ecs-albs/main.tf
@@ -53,6 +53,21 @@ variable "alertmanager_count" {
   default     = "3"
 }
 
+variable "alerts_allowed_cidrs" {
+  type        = "list"
+  description = "List of CIDRs which are able to access the alertmanager ALB, default are GDS ips"
+
+  default = [
+    "213.86.153.212/32",
+    "213.86.153.213/32",
+    "213.86.153.214/32",
+    "213.86.153.235/32",
+    "213.86.153.236/32",
+    "213.86.153.237/32",
+    "85.133.67.244/32",
+  ]
+}
+
 # locals
 # --------------------------------------------------------------
 
@@ -136,40 +151,6 @@ resource "aws_lb" "monitoring_internal_alb" {
     map("Stackname", "${var.stack_name}"),
     map("Name", "${var.stack_name}-monitoring-internal-${count.index + 1}")
   )}"
-}
-
-# AWS should manage the certificate renewal automatically
-# https://docs.aws.amazon.com/acm/latest/userguide/managed-renewal.html
-# If this fails, AWS will email associated with the AWS account
-resource "aws_acm_certificate" "alertmanager_cert" {
-  domain_name       = "alerts.${local.subdomain}"
-  validation_method = "DNS"
-
-  subject_alternative_names = ["${aws_route53_record.alerts_alias.*.fqdn}"]
-
-  lifecycle {
-    # We can't destroy a certificate that's in use, and we can't stop
-    # using it until the new one is ready.  Hence
-    # create_before_destroy here.
-    create_before_destroy = true
-  }
-}
-
-resource "aws_route53_record" "alertmanager_cert_validation" {
-  # Count matches the domain_name plus each `subject_alternative_domain`
-  count = "${1 + local.alerts_records_count}"
-
-  name       = "${lookup(aws_acm_certificate.alertmanager_cert.domain_validation_options[count.index], "resource_record_name")}"
-  type       = "${lookup(aws_acm_certificate.alertmanager_cert.domain_validation_options[count.index], "resource_record_type")}"
-  zone_id    = "${var.zone_id}"
-  records    = ["${lookup(aws_acm_certificate.alertmanager_cert.domain_validation_options[count.index], "resource_record_value")}"]
-  ttl        = 60
-  depends_on = ["aws_acm_certificate.alertmanager_cert"]
-}
-
-resource "aws_acm_certificate_validation" "alertmanager_cert" {
-  certificate_arn         = "${aws_acm_certificate.alertmanager_cert.arn}"
-  validation_record_fqdns = ["${aws_route53_record.alertmanager_cert_validation.*.fqdn}"]
 }
 
 resource "aws_route53_record" "alerts_alias" {
@@ -364,6 +345,9 @@ resource "aws_security_group" "prometheus_alb" {
   vpc_id      = "${local.vpc_id}"
 }
 
+# Prometheus is fronted by an nginx which controls access to
+# either approved IP addresses, or users with basic auth creds
+# so we need to allow all IPs here
 resource "aws_security_group_rule" "prom_allow_http" {
   security_group_id = "${aws_security_group.prometheus_alb.id}"
   type              = "ingress"
@@ -478,6 +462,183 @@ resource "aws_lb_target_group" "prometheus_tg" {
   }
 }
 
+######################################################################
+# ----- alertmanager public ALB -------
+######################################################################
+
+# AWS should manage the certificate renewal automatically
+# https://docs.aws.amazon.com/acm/latest/userguide/managed-renewal.html
+# If this fails, AWS will email associated with the AWS account
+resource "aws_acm_certificate" "alertmanager_cert" {
+  domain_name       = "alerts.${local.subdomain}"
+  validation_method = "DNS"
+
+  subject_alternative_names = ["${aws_route53_record.alerts_alias.*.fqdn}"]
+
+  lifecycle {
+    # We can't destroy a certificate that's in use, and we can't stop
+    # using it until the new one is ready.  Hence
+    # create_before_destroy here.
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "alertmanager_cert_validation" {
+  # Count matches the domain_name plus each `subject_alternative_domain`
+  count = "${1 + local.alerts_records_count}"
+
+  name       = "${lookup(aws_acm_certificate.alertmanager_cert.domain_validation_options[count.index], "resource_record_name")}"
+  type       = "${lookup(aws_acm_certificate.alertmanager_cert.domain_validation_options[count.index], "resource_record_type")}"
+  zone_id    = "${var.zone_id}"
+  records    = ["${lookup(aws_acm_certificate.alertmanager_cert.domain_validation_options[count.index], "resource_record_value")}"]
+  ttl        = 60
+  depends_on = ["aws_acm_certificate.alertmanager_cert"]
+}
+
+resource "aws_acm_certificate_validation" "alertmanager_cert" {
+  certificate_arn         = "${aws_acm_certificate.alertmanager_cert.arn}"
+  validation_record_fqdns = ["${aws_route53_record.alertmanager_cert_validation.*.fqdn}"]
+}
+
+#### Uncomment this and remove the other alerts_alias when switching
+#### over from the old ALB
+#
+# resource "aws_route53_record" "alerts_alias" {
+#   count = "${local.alerts_records_count}"
+
+#   zone_id = "${var.zone_id}"
+#   name    = "alerts-${count.index + 1}"
+#   type    = "A"
+
+#   alias {
+#     name                   = "${aws_lb.alertmanager_alb.dns_name}"
+#     zone_id                = "${aws_lb.alertmanager_alb.zone_id}"
+#     evaluate_target_health = false
+#   }
+# }
+
+resource "aws_security_group" "alertmanager_alb" {
+  name        = "${var.stack_name}-alertmanager-alb"
+  description = "Access to alertmanager ALB (${var.stack_name})"
+  vpc_id      = "${local.vpc_id}"
+}
+
+# Unlike prometheus, alertmanager is IP restricted by security group
+# here
+resource "aws_security_group_rule" "alerts_allow_http" {
+  security_group_id = "${aws_security_group.alertmanager_alb.id}"
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = ["${var.alerts_allowed_cidrs}"]
+}
+
+resource "aws_security_group_rule" "alerts_allow_https" {
+  security_group_id = "${aws_security_group.alertmanager_alb.id}"
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["${var.alerts_allowed_cidrs}"]
+}
+
+resource "aws_lb" "alertmanager_alb" {
+  name               = "${var.stack_name}-alertmanager-alb"
+  internal           = false
+  load_balancer_type = "application"
+
+  security_groups = [
+    "${data.terraform_remote_state.infra_security_groups.monitoring_external_sg_id}",
+    "${aws_security_group.alertmanager_alb.id}",
+  ]
+
+  subnets = [
+    "${var.subnets}",
+  ]
+
+  tags = "${merge(
+    local.default_tags,
+    var.additional_tags,
+    map("Stackname", "${var.stack_name}"),
+    map("Name", "${var.stack_name}-alertmanager-alb")
+  )}"
+}
+
+resource "aws_lb_listener" "alertmanager_listener_http" {
+  load_balancer_arn = "${aws_lb.alertmanager_alb.arn}"
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "alertmanager_listener_https" {
+  load_balancer_arn = "${aws_lb.alertmanager_alb.arn}"
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
+  certificate_arn   = "${aws_acm_certificate_validation.alertmanager_cert.certificate_arn}"
+
+  default_action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Not found"
+      status_code  = "404"
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "alerts_listener_https" {
+  count = "${var.alertmanager_count}"
+
+  listener_arn = "${aws_lb_listener.alertmanager_listener_https.arn}"
+  priority     = "${100 + count.index}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${element(aws_lb_target_group.alertmanager_tg.*.arn, count.index)}"
+  }
+
+  condition {
+    field = "host-header"
+
+    values = [
+      "alerts-${count.index + 1}.*",
+    ]
+  }
+}
+
+resource "aws_lb_target_group" "alertmanager_tg" {
+  count = "${var.alertmanager_count}"
+
+  name                 = "${var.stack_name}-alerts-${count.index +1}-tg"
+  port                 = 80
+  protocol             = "HTTP"
+  vpc_id               = "${local.vpc_id}"
+  deregistration_delay = 30
+
+  health_check {
+    interval            = "10"
+    path                = "/health" # static health check on nginx auth proxy
+    matcher             = "200"
+    protocol            = "HTTP"
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = "5"
+  }
+}
+
 ## Outputs
 
 output "monitoring_external_tg" {
@@ -533,4 +694,9 @@ output "prom_private_record_fqdns" {
 output "prometheus_target_group_ids" {
   value       = "${aws_lb_target_group.prometheus_tg.*.arn}"
   description = "Prometheus target group IDs"
+}
+
+output "alertmanager_target_group_ids" {
+  value       = "${aws_lb_target_group.alertmanager_tg.*.arn}"
+  description = "Alertmanager target group IDs"
 }

--- a/terraform/modules/app-ecs-albs/main.tf
+++ b/terraform/modules/app-ecs-albs/main.tf
@@ -340,7 +340,7 @@ resource "aws_route53_record" "prom_alias" {
 }
 
 resource "aws_security_group" "prometheus_alb" {
-  name        = "${var.stack_name}-prometheus-alb"
+  name        = "${var.stack_name}-prometheus-alb-sg"
   description = "Access to prometheus ALB (${var.stack_name})"
   vpc_id      = "${local.vpc_id}"
 }
@@ -517,7 +517,7 @@ resource "aws_acm_certificate_validation" "alertmanager_cert" {
 # }
 
 resource "aws_security_group" "alertmanager_alb" {
-  name        = "${var.stack_name}-alertmanager-alb"
+  name        = "${var.stack_name}-alertmanager-alb-sg"
   description = "Access to alertmanager ALB (${var.stack_name})"
   vpc_id      = "${local.vpc_id}"
 }

--- a/terraform/modules/app-ecs-albs/main.tf
+++ b/terraform/modules/app-ecs-albs/main.tf
@@ -345,10 +345,9 @@ resource "aws_security_group" "prometheus_alb" {
   vpc_id      = "${local.vpc_id}"
 }
 
-# Prometheus is fronted by an nginx which controls access to
-# either approved IP addresses, or users with basic auth creds
-# so we need to allow all IPs here
-resource "aws_security_group_rule" "prom_allow_http" {
+# We allow all IPs to access the ALB as Prometheus is fronted by an nginx which controls access to either approved IP
+# addresses, or users with basic auth creds
+resource "aws_security_group_rule" "prom_alb_allow_http" {
   security_group_id = "${aws_security_group.prometheus_alb.id}"
   type              = "ingress"
   from_port         = 80
@@ -357,7 +356,7 @@ resource "aws_security_group_rule" "prom_allow_http" {
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
-resource "aws_security_group_rule" "prom_allow_https" {
+resource "aws_security_group_rule" "prom_alb_allow_https" {
   security_group_id = "${aws_security_group.prometheus_alb.id}"
   type              = "ingress"
   from_port         = 443
@@ -525,7 +524,7 @@ resource "aws_security_group" "alertmanager_alb" {
 
 # Unlike prometheus, alertmanager is IP restricted by security group
 # here
-resource "aws_security_group_rule" "alerts_allow_http" {
+resource "aws_security_group_rule" "alertmanager_alb_allow_http" {
   security_group_id = "${aws_security_group.alertmanager_alb.id}"
   type              = "ingress"
   from_port         = 80
@@ -534,7 +533,7 @@ resource "aws_security_group_rule" "alerts_allow_http" {
   cidr_blocks       = ["${var.alerts_allowed_cidrs}"]
 }
 
-resource "aws_security_group_rule" "alerts_allow_https" {
+resource "aws_security_group_rule" "alertmanager_alb_allow_https" {
   security_group_id = "${aws_security_group.alertmanager_alb.id}"
   type              = "ingress"
   from_port         = 443

--- a/terraform/modules/app-ecs-albs/main.tf
+++ b/terraform/modules/app-ecs-albs/main.tf
@@ -548,7 +548,6 @@ resource "aws_lb" "alertmanager_alb" {
   load_balancer_type = "application"
 
   security_groups = [
-    "${data.terraform_remote_state.infra_security_groups.monitoring_external_sg_id}",
     "${aws_security_group.alertmanager_alb.id}",
   ]
 

--- a/terraform/modules/app-ecs-albs/main.tf
+++ b/terraform/modules/app-ecs-albs/main.tf
@@ -53,7 +53,7 @@ variable "alertmanager_count" {
   default     = "3"
 }
 
-variable "alerts_allowed_cidrs" {
+variable "allowed_cidrs" {
   type        = "list"
   description = "List of CIDRs which are able to access the alertmanager ALB, default are GDS ips"
 
@@ -530,7 +530,7 @@ resource "aws_security_group_rule" "alertmanager_alb_allow_http" {
   from_port         = 80
   to_port           = 80
   protocol          = "tcp"
-  cidr_blocks       = ["${var.alerts_allowed_cidrs}"]
+  cidr_blocks       = ["${var.allowed_cidrs}"]
 }
 
 resource "aws_security_group_rule" "alertmanager_alb_allow_https" {
@@ -539,7 +539,7 @@ resource "aws_security_group_rule" "alertmanager_alb_allow_https" {
   from_port         = 443
   to_port           = 443
   protocol          = "tcp"
-  cidr_blocks       = ["${var.alerts_allowed_cidrs}"]
+  cidr_blocks       = ["${var.allowed_cidrs}"]
 }
 
 resource "aws_lb" "alertmanager_alb" {

--- a/terraform/modules/app-ecs-albs/main.tf
+++ b/terraform/modules/app-ecs-albs/main.tf
@@ -622,14 +622,14 @@ resource "aws_lb_target_group" "alertmanager_tg" {
   count = "${var.alertmanager_count}"
 
   name                 = "${var.stack_name}-alerts-${count.index +1}-tg"
-  port                 = 80
+  port                 = 9093
   protocol             = "HTTP"
   vpc_id               = "${local.vpc_id}"
   deregistration_delay = 30
 
   health_check {
     interval            = "10"
-    path                = "/health" # static health check on nginx auth proxy
+    path                = "/"
     matcher             = "200"
     protocol            = "HTTP"
     healthy_threshold   = 2

--- a/terraform/projects/app-ecs-albs-dev/main.tf
+++ b/terraform/projects/app-ecs-albs-dev/main.tf
@@ -40,6 +40,16 @@ variable "project" {
   default     = "app-ecs-albs-dev"
 }
 
+data "terraform_remote_state" "infra_networking" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "infra-networking-modular.tfstate"
+    region = "${var.aws_region}"
+  }
+}
+
 module "app-ecs-albs" {
   source = "../../modules/app-ecs-albs/"
 
@@ -47,6 +57,7 @@ module "app-ecs-albs" {
   stack_name          = "${var.stack_name}"
   remote_state_bucket = "${var.remote_state_bucket}"
   project             = "${var.project}"
+  zone_id             = "${data.terraform_remote_state.infra_networking.public_zone_id}"
 }
 
 output "monitoring_external_tg" {

--- a/terraform/projects/app-ecs-albs-dev/main.tf
+++ b/terraform/projects/app-ecs-albs-dev/main.tf
@@ -25,7 +25,7 @@ variable "aws_region" {
 variable "remote_state_bucket" {
   type        = "string"
   description = "S3 bucket we store our terraform state in"
-  default     = "re-observe-dev"
+  default     = "re-prom-dev-tfstate"
 }
 
 variable "stack_name" {

--- a/terraform/projects/app-ecs-albs-dev/main.tf
+++ b/terraform/projects/app-ecs-albs-dev/main.tf
@@ -58,6 +58,7 @@ module "app-ecs-albs" {
   remote_state_bucket = "${var.remote_state_bucket}"
   project             = "${var.project}"
   zone_id             = "${data.terraform_remote_state.infra_networking.public_zone_id}"
+  subnets             = "${data.terraform_remote_state.infra_networking.public_subnets}"
 }
 
 output "monitoring_external_tg" {

--- a/terraform/projects/app-ecs-albs-production/main.tf
+++ b/terraform/projects/app-ecs-albs-production/main.tf
@@ -57,6 +57,7 @@ module "app-ecs-albs" {
   remote_state_bucket = "${var.remote_state_bucket}"
   project             = "${var.project}"
   zone_id             = "${data.terraform_remote_state.infra_networking.public_zone_id}"
+  subnets             = "${data.terraform_remote_state.infra_networking.public_subnets}"
 }
 
 output "monitoring_external_tg" {

--- a/terraform/projects/app-ecs-albs-production/main.tf
+++ b/terraform/projects/app-ecs-albs-production/main.tf
@@ -39,6 +39,16 @@ variable "project" {
   default     = "app-ecs-albs-production"
 }
 
+data "terraform_remote_state" "infra_networking" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "infra-networking-modular.tfstate"
+    region = "${var.aws_region}"
+  }
+}
+
 module "app-ecs-albs" {
   source = "../../modules/app-ecs-albs/"
 
@@ -46,6 +56,7 @@ module "app-ecs-albs" {
   stack_name          = "${var.stack_name}"
   remote_state_bucket = "${var.remote_state_bucket}"
   project             = "${var.project}"
+  zone_id             = "${data.terraform_remote_state.infra_networking.public_zone_id}"
 }
 
 output "monitoring_external_tg" {

--- a/terraform/projects/app-ecs-albs-staging/main.tf
+++ b/terraform/projects/app-ecs-albs-staging/main.tf
@@ -57,6 +57,7 @@ module "app-ecs-albs" {
   remote_state_bucket = "${var.remote_state_bucket}"
   project             = "${var.project}"
   zone_id             = "${data.terraform_remote_state.infra_networking.public_zone_id}"
+  subnets             = "${data.terraform_remote_state.infra_networking.public_subnets}"
 }
 
 output "monitoring_external_tg" {

--- a/terraform/projects/app-ecs-albs-staging/main.tf
+++ b/terraform/projects/app-ecs-albs-staging/main.tf
@@ -39,6 +39,16 @@ variable "project" {
   default     = "app-ecs-albs-staging"
 }
 
+data "terraform_remote_state" "infra_networking" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "infra-networking-modular.tfstate"
+    region = "${var.aws_region}"
+  }
+}
+
 module "app-ecs-albs" {
   source = "../../modules/app-ecs-albs/"
 
@@ -46,6 +56,7 @@ module "app-ecs-albs" {
   stack_name          = "${var.stack_name}"
   remote_state_bucket = "${var.remote_state_bucket}"
   project             = "${var.project}"
+  zone_id             = "${data.terraform_remote_state.infra_networking.public_zone_id}"
 }
 
 output "monitoring_external_tg" {

--- a/terraform/projects/app-ecs-instances-dev/main.tf
+++ b/terraform/projects/app-ecs-instances-dev/main.tf
@@ -35,7 +35,7 @@ variable "project" {
 variable "remote_state_bucket" {
   type        = "string"
   description = "S3 bucket we store our terraform state in"
-  default     = "re-observe-dev"
+  default     = "re-prom-dev-tfstate"
 }
 
 module "app-ecs-instances" {

--- a/terraform/projects/app-ecs-services-dev/main.tf
+++ b/terraform/projects/app-ecs-services-dev/main.tf
@@ -62,7 +62,8 @@ variable "remote_state_bucket" {
 module "app-ecs-services" {
   source = "../../modules/app-ecs-services"
 
-  dev_environment     = "true"
-  remote_state_bucket = "${var.remote_state_bucket}"
-  stack_name          = "${var.stack_name}"
+  dev_environment            = "true"
+  remote_state_bucket        = "${var.remote_state_bucket}"
+  stack_name                 = "${var.stack_name}"
+  dev_ticket_recipient_email = "test@example.com"
 }

--- a/terraform/projects/app-ecs-services-dev/main.tf
+++ b/terraform/projects/app-ecs-services-dev/main.tf
@@ -56,7 +56,7 @@ provider "pass" {
 variable "remote_state_bucket" {
   type        = "string"
   description = "S3 bucket we store our terraform state in"
-  default     = "re-observe-dev"
+  default     = "re-prom-dev-tfstate"
 }
 
 module "app-ecs-services" {

--- a/terraform/projects/infra-security-groups-dev/main.tf
+++ b/terraform/projects/infra-security-groups-dev/main.tf
@@ -23,7 +23,7 @@ variable "aws_region" {
 variable "remote_state_bucket" {
   type        = "string"
   description = "S3 bucket we store our terraform state in"
-  default     = "re-observe-dev"
+  default     = "re-prom-dev-tfstate"
 }
 
 variable "stack_name" {

--- a/terraform/projects/prom-ec2/paas-dev/main.tf
+++ b/terraform/projects/prom-ec2/paas-dev/main.tf
@@ -24,7 +24,7 @@ data "terraform_remote_state" "infra_networking" {
   backend = "s3"
 
   config {
-    bucket = "re-observe-dev"
+    bucket = "re-prom-dev-tfstate"
     key    = "infra-networking-modular.tfstate"
     region = "eu-west-1"
   }
@@ -34,7 +34,7 @@ data "terraform_remote_state" "infra_security_groups" {
   backend = "s3"
 
   config {
-    bucket = "re-observe-dev"
+    bucket = "re-prom-dev-tfstate"
     key    = "infra-security-groups-modular.tfstate"
     region = "eu-west-1"
   }
@@ -44,7 +44,7 @@ data "terraform_remote_state" "app_ecs_albs" {
   backend = "s3"
 
   config {
-    bucket = "re-observe-dev"
+    bucket = "re-prom-dev-tfstate"
     key    = "app-ecs-albs-modular.tfstate"
     region = "eu-west-1"
   }


### PR DESCRIPTION
# Why I am making this change

Now that prometheus does not need the nginx auth-proxy ECS service, @idavidmcdonald and I talked about how to remove the last uses of it.  We decided that, as alertmanager doesn't need basic auth, the IP restriction can be implemented by a security group instead of nginx.

In order to achieve that, we need to do a fairly substantial redesign (and simplification) of how alertmanager uses ALBs.

# What approach I took

This PR adds a new ALB for alertmanager in ECS.  The new ALB:

 - is IP-restricted to office IPs at the security group level
 - skips the auth-proxy nginx and goes straight to the backend
 - uses an ACM certificate purely for alertmanager (no prom-* [SANs](https://en.wikipedia.org/wiki/Subject_Alternative_Name))

The new ALB is not in use yet.  To switch over, a future PR needs to:

 - change the `alerts-*` DNS records to point at the new ALB, not the old
 - change the alertmanager ECS service to point at the new target group, not the old

This will cause a period of downtime, but only for office users of the alertmanager UI - not for actual alert delivery.  As this is not a critical use case, I think this downtime would be acceptable.

Once that is done, we can then delete lots of stuff:

 - all the nginx auth-proxy ECS services
 - the old monitoring_external and monitoring_internal load balancers, and associated:
   - listeners, listener rules, target groups in app-ecs-albs
   - security groups in infra-security-groups

We may also be able to remove any internal DNS names, because (after #241 is merged) auth-proxy is the last thing actually using those names, I think.