### PR TITLE
Add relabel_configs to allow /_metrics scrape paths for DM

### DIFF
--- a/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
+++ b/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
@@ -39,6 +39,22 @@ scrape_configs:
     file_sd_configs:
       - files: ['/etc/prometheus/targets/*.json']
         refresh_interval: 30s
+    # Digital marketplace's API and frontend apps listen on a
+    # different metrics path, so when we detect one we modify the
+    # __metrics_path__ label to set the path we scrape
+    relabel_configs:
+      - source_labels: ['__metrics_path__', 'org', 'job']
+        regex: '(.*)/metrics;digitalmarketplace;api'
+        target_label: '__metrics_path__'
+        replacement: '$1/_metrics'
+      - source_labels: ['__metrics_path__', 'org', 'job']
+        regex: '(.*)/metrics;digitalmarketplace;.*-api'
+        target_label: '__metrics_path__'
+        replacement: '$1/_metrics'
+      - source_labels: ['__metrics_path__', 'org', 'job']
+        regex: '(.*)/metrics;digitalmarketplace;.*-frontend'
+        target_label: '__metrics_path__'
+        replacement: '$1/_metrics'
   - job_name: alertmanager
     ec2_sd_configs:
       - region: eu-west-1


### PR DESCRIPTION
Digital marketplace are instrumenting their apps, and they have URL
slugs that are dependent on content submitted by users.  This means
that `/.../metrics` isn't guaranteed to be available on their apps (and in
fact is not available on one of them).

They are able to serve metrics from a `/.../_metrics` endpoint
instead.  But I can't think of any general way for them to tell
us (via the service broker) about a custom metrics endpoint that we
should be scraping.

In lieu of a clean, self-service solution like that, I offer this hack
instead.  This commit adds relabel_configs to the paas-targets scrape
config.  They detect any apps running in the `digitalmarketplace` org,
with app name `api`, `*-api` or `*-frontend`, and change the
`__metrics_path__` label to end in `/_metrics` instead of `/metrics`.

Targets which do not match the regex will be unaffected and continue
to work as before.

# Why I am making this change

<write down the problem you are trying to solve, feature you are
trying to implement, etc>

# What approach I took

<write down any notable decisions you took in terms of implementation.
Small changes don't need much explanation here.>
