### PR TITLE
switch load balancer listeners to use the fargate services

### DIFF
--- a/terraform/projects/app-ecs-albs-dev/main.tf
+++ b/terraform/projects/app-ecs-albs-dev/main.tf
@@ -75,10 +75,6 @@ output "prometheus_target_group_arns" {
   value = "${module.app-ecs-albs.prometheus_target_group_ids}"
 }
 
-output "alertmanager_target_group_arns" {
-  value = "${module.app-ecs-albs.alertmanager_target_group_ids}"
-}
-
 output "alertmanager_ip_target_group_arns" {
   value = "${module.app-ecs-albs.alertmanager_ip_target_group_ids}"
 }

--- a/terraform/projects/app-ecs-albs-production/main.tf
+++ b/terraform/projects/app-ecs-albs-production/main.tf
@@ -74,10 +74,6 @@ output "prometheus_target_group_arns" {
   value = "${module.app-ecs-albs.prometheus_target_group_ids}"
 }
 
-output "alertmanager_target_group_arns" {
-  value = "${module.app-ecs-albs.alertmanager_target_group_ids}"
-}
-
 output "alertmanager_ip_target_group_arns" {
   value = "${module.app-ecs-albs.alertmanager_ip_target_group_ids}"
 }

--- a/terraform/projects/app-ecs-albs-staging/main.tf
+++ b/terraform/projects/app-ecs-albs-staging/main.tf
@@ -74,10 +74,6 @@ output "prometheus_target_group_arns" {
   value = "${module.app-ecs-albs.prometheus_target_group_ids}"
 }
 
-output "alertmanager_target_group_arns" {
-  value = "${module.app-ecs-albs.alertmanager_target_group_ids}"
-}
-
 output "alertmanager_ip_target_group_arns" {
   value = "${module.app-ecs-albs.alertmanager_ip_target_group_ids}"
 }


### PR DESCRIPTION
This switches the load balancer listener rules so that alerts-1.* goes
to the fargate alertmanager instead of the EC2-ECS alertmanager.

A future PR will remove all the old EC2 instances, ECS services etc.

