### PR TITLE
Update alertmanager mesh-n DNS records when instances respin

### DIFF
--- a/terraform/modules/app-ecs-instances/instance-user-data.tpl
+++ b/terraform/modules/app-ecs-instances/instance-user-data.tpl
@@ -3,5 +3,53 @@
 echo "ECS_CLUSTER=${cluster_name}" >> /etc/ecs/ecs.config
 yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
 yum install -y ecs-init
+yum install -y aws-cli
 start amazon-ssm-agent ecs
+
+AZ=$(curl http://169.254.169.254/latest/meta-data/placement/availability-zone)
+IPV4_ADDRESS=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
+
+case "$AZ" in
+        "eu-west-1a")
+            dns_name="mesh-1"
+            ;;
+
+        "eu-west-1b")
+            dns_name="mesh-2"
+            ;;
+
+        "eu-west-1c")
+            dns_name="mesh-3"
+            ;;
+
+         *)
+            echo "no Dns values found"
+            ;;
+
+esac
+
+mkdir /ecs/
+cat <<EOF > /ecs/dns_update.json
+{
+    "Comment": "Update new instance IP address route 53",
+    "Changes": [
+        {
+            "Action": "UPSERT",
+            "ResourceRecordSet": {
+                "Name": "$dns_name.${private_subdomain}",
+                "Type": "A",
+                "TTL": 300,
+                "ResourceRecords": [
+                    {
+                        "Value": "$IPV4_ADDRESS"
+                    }
+                ]
+            }
+        }
+    ]
+}
+EOF
+
+aws route53 change-resource-record-sets --hosted-zone-id ${dns_zone_id} --change-batch file:///ecs/dns_update.json
+
 service docker start

--- a/terraform/modules/app-ecs-instances/main.tf
+++ b/terraform/modules/app-ecs-instances/main.tf
@@ -117,7 +117,9 @@ data "template_file" "instance_user_data" {
   template = "${file("${path.module}/instance-user-data.tpl")}"
 
   vars {
-    cluster_name = "${local.cluster_name}"
+    dns_zone_id       = "${data.terraform_remote_state.infra_networking.private_zone_id}"
+    private_subdomain = "${data.terraform_remote_state.infra_networking.private_subdomain}"
+    cluster_name      = "${local.cluster_name}"
   }
 }
 

--- a/terraform/modules/infra-security-groups/main.tf
+++ b/terraform/modules/infra-security-groups/main.tf
@@ -230,6 +230,15 @@ resource "aws_security_group_rule" "ingress_from_prometheus_ec2_to_alertmanager_
   source_security_group_id = "${aws_security_group.prometheus_ec2.id}"
 }
 
+resource "aws_security_group_rule" "ingress_from_alertmanager_ec2_to_alertmanager_ec2" {
+  security_group_id        = "${aws_security_group.alertmanager_ec2.id}"
+  type                     = "ingress"
+  from_port                = 9094
+  to_port                  = 9094
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_security_group.alertmanager_ec2.id}"
+}
+
 # This rule allows all egress out of alertmanager_ec2. This is for the following purposes:
 # - downloading packages from package repos
 # - calling AWS APIs such as SSM, S3 and EC2


### PR DESCRIPTION
- Nowhere in Terraform were the alertmanager `mesh-(1,2,3)` DNS records
  being updated when the ECS EC2 instances re-spun.
- This turned out to be because it was deleted (for no apparent reason)
  in c49bbcdb7a09a31050e0e68023a0024c6a028b61, after being added in
  09e6e89780abd61bd580e620f700f9a3b4bae6c9. We found this with use of
  `git log --follow terraform/modules/app-ecs-instances/instance-user-data.tpl`
  as it had since been moved around a bit after the Great Modularization
  of 2018.
- Now this is restored (and a new `AZ` variable created that pulls the
  instance's current AZ from the AWS metadata API to make it work), the
  DNS records are updated whenever an instance re-spins, so AlertManager
  so AlertManager should be able to at least start meshing.

Co-authored-by: Matthew Cullum <matthew.cullum@digital.cabinet-office.gov.uk>