### PR TITLE
Add Cloud Security Watch to Staging and Production environments

### DIFF
--- a/terraform/projects/app-ecs-albs-production/main.tf
+++ b/terraform/projects/app-ecs-albs-production/main.tf
@@ -49,6 +49,12 @@ data "terraform_remote_state" "infra_networking" {
   }
 }
 
+module "csw_role" {
+  source = "git::https://github.com/alphagov/csw-client-role.git?ref=v1.2"
+
+  csw_agent_account_id = "779799343306"
+}
+
 module "app-ecs-albs" {
   source = "../../modules/app-ecs-albs/"
 

--- a/terraform/projects/app-ecs-albs-staging/main.tf
+++ b/terraform/projects/app-ecs-albs-staging/main.tf
@@ -49,6 +49,12 @@ data "terraform_remote_state" "infra_networking" {
   }
 }
 
+module "csw_role" {
+  source = "git::https://github.com/alphagov/csw-client-role.git?ref=v1.2"
+
+  csw_agent_account_id = "779799343306"
+}
+
 module "app-ecs-albs" {
   source = "../../modules/app-ecs-albs/"
 

--- a/terraform/projects/app-ecs-services-production/main.tf
+++ b/terraform/projects/app-ecs-services-production/main.tf
@@ -62,6 +62,12 @@ variable "remote_state_bucket" {
   default     = "prometheus-production"
 }
 
+module "csw_role" {
+  source = "git::https://github.com/alphagov/csw-client-role.git?ref=v1.2"
+
+  csw_agent_account_id = "779799343306"
+}
+
 module "app-ecs-services" {
   source = "../../modules/app-ecs-services"
 

--- a/terraform/projects/app-ecs-services-staging/main.tf
+++ b/terraform/projects/app-ecs-services-staging/main.tf
@@ -62,6 +62,12 @@ variable "remote_state_bucket" {
   default     = "prometheus-staging"
 }
 
+module "csw_role" {
+  source = "git::https://github.com/alphagov/csw-client-role.git?ref=v1.2"
+
+  csw_agent_account_id = "779799343306"
+}
+
 module "app-ecs-services" {
   source = "../../modules/app-ecs-services"
 

--- a/terraform/projects/infra-networking-production/main.tf
+++ b/terraform/projects/infra-networking-production/main.tf
@@ -37,6 +37,12 @@ variable "stack_name" {
   default     = "production"
 }
 
+module "csw_role" {
+  source = "git::https://github.com/alphagov/csw-client-role.git?ref=v1.2"
+
+  csw_agent_account_id = "779799343306"
+}
+
 module "infra-networking" {
   source = "../../modules/infra-networking"
 

--- a/terraform/projects/infra-networking-staging/main.tf
+++ b/terraform/projects/infra-networking-staging/main.tf
@@ -37,6 +37,12 @@ variable "project" {
   default     = "infra-networking-staging"
 }
 
+module "csw_role" {
+  source = "git::https://github.com/alphagov/csw-client-role.git?ref=v1.2"
+
+  csw_agent_account_id = "779799343306"
+}
+
 module "infra-networking" {
   source = "../../modules/infra-networking"
 

--- a/terraform/projects/infra-security-groups-production/main.tf
+++ b/terraform/projects/infra-security-groups-production/main.tf
@@ -37,6 +37,12 @@ variable "project" {
   default     = "infra-security-groups-production"
 }
 
+module "csw_role" {
+  source = "git::https://github.com/alphagov/csw-client-role.git?ref=v1.2"
+
+  csw_agent_account_id = "779799343306"
+}
+
 module "infra-security-groups" {
   source = "../../modules/infra-security-groups/"
 

--- a/terraform/projects/infra-security-groups-staging/main.tf
+++ b/terraform/projects/infra-security-groups-staging/main.tf
@@ -37,6 +37,12 @@ variable "project" {
   default     = "infra-security-groups-staging"
 }
 
+module "csw_role" {
+  source = "git::https://github.com/alphagov/csw-client-role.git?ref=v1.2"
+
+  csw_agent_account_id = "779799343306"
+}
+
 module "infra-security-groups" {
   source = "../../modules/infra-security-groups/"
 

--- a/terraform/projects/prom-ec2/paas-production/main.tf
+++ b/terraform/projects/prom-ec2/paas-production/main.tf
@@ -63,6 +63,12 @@ data "pass_password" "prometheus_htpasswd" {
   path = "prometheus-basic-auth-htpasswd"
 }
 
+module "csw_role" {
+  source = "git::https://github.com/alphagov/csw-client-role.git?ref=v1.2"
+
+  csw_agent_account_id = "779799343306"
+}
+
 module "ami" {
   source = "../../../modules/common/ami"
 }

--- a/terraform/projects/prom-ec2/paas-staging/main.tf
+++ b/terraform/projects/prom-ec2/paas-staging/main.tf
@@ -59,6 +59,12 @@ data "pass_password" "prometheus_htpasswd" {
   path = "prometheus-basic-auth-htpasswd"
 }
 
+module "csw_role" {
+  source = "git::https://github.com/alphagov/csw-client-role.git?ref=v1.2"
+
+  csw_agent_account_id = "779799343306"
+}
+
 module "ami" {
   source = "../../../modules/common/ami"
 }


### PR DESCRIPTION
- Cyber Security have created a tool - Cyber Security Watch - that can
  assume a read-only role to an AWS account and analyse its configuration,
  to identify any security concerns.