### PR TITLE
Swap alertmanager traffic to use new alertmanager ALB

### DIFF
--- a/terraform/modules/app-ecs-albs/main.tf
+++ b/terraform/modules/app-ecs-albs/main.tf
@@ -153,20 +153,6 @@ resource "aws_lb" "monitoring_internal_alb" {
   )}"
 }
 
-resource "aws_route53_record" "alerts_alias" {
-  count = "${local.alerts_records_count}"
-
-  zone_id = "${var.zone_id}"
-  name    = "alerts-${count.index + 1}"
-  type    = "A"
-
-  alias {
-    name                   = "${aws_lb.nginx_auth_external_alb.dns_name}"
-    zone_id                = "${aws_lb.nginx_auth_external_alb.zone_id}"
-    evaluate_target_health = false
-  }
-}
-
 resource "aws_lb_target_group" "nginx_auth_proxy_external_endpoint" {
   name                 = "${var.stack_name}-ext-tg"
   port                 = 80
@@ -499,22 +485,19 @@ resource "aws_acm_certificate_validation" "alertmanager_cert" {
   validation_record_fqdns = ["${aws_route53_record.alertmanager_cert_validation.*.fqdn}"]
 }
 
-#### Uncomment this and remove the other alerts_alias when switching
-#### over from the old ALB
-#
-# resource "aws_route53_record" "alerts_alias" {
-#   count = "${local.alerts_records_count}"
+resource "aws_route53_record" "alerts_alias" {
+  count = "${local.alerts_records_count}"
 
-#   zone_id = "${var.zone_id}"
-#   name    = "alerts-${count.index + 1}"
-#   type    = "A"
+  zone_id = "${var.zone_id}"
+  name    = "alerts-${count.index + 1}"
+  type    = "A"
 
-#   alias {
-#     name                   = "${aws_lb.alertmanager_alb.dns_name}"
-#     zone_id                = "${aws_lb.alertmanager_alb.zone_id}"
-#     evaluate_target_health = false
-#   }
-# }
+  alias {
+    name                   = "${aws_lb.alertmanager_alb.dns_name}"
+    zone_id                = "${aws_lb.alertmanager_alb.zone_id}"
+    evaluate_target_health = false
+  }
+}
 
 resource "aws_security_group" "alertmanager_alb" {
   name        = "${var.stack_name}-alertmanager-alb-sg"

--- a/terraform/modules/app-ecs-albs/main.tf
+++ b/terraform/modules/app-ecs-albs/main.tf
@@ -525,6 +525,24 @@ resource "aws_security_group_rule" "alertmanager_alb_allow_https" {
   cidr_blocks       = ["${var.allowed_cidrs}"]
 }
 
+resource "aws_security_group_rule" "alertmanager_alb_to_alertmanager" {
+  security_group_id        = "${aws_security_group.alertmanager_alb.id}"
+  type                     = "egress"
+  from_port                = 9093
+  to_port                  = 9093
+  protocol                 = "tcp"
+  source_security_group_id = "${data.terraform_remote_state.infra_security_groups.monitoring_internal_sg_id}"
+}
+
+resource "aws_security_group_rule" "alertmanager_from_alertmanager_alb" {
+  security_group_id        = "${data.terraform_remote_state.infra_security_groups.monitoring_internal_sg_id}"
+  type                     = "ingress"
+  from_port                = 9093
+  to_port                  = 9093
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_security_group.alertmanager_alb.id}"
+}
+
 resource "aws_lb" "alertmanager_alb" {
   name               = "${var.stack_name}-alertmanager-alb"
   internal           = false

--- a/terraform/modules/app-ecs-services/alertmanager-service.tf
+++ b/terraform/modules/app-ecs-services/alertmanager-service.tf
@@ -131,7 +131,7 @@ resource "aws_ecs_service" "alertmanager_server" {
   desired_count   = 1
 
   load_balancer {
-    target_group_arn = "${element(data.terraform_remote_state.app_ecs_albs.monitoring_internal_tg, count.index)}"
+    target_group_arn = "${element(data.terraform_remote_state.app_ecs_albs.alertmanager_target_group_arns, count.index)}"
     container_name   = "alertmanager"
     container_port   = 9093
   }

--- a/terraform/projects/app-ecs-albs-dev/main.tf
+++ b/terraform/projects/app-ecs-albs-dev/main.tf
@@ -89,3 +89,7 @@ output "alerts_private_record_fqdns" {
 output "prometheus_target_group_arns" {
   value = "${module.app-ecs-albs.prometheus_target_group_ids}"
 }
+
+output "alertmanager_target_group_arns" {
+  value = "${module.app-ecs-albs.alertmanager_target_group_ids}"
+}

--- a/terraform/projects/app-ecs-albs-production/main.tf
+++ b/terraform/projects/app-ecs-albs-production/main.tf
@@ -88,3 +88,7 @@ output "alerts_private_record_fqdns" {
 output "prometheus_target_group_arns" {
   value = "${module.app-ecs-albs.prometheus_target_group_ids}"
 }
+
+output "alertmanager_target_group_arns" {
+  value = "${module.app-ecs-albs.alertmanager_target_group_ids}"
+}

--- a/terraform/projects/app-ecs-albs-staging/main.tf
+++ b/terraform/projects/app-ecs-albs-staging/main.tf
@@ -88,3 +88,7 @@ output "alerts_private_record_fqdns" {
 output "prometheus_target_group_arns" {
   value = "${module.app-ecs-albs.prometheus_target_group_ids}"
 }
+
+output "alertmanager_target_group_arns" {
+  value = "${module.app-ecs-albs.alertmanager_target_group_ids}"
+}


### PR DESCRIPTION
Actually changes traffic over for alertmanager to go through the
alertmanager ALB. Traffic is locked down at the load balancer
using security groups to office IPs.

After this is deployed we can then remove the nginx auth-proxy in
ECS and related load balancers/security groups.

Alertmanager itself remains in ECS.

Note, this will cause downtime between the deploy of the
ALBs and the alertmanager ECS service whilst the route53
records are swapped but the alertmanagers are not yet
registered to the new target groups.
