### PR TITLE
send resolved alerts to slack

### DIFF
--- a/terraform/modules/app-ecs-services/templates/alertmanager.tpl
+++ b/terraform/modules/app-ecs-services/templates/alertmanager.tpl
@@ -93,7 +93,8 @@ receivers:
     url: "${verify_joint_cronitor}"
 - name: "autom8-slack"
   slack_configs:
-  - channel: '#re-autom8-alerts'
+  - send_resolved: true
+    channel: '#re-autom8-alerts'
     icon_emoji: ':verify-shield:'
     username: alertmanager
 - name: "verify-p1"


### PR DESCRIPTION
Right now, we only send firing alerts to slack, but we don't say when they've resolved.