### PR TITLE
Implemented new security groups with sane naming scheme.

### DIFF
--- a/terraform/modules/app-ecs-albs/main.tf
+++ b/terraform/modules/app-ecs-albs/main.tf
@@ -192,8 +192,7 @@ resource "aws_lb" "prometheus_alb" {
   internal           = false
   load_balancer_type = "application"
 
-  security_groups = [
-    "${data.terraform_remote_state.infra_security_groups.monitoring_external_sg_id}",
+  security_groups = ["${data.terraform_remote_state.infra_security_groups.prometheus_alb_sg_id}", "${data.terraform_remote_state.infra_security_groups.monitoring_external_sg_id}",
     "${aws_security_group.prometheus_alb.id}",
   ]
 
@@ -384,6 +383,7 @@ resource "aws_lb" "alertmanager_alb" {
   load_balancer_type = "application"
 
   security_groups = [
+    "${data.terraform_remote_state.infra_security_groups.alertmanager_alb_sg_id}",
     "${aws_security_group.alertmanager_alb.id}",
   ]
 

--- a/terraform/modules/app-ecs-instances/main.tf
+++ b/terraform/modules/app-ecs-instances/main.tf
@@ -136,7 +136,9 @@ module "ecs_instance" {
   image_id      = "${module.ami.ecs_optimized_ami_id}"
   instance_type = "${var.ecs_instance_type}"
 
-  security_groups = ["${data.terraform_remote_state.infra_security_groups.monitoring_internal_sg_id}",
+  security_groups = [
+    "${data.terraform_remote_state.infra_security_groups.alertmanager_ec2_sg_id}",
+    "${data.terraform_remote_state.infra_security_groups.monitoring_internal_sg_id}",
     "${data.terraform_remote_state.infra_security_groups.monitoring_external_sg_id}",
   ]
 

--- a/terraform/modules/infra-security-groups/main.tf
+++ b/terraform/modules/infra-security-groups/main.tf
@@ -28,6 +28,21 @@ variable "project" {
   description = "Which project, in which environment, we're running"
 }
 
+variable "allowed_cidrs" {
+  type        = "list"
+  description = "List of CIDRs which are able to access the alertmanager ALB, default are GDS ips"
+
+  default = [
+    "213.86.153.212/32",
+    "213.86.153.213/32",
+    "213.86.153.214/32",
+    "213.86.153.235/32",
+    "213.86.153.236/32",
+    "213.86.153.237/32",
+    "85.133.67.244/32",
+  ]
+}
+
 # locals
 # --------------------------------------------------------------
 
@@ -53,7 +68,184 @@ data "terraform_remote_state" "infra_networking" {
   }
 }
 
-## Resources
+resource "aws_security_group" "prometheus_alb" {
+  name        = "${var.stack_name}-prometheus-alb"
+  vpc_id      = "${data.terraform_remote_state.infra_networking.vpc_id}"
+  description = "Controls ingress and egress for prometheus ALB"
+
+  tags = "${merge(
+    local.default_tags,
+    map("Stackname", "${var.stack_name}"),
+  )}"
+}
+
+# We allow all IPs to access the ALB as Prometheus is fronted by an nginx which controls access to either approved IP
+# addresses, or users with basic auth creds
+resource "aws_security_group_rule" "ingress_from_public_http_to_prometheus_alb" {
+  security_group_id = "${aws_security_group.prometheus_alb.id}"
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "ingress_from_public_https_to_prometheus_alb" {
+  security_group_id = "${aws_security_group.prometheus_alb.id}"
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "egress_from_prometheus_alb_to_prometheus_ec2" {
+  security_group_id        = "${aws_security_group.prometheus_alb.id}"
+  type                     = "egress"
+  to_port                  = 80
+  from_port                = 80
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_security_group.prometheus_ec2.id}"
+}
+
+resource "aws_security_group" "prometheus_ec2" {
+  name        = "${var.stack_name}-prometheus-ec2"
+  vpc_id      = "${data.terraform_remote_state.infra_networking.vpc_id}"
+  description = "Controls ingress and egress for prometheus EC2 instances"
+
+  tags = "${merge(
+    local.default_tags,
+    map("Stackname", "${var.stack_name}"),
+  )}"
+}
+
+resource "aws_security_group_rule" "ingress_from_prometheus_alb_to_prometheus_ec2" {
+  security_group_id        = "${aws_security_group.prometheus_ec2.id}"
+  type                     = "ingress"
+  to_port                  = 80
+  from_port                = 80
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_security_group.prometheus_alb.id}"
+}
+
+resource "aws_security_group_rule" "ingress_from_prometheus_ec2_to_prometheus_ec2" {
+  security_group_id        = "${aws_security_group.prometheus_ec2.id}"
+  type                     = "ingress"
+  to_port                  = 9090
+  from_port                = 9090
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_security_group.prometheus_ec2.id}"
+}
+
+resource "aws_security_group_rule" "ingress_from_prometheus_to_prometheus_node_exporter" {
+  security_group_id        = "${aws_security_group.prometheus_ec2.id}"
+  type                     = "ingress"
+  to_port                  = 9090
+  from_port                = 9090
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_security_group.prometheus_ec2.id}"
+}
+
+# This rule allows all egress out of prometheus_ec2. This is for the following purposes:
+# - downloading packages from package repos
+# - calling AWS APIs such as SSM, S3 and EC2
+# - scraping alertmanager on port 9093
+# - sending alerts to alertmanager on port 9093
+# - scraping external targets that run on the PaaS
+# - scraping itself and other promethis on port 9090
+# - scraping node exporters on port 9100
+resource "aws_security_group_rule" "egress_from_prometheus_ec2_to_all" {
+  security_group_id = "${aws_security_group.prometheus_ec2.id}"
+  type              = "egress"
+  to_port           = 0
+  from_port         = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group" "alertmanager_alb" {
+  name        = "${var.stack_name}-alertmanager-alb"
+  vpc_id      = "${data.terraform_remote_state.infra_networking.vpc_id}"
+  description = "Controls ingress and egress for the alertmanager alb"
+
+  tags = "${merge(
+    local.default_tags,
+    map("Stackname", "${var.stack_name}"),
+  )}"
+}
+
+resource "aws_security_group_rule" "ingress_from_office_http_to_alertmanager_alb" {
+  security_group_id = "${aws_security_group.alertmanager_alb.id}"
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = ["${var.allowed_cidrs}"]
+}
+
+resource "aws_security_group_rule" "ingress_from_office_https_to_alertmanager_alb" {
+  security_group_id = "${aws_security_group.alertmanager_alb.id}"
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["${var.allowed_cidrs}"]
+}
+
+resource "aws_security_group_rule" "egress_from_alertmanager_alb_to_alertmanager_ec2" {
+  security_group_id        = "${aws_security_group.alertmanager_alb.id}"
+  type                     = "egress"
+  to_port                  = 9093
+  from_port                = 9093
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_security_group.alertmanager_ec2.id}"
+}
+
+resource "aws_security_group" "alertmanager_ec2" {
+  name        = "${var.stack_name}-alertmanager-ec2"
+  vpc_id      = "${data.terraform_remote_state.infra_networking.vpc_id}"
+  description = "Controls ingress and egress for alertmanager ec2 instances"
+
+  tags = "${merge(
+    local.default_tags,
+    map("Stackname", "${var.stack_name}"),
+  )}"
+}
+
+resource "aws_security_group_rule" "ingress_from_alertmanager_alb_to_alertmanager_ec2" {
+  security_group_id        = "${aws_security_group.alertmanager_ec2.id}"
+  type                     = "ingress"
+  from_port                = 9093
+  to_port                  = 9093
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_security_group.alertmanager_alb.id}"
+}
+
+resource "aws_security_group_rule" "ingress_from_prometheus_ec2_to_alertmanager_ec2" {
+  security_group_id        = "${aws_security_group.alertmanager_ec2.id}"
+  type                     = "ingress"
+  from_port                = 9093
+  to_port                  = 9093
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_security_group.prometheus_ec2.id}"
+}
+
+# This rule allows all egress out of alertmanager_ec2. This is for the following purposes:
+# - downloading packages from package repos
+# - calling AWS APIs such as SSM, S3 and EC2
+# - raising alerts with receivers such as pagerduty and cronitor
+# - sending emails via AWS API
+# - communicate with other alertmanagers to mesh
+resource "aws_security_group_rule" "egress_from_alertmanager_ec2_to_all" {
+  security_group_id = "${aws_security_group.alertmanager_ec2.id}"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+## All below resources are for the original security groups and will be removed after migration to new security groups
 
 ### External SG
 
@@ -139,4 +331,24 @@ output "monitoring_external_sg_id" {
 output "monitoring_internal_sg_id" {
   value       = "${aws_security_group.monitoring_internal_sg.id}"
   description = "monitoring_internal_sg ID"
+}
+
+output "prometheus_ec2_sg_id" {
+  value       = "${aws_security_group.prometheus_ec2.id}"
+  description = "security group prometheus_ec2 ID"
+}
+
+output "prometheus_alb_sg_id" {
+  value       = "${aws_security_group.prometheus_alb.id}"
+  description = "security group prometheus_alb ID"
+}
+
+output "alertmanager_ec2_sg_id" {
+  value       = "${aws_security_group.alertmanager_ec2.id}"
+  description = "security group alertmanager_ec2 ID"
+}
+
+output "alertmanager_alb_sg_id" {
+  value       = "${aws_security_group.alertmanager_alb.id}"
+  description = "security group alertmanager_alb ID"
 }

--- a/terraform/projects/infra-security-groups-dev/main.tf
+++ b/terraform/projects/infra-security-groups-dev/main.tf
@@ -58,3 +58,23 @@ output "monitoring_internal_sg_id" {
   value       = "${module.infra-security-groups.monitoring_internal_sg_id}"
   description = "monitoring_internal_sg ID"
 }
+
+output "prometheus_ec2_sg_id" {
+  value       = "${module.infra-security-groups.prometheus_ec2_sg_id}"
+  description = "security group prometheus_ec2 ID"
+}
+
+output "prometheus_alb_sg_id" {
+  value       = "${module.infra-security-groups.prometheus_alb_sg_id}"
+  description = "security group prometheus_alb ID"
+}
+
+output "alertmanager_ec2_sg_id" {
+  value       = "${module.infra-security-groups.alertmanager_ec2_sg_id}"
+  description = "security group alertmanager_ec2 ID"
+}
+
+output "alertmanager_alb_sg_id" {
+  value       = "${module.infra-security-groups.alertmanager_alb_sg_id}"
+  description = "security group alertmanager_alb ID"
+}

--- a/terraform/projects/infra-security-groups-production/main.tf
+++ b/terraform/projects/infra-security-groups-production/main.tf
@@ -57,3 +57,23 @@ output "monitoring_internal_sg_id" {
   value       = "${module.infra-security-groups.monitoring_internal_sg_id}"
   description = "monitoring_internal_sg ID"
 }
+
+output "prometheus_ec2_sg_id" {
+  value       = "${module.infra-security-groups.prometheus_ec2_sg_id}"
+  description = "security group prometheus_ec2 ID"
+}
+
+output "prometheus_alb_sg_id" {
+  value       = "${module.infra-security-groups.prometheus_alb_sg_id}"
+  description = "security group prometheus_alb ID"
+}
+
+output "alertmanager_ec2_sg_id" {
+  value       = "${module.infra-security-groups.alertmanager_ec2_sg_id}"
+  description = "security group alertmanager_ec2 ID"
+}
+
+output "alertmanager_alb_sg_id" {
+  value       = "${module.infra-security-groups.alertmanager_alb_sg_id}"
+  description = "security group alertmanager_alb ID"
+}

--- a/terraform/projects/infra-security-groups-staging/main.tf
+++ b/terraform/projects/infra-security-groups-staging/main.tf
@@ -57,3 +57,23 @@ output "monitoring_internal_sg_id" {
   value       = "${module.infra-security-groups.monitoring_internal_sg_id}"
   description = "monitoring_internal_sg ID"
 }
+
+output "prometheus_ec2_sg_id" {
+  value       = "${module.infra-security-groups.prometheus_ec2_sg_id}"
+  description = "security group prometheus_ec2 ID"
+}
+
+output "prometheus_alb_sg_id" {
+  value       = "${module.infra-security-groups.prometheus_alb_sg_id}"
+  description = "security group prometheus_alb ID"
+}
+
+output "alertmanager_ec2_sg_id" {
+  value       = "${module.infra-security-groups.alertmanager_ec2_sg_id}"
+  description = "security group alertmanager_ec2 ID"
+}
+
+output "alertmanager_alb_sg_id" {
+  value       = "${module.infra-security-groups.alertmanager_alb_sg_id}"
+  description = "security group alertmanager_alb ID"
+}

--- a/terraform/projects/prom-ec2/paas-dev/main.tf
+++ b/terraform/projects/prom-ec2/paas-dev/main.tf
@@ -71,7 +71,7 @@ module "prometheus" {
 
   subnet_ids            = "${data.terraform_remote_state.infra_networking.private_subnets}"
   availability_zones    = "${data.terraform_remote_state.infra_networking.subnets_by_az}"
-  vpc_security_groups   = ["${data.terraform_remote_state.infra_security_groups.monitoring_external_sg_id}"]
+  vpc_security_groups   = ["${data.terraform_remote_state.infra_security_groups.prometheus_ec2_sg_id}", "${data.terraform_remote_state.infra_security_groups.monitoring_external_sg_id}"]
   source_security_group = "${data.terraform_remote_state.infra_security_groups.monitoring_internal_sg_id}"
   region                = "eu-west-1"
 

--- a/terraform/projects/prom-ec2/paas-production/main.tf
+++ b/terraform/projects/prom-ec2/paas-production/main.tf
@@ -86,7 +86,7 @@ module "prometheus" {
 
   subnet_ids            = "${data.terraform_remote_state.infra_networking.private_subnets}"
   availability_zones    = "${data.terraform_remote_state.infra_networking.subnets_by_az}"
-  vpc_security_groups   = ["${data.terraform_remote_state.infra_security_groups.monitoring_external_sg_id}"]
+  vpc_security_groups   = ["${data.terraform_remote_state.infra_security_groups.prometheus_ec2_sg_id}", "${data.terraform_remote_state.infra_security_groups.monitoring_external_sg_id}"]
   source_security_group = "${data.terraform_remote_state.infra_security_groups.monitoring_internal_sg_id}"
   region                = "eu-west-1"
 

--- a/terraform/projects/prom-ec2/paas-staging/main.tf
+++ b/terraform/projects/prom-ec2/paas-staging/main.tf
@@ -81,7 +81,7 @@ module "prometheus" {
 
   subnet_ids            = "${data.terraform_remote_state.infra_networking.private_subnets}"
   availability_zones    = "${data.terraform_remote_state.infra_networking.subnets_by_az}"
-  vpc_security_groups   = ["${data.terraform_remote_state.infra_security_groups.monitoring_external_sg_id}"]
+  vpc_security_groups   = ["${data.terraform_remote_state.infra_security_groups.prometheus_ec2_sg_id}", "${data.terraform_remote_state.infra_security_groups.monitoring_external_sg_id}"]
   source_security_group = "${data.terraform_remote_state.infra_security_groups.monitoring_internal_sg_id}"
   region                = "eu-west-1"
 


### PR DESCRIPTION
Added new security groups and added to the resources, removal of the old
SGs will happen in a later PR.
Currently egress is allowed to any this may be tightened at a later
date.

Pair: matthewcullum-gds idavidmcdonald

# Why I am making this change

The old security groups were named badly and did not reflect what they did

# What approach I took

Has been applied to the dev stack to ensure that we can deploy with no down time and that we have retained all functionality.
