### PR TITLE
Send Verify P1 alerts to Slack as well as PagerDuty

### DIFF
--- a/terraform/modules/app-ecs-services/templates/alertmanager.tpl
+++ b/terraform/modules/app-ecs-services/templates/alertmanager.tpl
@@ -92,7 +92,7 @@ receivers:
   - send_resolved: false
     url: "${verify_joint_cronitor}"
 - name: "verify-2ndline-slack"
-  slack_configs:
+  slack_configs: &verify-2ndline-slack-configs
   - send_resolved: true
     channel: '#verify-2ndline'
     icon_emoji: ':verify-shield:'
@@ -100,3 +100,5 @@ receivers:
 - name: "verify-p1"
   pagerduty_configs:
     - service_key: "${verify_p1_pagerduty_key}"
+  slack_configs: *verify-2ndline-slack-configs
+

--- a/terraform/modules/app-ecs-services/templates/alertmanager.tpl
+++ b/terraform/modules/app-ecs-services/templates/alertmanager.tpl
@@ -32,7 +32,7 @@ route:
     match:
       product: "prometheus"
       severity: "constant"
-  - receiver: "autom8-slack"
+  - receiver: "verify-2ndline-slack"
     match:
       product: "verify"
     routes:
@@ -91,7 +91,7 @@ receivers:
   webhook_configs:
   - send_resolved: false
     url: "${verify_joint_cronitor}"
-- name: "autom8-slack"
+- name: "verify-2ndline-slack"
   slack_configs:
   - send_resolved: true
     channel: '#verify-2ndline'


### PR DESCRIPTION
# Why I am making this change

Previously, all alerts *except* P1s went to Slack, P1s only went to
PagerDuty. For visibility for people not on-call or following along from
home, we want P1s to hit Slack too.

# What approach I took

This adds the Slack config to the "verify-p1" receiver that sends to
PagerDuty, as per
https://www.robustperception.io/sending-alert-notifications-to-multiple-destinations,
with some YAML anchors.

This also changes the Slack receiver from `autom8` to `verify-2ndline`
to reflect what the destination Slack channel actually is now.