### PR TITLE
Set dev_environments correctly and remove shared_dev_subdomain

### DIFF
--- a/terraform/modules/infra-networking/main.tf
+++ b/terraform/modules/infra-networking/main.tf
@@ -47,9 +47,8 @@ locals {
     Project   = "${var.project}"
   }
 
-  shared_dev_subdomain_name = "dev.gds-reliability.engineering"
-  subdomain_name            = "${var.dev_environment == "true" ? "${var.prometheus_subdomain}.${local.shared_dev_subdomain_name}" : "${var.prometheus_subdomain}.gds-reliability.engineering"}"
-  private_subdomain_name    = "${var.stack_name}.monitoring.private"
+  subdomain_name         = "${var.prometheus_subdomain}.gds-reliability.engineering"
+  private_subdomain_name = "${var.stack_name}.monitoring.private"
 }
 
 ## Data sources
@@ -96,31 +95,6 @@ resource "aws_route53_zone" "private" {
   vpc_id        = "${module.vpc.vpc_id}"
   name          = "${local.private_subdomain_name}"
   force_destroy = true
-}
-
-## Development resources
-# --------------------------------------------------------------
-# These resources are only created for development environments (not staging or prod)
-# This is to add the extra delegation from dev.gds-reliability.engineering to the prometheus subdomain
-
-data "aws_route53_zone" "shared_dev_subdomain" {
-  count = "${var.dev_environment == "true" ? 1 : 0}"
-  name  = "${local.shared_dev_subdomain_name}"
-}
-
-resource "aws_route53_record" "shared_dev_ns" {
-  count   = "${var.dev_environment == "true" ? 1 : 0}"
-  zone_id = "${data.aws_route53_zone.shared_dev_subdomain.zone_id}"
-  name    = "${var.stack_name}.${data.aws_route53_zone.shared_dev_subdomain.name}"
-  type    = "NS"
-  ttl     = "30"
-
-  records = [
-    "${aws_route53_zone.subdomain.name_servers.0}",
-    "${aws_route53_zone.subdomain.name_servers.1}",
-    "${aws_route53_zone.subdomain.name_servers.2}",
-    "${aws_route53_zone.subdomain.name_servers.3}",
-  ]
 }
 
 ## Outputs

--- a/terraform/projects/app-ecs-instances-dev/main.tf
+++ b/terraform/projects/app-ecs-instances-dev/main.tf
@@ -41,7 +41,7 @@ variable "remote_state_bucket" {
 module "app-ecs-instances" {
   source = "../../modules/app-ecs-instances"
 
-  dev_environment     = true
+  dev_environment     = "true"
   stack_name          = "${var.stack_name}"
   project             = "${var.project}"
   remote_state_bucket = "${var.remote_state_bucket}"

--- a/terraform/projects/app-ecs-services-dev/main.tf
+++ b/terraform/projects/app-ecs-services-dev/main.tf
@@ -62,7 +62,7 @@ variable "remote_state_bucket" {
 module "app-ecs-services" {
   source = "../../modules/app-ecs-services"
 
-  dev_environment     = true
+  dev_environment     = "true"
   remote_state_bucket = "${var.remote_state_bucket}"
   stack_name          = "${var.stack_name}"
 }

--- a/terraform/projects/infra-networking-dev/main.tf
+++ b/terraform/projects/infra-networking-dev/main.tf
@@ -41,7 +41,7 @@ variable "project" {
 module "infra-networking" {
   source = "../../modules/infra-networking"
 
-  dev_environment = true
+  dev_environment = "true"
 
   project              = "${var.project}"
   stack_name           = "${var.stack_name}"


### PR DESCRIPTION
# Why I am making this change

The dev stacks were not being correctly created as the value passed in to the modules was not set correctly, so they have been updated and it is now being set correctly.

As there is only 1 dev stack we no longer need to have a shared_dev_subdomain, so remove all the terraform code for that.
