### PR TITLE
Use host networking mode for alertmanager

### DIFF
--- a/terraform/modules/app-ecs-services/alertmanager-service.tf
+++ b/terraform/modules/app-ecs-services/alertmanager-service.tf
@@ -108,6 +108,7 @@ resource "aws_ecs_task_definition" "alertmanager_server" {
   family                = "${var.stack_name}-alertmanager-server-${count.index + 1}"
   container_definitions = "${element(data.template_file.alertmanager_container_defn.*.rendered, count.index)}"
   task_role_arn         = "${aws_iam_role.alertmanager_task_iam_role.arn}"
+  network_mode          = "host"
 
   volume {
     name      = "config-from-s3"


### PR DESCRIPTION
We believe that docker networking is causing alertmanager to behave
confusingly.

AlertManager currently presents its peers as:

```
Peers:
Name: 01D4MGAACVY855S6BXA88999EV
Address: 172.17.0.2:9094
Name: 01D4MGMMDE8APJ32ZVCCTFNGD1
Address: 172.17.0.3:9094
```

The 172.17.0.0/16 cidr refers to docker networking, whereas the DNS
records point to at 10/ cidr.

Using the host networking mode will give the private IP of the box to
alertmanager: i.e. `10.0.1.25`