### PR TITLE
Added node_creation_time metric.

### DIFF
--- a/terraform/modules/prom-ec2/prometheus/cloud.conf
+++ b/terraform/modules/prom-ec2/prometheus/cloud.conf
@@ -116,4 +116,5 @@ runcmd:
   - [bash, -c, "/root/format_disk.sh"]
   - [bash, -c, "mount /dev/xvdh /mnt"]
   - [bash, -c, "chown -R prometheus /mnt/"]
+  - [bash, -c, "echo \"node_creation_time `date +%s`\" > /var/lib/prometheus/node-exporter/node-creation-time.prom"]
   - [reboot]


### PR DESCRIPTION
We use this metric in logic to adjust the predict_linear function and
prevent false alerts.

Single: matthewcullum-gds

# Why I am making this change

Our dashboards are creating false alerts everytime a prometheus is respun

