### PR TITLE
Use node_creation_time with predict_linear

### DIFF
--- a/terraform/modules/app-ecs-services/config/alerts/observe-alerts.yml
+++ b/terraform/modules/app-ecs-services/config/alerts/observe-alerts.yml
@@ -35,7 +35,7 @@ groups:
         runbook: "https://re-team-manual.cloudapps.digital/prometheus-for-gds-paas-users.html#re-observe-prometheus-below-threshold"
 
   - alert: RE_Observe_PrometheusDiskPredictedToFill
-    expr: predict_linear(node_filesystem_avail{ mountpoint="/mnt", job="prometheus_node" }[12h], 3 * 86400) <= 0
+    expr: predict_linear(node_filesystem_avail{ mountpoint="/mnt", job="prometheus_node" }[12h], 3 * 86400)  and on (instance) (time() - node_creation_time) > 43200 <= 0
     labels:
         product: "prometheus"
         severity: "ticket"


### PR DESCRIPTION
Use the new node_creation_time metric with the predict_linear function
to reduce the number of false alerts. Now the alert will only fire if
the node has been created for the entire evaluation time. This prevents
newly spun up instances from falsely alerting.

Single: matthewcullum-gds

