### PR TITLE
bump pyyaml dependency in grafana_info script

### DIFF
--- a/tools/grafana_info/requirements.txt
+++ b/tools/grafana_info/requirements.txt
@@ -1,3 +1,3 @@
 grafana-api==0.2.4
 simplejson==3.16.0
-pyyaml==3.13
+pyyaml>=4.2b1


### PR DESCRIPTION
this isn't critical but it's causing a security warning so let's bump
the version to silence it.

Tested locally, all still works.

