### PR TITLE
Change the alert URLS to reflect the revised re-team-manual

### DIFF
--- a/terraform/modules/app-ecs-services/config/alerts/observe-alerts.yml
+++ b/terraform/modules/app-ecs-services/config/alerts/observe-alerts.yml
@@ -11,7 +11,7 @@ groups:
         summary: "Prometheus is not able to scrape Grafana"
         description: "Prometheus has not successfully scraped {{ $labels.job }} in the last 5 minutes. https://grafana-paas.cloudapps.digital/ may be down."
         logs: "https://kibana.logit.io/s/8fd50110-7b0c-490a-bedf-7544daebbec4/app/kibana#/discover?_g=()&_a=(columns:!(_source),index:'*-*',interval:h,query:(query_string:(query:'grafana-paas.cloudapps.digital%20AND%20NOT%20access.response_code:200')),sort:!('@timestamp',desc))"
-        runbook: "https://re-team-manual.cloudapps.digital/observe-support.html#re-observe-grafana-down"
+        runbook: "https://re-team-manual.cloudapps.digital/prometheus-for-paas-support.html#re-observe-grafana-down"
 
   - alert: RE_Observe_AlertManager_Below_Threshold
     expr: up{job="alertmanager"} == 0 and ignoring(instance) sum without(instance) (up{job="alertmanager"}) <= 1
@@ -22,7 +22,7 @@ groups:
     annotations:
         summary: "Service is below the expected instance Threshold"
         description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}."
-        runbook: "https://re-team-manual.cloudapps.digital/observe-support.html#re-observe-alertmanager-below-threshold"
+        runbook: "https://re-team-manual.cloudapps.digital/prometheus-for-paas-support.html#re-observe-alertmanager-below-threshold"
 
   - alert: RE_Observe_Prometheus_Below_Threshold
     expr: up{job="prometheus"} == 0 and ignoring(instance) sum without(instance) (up{job="prometheus"}) <= 1
@@ -34,7 +34,7 @@ groups:
         summary: "Service is below the expected instance Threshold"
         description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}."
         logs: "https://kibana.logit.io/s/8fd50110-7b0c-490a-bedf-7544daebbec4/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),index:'*-*',interval:auto,query:(query_string:(query:'tags:%20prometheus')),sort:!('@timestamp',desc))"
-        runbook: "https://re-team-manual.cloudapps.digital/observe-support.html#re-observe-prometheus-below-threshold"
+        runbook: "https://re-team-manual.cloudapps.digital/prometheus-for-paas-support.html#re-observe-prometheus-below-threshold"
 
   - alert: RE_Observe_PrometheusDiskPredictedToFill
     expr: predict_linear(node_filesystem_avail{ mountpoint="/mnt", job="prometheus_node" }[12h], 3 * 86400) <= 0
@@ -44,7 +44,7 @@ groups:
     annotations:
         summary: "Instance {{ $labels.instance }} disk {{ $labels.mountpoint }} is predicted to fill in 72h"
         logs: "https://kibana.logit.io/s/8fd50110-7b0c-490a-bedf-7544daebbec4/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),index:'*-*',interval:auto,query:(query_string:(query:'tags:%20prometheus')),sort:!('@timestamp',desc))"
-        runbook: "https://re-team-manual.cloudapps.digital/observe-support.html#re-observe-prometheus-disk-predicted-to-fill"
+        runbook: "https://re-team-manual.cloudapps.digital/prometheus-for-paas-support.html#re-observe-prometheus-disk-predicted-to-fill"
 
   - alert: RE_Observe_No_FileSd_Targets
     # Notes:
@@ -60,7 +60,7 @@ groups:
         summary: "No file_sd targets detected"
         description: "No file_sd targets were detected.  Is there a problem accessing the targets bucket?"
         logs: "https://kibana.logit.io/s/8fd50110-7b0c-490a-bedf-7544daebbec4/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),index:'*-*',interval:auto,query:(query_string:(query:'tags:%20prometheus')),sort:!('@timestamp',desc))"
-        runbook: "https://re-team-manual.cloudapps.digital/observe-support.html#re-observe-no-filesd-targets"
+        runbook: "https://re-team-manual.cloudapps.digital/prometheus-for-paas-support.html#re-observe-no-filesd-targets"
 
   - alert: RE_Observe_Prometheus_Over_Capacity
     expr: sum without(slice)(rate(prometheus_engine_query_duration_seconds_sum{job="prometheus"}[5m])) > 8
@@ -72,7 +72,7 @@ groups:
         summary: "Service is over capacity."
         description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}."
         logs: "https://kibana.logit.io/s/8fd50110-7b0c-490a-bedf-7544daebbec4/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),index:'*-*',interval:auto,query:(query_string:(query:'tags:%20prometheus')),sort:!('@timestamp',desc))"
-        runbook: "https://re-team-manual.cloudapps.digital/observe-support.html#re-observe-prometheus-over-capacity"
+        runbook: "https://re-team-manual.cloudapps.digital/prometheus-for-paas-support.html#re-observe-prometheus-over-capacity"
 
   - alert: RE_Observe_Prometheus_High_Load
     expr: sum without(slice)(rate(prometheus_engine_query_duration_seconds_sum{job="prometheus"}[2h])) > 4
@@ -83,7 +83,7 @@ groups:
         summary: "Service is approaching capacity."
         description: "The service name is {{ $labels.job }}. The URL experiencing the issue is {{ $labels.instance }}."
         logs: "https://kibana.logit.io/s/8fd50110-7b0c-490a-bedf-7544daebbec4/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),index:'*-*',interval:auto,query:(query_string:(query:'tags:%20prometheus')),sort:!('@timestamp',desc))"
-        runbook: "https://re-team-manual.cloudapps.digital/observe-support.html#re-observe-prometheus-high-load"
+        runbook: "https://re-team-manual.cloudapps.digital/prometheus-for-paas-support.html#re-observe-prometheus-high-load"
 
   - alert: RE_Observe_Target_Down
     expr: up{} == 0
@@ -94,4 +94,4 @@ groups:
     annotations:
         summary: "{{ $labels.job }} target is down"
         description: "One of the {{ $labels.job }} targets has been down for 24 hours"
-        runbook: "https://re-team-manual.cloudapps.digital/observe-support.html#re-observe-target-down"
+        runbook: "https://re-team-manual.cloudapps.digital/prometheus-for-paas-support.html#re-observe-target-down"


### PR DESCRIPTION
# Why I am making this change

With Observe being disbanded and their functionality being moved to Autom8 the docs need updating

https://trello.com/c/loV2aljk/804-create-rename-re-team-manual-section-for-prometheus-for-gds-paas-users

# Relies on

https://github.com/alphagov/re-team-manual/pull/58
