### PR TITLE
Send Verify P2 alerts (integration) to Slack and PagerDuty

### DIFF
--- a/terraform/modules/app-ecs-services/templates/alertmanager.tpl
+++ b/terraform/modules/app-ecs-services/templates/alertmanager.tpl
@@ -40,6 +40,10 @@ route:
       match:
         deployment: prod
         severity: p1
+    - receiver: "verify-p2"
+      match:
+        deployment: integration
+        severity: p2
     - match:
         severity: constant
       group_interval: 1m
@@ -101,4 +105,7 @@ receivers:
   pagerduty_configs:
     - service_key: "${verify_p1_pagerduty_key}"
   slack_configs: *verify-2ndline-slack-configs
-
+- name: "verify-p2"
+  pagerduty_configs:
+    - service_key: "${verify_p1_pagerduty_key}"
+  slack_configs: *verify-2ndline-slack-configs


### PR DESCRIPTION
https://trello.com/c/0P66rAiU/319-make-integration-alerts-go-to-p2-pagerduty

@andy-paine Is this sort of what you want? (We'll have to change the actual alert definitions to mark as P2, but this is a start of the routing I think?)