### PR TITLE
Pin everything to the new dev account

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ asg_dev_scaledown_schedules = ["30 19 * * MON,WED,THU,FRI", "30 18 * * TUE"]
 
 For other examples on how to set up your own cron schedule have a look at this web page: https://crontab.guru/examples.html
 
-### How to connect to your dev ECS container instance
+### How to connect to your dev EC2 container instance
 
 If you are experiencing problems after creating the stack, you may want to connect to the EC2 instance using AWS Session Manager:
 
@@ -101,9 +101,17 @@ Before starting a session:
   - [install the session-manager-plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)
   - find the instance id of the instance you want to connect to
 
+Add a dev admin profile to your AWS config, `~/.aws/config`
+
+```
+[profile gds-tech-ops-dev]
+...
+role_arn=arn:aws:iam::931679966755:role/<first_name.last_name>-admin
+```
+
 To connect to an instance `$INSTANCE_ID`, run the command:
 ```shell
-aws-vault exec gds-tech-ops -- aws ssm start-session --target $INSTANCE_ID
+aws-vault exec gds-tech-ops-dev -- aws ssm start-session --target $INSTANCE_ID
 ```
 
 ## Viewing the Prometheus dashboard

--- a/terraform/modules/prom-ec2/prometheus/test/prometheus-paas/main.tf
+++ b/terraform/modules/prom-ec2/prometheus/test/prometheus-paas/main.tf
@@ -18,7 +18,7 @@ terraform {
 
 provider "aws" {
   region              = "eu-west-1"
-  allowed_account_ids = ["455214962221"]
+  allowed_account_ids = ["931679966755"]
 }
 
 # Data sources

--- a/terraform/modules/prom-ec2/prometheus/test/prometheus-paas/main.tf
+++ b/terraform/modules/prom-ec2/prometheus/test/prometheus-paas/main.tf
@@ -17,7 +17,8 @@ terraform {
 }
 
 provider "aws" {
-  region = "eu-west-1"
+  region              = "eu-west-1"
+  allowed_account_ids = ["455214962221"]
 }
 
 # Data sources

--- a/terraform/projects/app-ecs-albs-dev/main.tf
+++ b/terraform/projects/app-ecs-albs-dev/main.tf
@@ -12,7 +12,7 @@ terraform {
 
 provider "aws" {
   version             = "~> 1.51.0"
-  allowed_account_ids = ["455214962221"]
+  allowed_account_ids = ["931679966755"]
   region              = "${var.aws_region}"
 }
 

--- a/terraform/projects/app-ecs-albs-dev/main.tf
+++ b/terraform/projects/app-ecs-albs-dev/main.tf
@@ -4,15 +4,16 @@ terraform {
   required_version = "= 0.11.10"
 
   backend "s3" {
-    bucket = "re-observe-dev"
+    bucket = "re-prom-dev-tfstate"
     key    = "app-ecs-albs-modular.tfstate"
     region = "eu-west-1"
   }
 }
 
 provider "aws" {
-  version = "~> 1.51.0"
-  region  = "${var.aws_region}"
+  version             = "~> 1.51.0"
+  allowed_account_ids = ["455214962221"]
+  region              = "${var.aws_region}"
 }
 
 variable "aws_region" {

--- a/terraform/projects/app-ecs-instances-dev/main.tf
+++ b/terraform/projects/app-ecs-instances-dev/main.tf
@@ -10,7 +10,7 @@ terraform {
 
 provider "aws" {
   version             = "~> 1.14.1"
-  allowed_account_ids = ["455214962221"]
+  allowed_account_ids = ["931679966755"]
   region              = "${var.aws_region}"
 }
 

--- a/terraform/projects/app-ecs-instances-dev/main.tf
+++ b/terraform/projects/app-ecs-instances-dev/main.tf
@@ -2,15 +2,16 @@ terraform {
   required_version = "= 0.11.10"
 
   backend "s3" {
-    bucket = "re-observe-dev"
+    bucket = "re-prom-dev-tfstate"
     key    = "app-ecs-instances-modular.tfstate"
     region = "eu-west-1"
   }
 }
 
 provider "aws" {
-  version = "~> 1.14.1"
-  region  = "${var.aws_region}"
+  version             = "~> 1.14.1"
+  allowed_account_ids = ["455214962221"]
+  region              = "${var.aws_region}"
 }
 
 variable "aws_region" {

--- a/terraform/projects/app-ecs-services-dev/main.tf
+++ b/terraform/projects/app-ecs-services-dev/main.tf
@@ -32,15 +32,16 @@ terraform {
   required_version = "= 0.11.10"
 
   backend "s3" {
-    bucket = "re-observe-dev"
+    bucket = "re-prom-dev-tfstate"
     key    = "app-ecs-services-modular.tfstate"
     region = "eu-west-1"
   }
 }
 
 provider "aws" {
-  version = "~> 1.17"
-  region  = "${var.aws_region}"
+  version             = "~> 1.17"
+  allowed_account_ids = ["455214962221"]
+  region              = "${var.aws_region}"
 }
 
 provider "template" {

--- a/terraform/projects/app-ecs-services-dev/main.tf
+++ b/terraform/projects/app-ecs-services-dev/main.tf
@@ -40,7 +40,7 @@ terraform {
 
 provider "aws" {
   version             = "~> 1.17"
-  allowed_account_ids = ["455214962221"]
+  allowed_account_ids = ["931679966755"]
   region              = "${var.aws_region}"
 }
 

--- a/terraform/projects/infra-networking-dev/main.tf
+++ b/terraform/projects/infra-networking-dev/main.tf
@@ -10,7 +10,7 @@ terraform {
 
 provider "aws" {
   version             = "~> 1.14.1"
-  allowed_account_ids = ["455214962221"]
+  allowed_account_ids = ["931679966755"]
   region              = "${var.aws_region}"
 }
 

--- a/terraform/projects/infra-networking-dev/main.tf
+++ b/terraform/projects/infra-networking-dev/main.tf
@@ -2,15 +2,16 @@ terraform {
   required_version = "= 0.11.10"
 
   backend "s3" {
-    bucket = "re-observe-dev"
+    bucket = "re-prom-dev-tfstate"
     key    = "infra-networking-modular.tfstate"
     region = "eu-west-1"
   }
 }
 
 provider "aws" {
-  version = "~> 1.14.1"
-  region  = "${var.aws_region}"
+  version             = "~> 1.14.1"
+  allowed_account_ids = ["455214962221"]
+  region              = "${var.aws_region}"
 }
 
 variable "aws_region" {

--- a/terraform/projects/infra-security-groups-dev/main.tf
+++ b/terraform/projects/infra-security-groups-dev/main.tf
@@ -10,7 +10,7 @@ terraform {
 
 provider "aws" {
   version             = "~> 1.14.1"
-  allowed_account_ids = ["455214962221"]
+  allowed_account_ids = ["931679966755"]
   region              = "${var.aws_region}"
 }
 

--- a/terraform/projects/infra-security-groups-dev/main.tf
+++ b/terraform/projects/infra-security-groups-dev/main.tf
@@ -2,15 +2,16 @@ terraform {
   required_version = "= 0.11.10"
 
   backend "s3" {
-    bucket = "re-observe-dev"
+    bucket = "re-prom-dev-tfstate"
     key    = "infra-security-groups-modular.tfstate"
     region = "eu-west-1"
   }
 }
 
 provider "aws" {
-  version = "~> 1.14.1"
-  region  = "${var.aws_region}"
+  version             = "~> 1.14.1"
+  allowed_account_ids = ["455214962221"]
+  region              = "${var.aws_region}"
 }
 
 variable "aws_region" {

--- a/terraform/projects/prom-ec2/paas-dev/main.tf
+++ b/terraform/projects/prom-ec2/paas-dev/main.tf
@@ -19,7 +19,7 @@ terraform {
 
 provider "aws" {
   region              = "eu-west-1"
-  allowed_account_ids = ["455214962221"]
+  allowed_account_ids = ["931679966755"]
 }
 
 data "terraform_remote_state" "infra_networking" {

--- a/terraform/projects/prom-ec2/paas-dev/main.tf
+++ b/terraform/projects/prom-ec2/paas-dev/main.tf
@@ -10,7 +10,7 @@ terraform {
   required_version = "= 0.11.10"
 
   backend "s3" {
-    bucket  = "re-observe-dev"
+    bucket  = "re-prom-dev-tfstate"
     key     = "prometheus.tfstate"
     encrypt = true
     region  = "eu-west-1"
@@ -19,7 +19,7 @@ terraform {
 
 provider "aws" {
   region              = "eu-west-1"
-  allowed_account_ids = ["047969882937"]
+  allowed_account_ids = ["455214962221"]
 }
 
 data "terraform_remote_state" "infra_networking" {


### PR DESCRIPTION
This adds constraints so that dev projects can only be run in the new
dev account, not in gds-tech-ops.

Before merging, destroy all test kitchen stacks and ensure the `dev`
environment is destroyed in gds-tech-ops.  Also, make sure everyone can
access the new account 😄 (the roles should already be there but users will
need `~/.aws/config` changes)