### PR TITLE
set XX-CF-APP-INSTANCE as well

### DIFF
--- a/terraform/modules/prom-ec2/prometheus/cloud.conf
+++ b/terraform/modules/prom-ec2/prometheus/cloud.conf
@@ -64,6 +64,7 @@ write_files:
           proxy_pass https://$host$uri;
           proxy_ssl_server_name on;
           proxy_set_header X-CF-APP-INSTANCE $cleaned_header;
+          proxy_set_header XX-CF-APP-INSTANCE $cleaned_header;
           proxy_set_header Authorization "Bearer $arg_cf_app_guid";
         }
 


### PR DESCRIPTION
See alphagov/re-paas-ip-safelist-service#5 for why we need this extra
header.

