### PR TITLE
Only report crashes in prod space

### DIFF
--- a/terraform/modules/app-ecs-services/config/alerts/registers-alerts.yml
+++ b/terraform/modules/app-ecs-services/config/alerts/registers-alerts.yml
@@ -34,7 +34,7 @@ groups:
         dashboard_registers: https://grafana-paas.cloudapps.digital/d/sljj3z6zk/registers?orgId=1
 
   - alert: Registers_AppCrashesInLastHour
-    expr: sum(increase(crash{org="openregister"}[1h])) without (exported_instance) > 5
+    expr: sum(increase(crash{org="openregister",space="prod"}[1h])) without (exported_instance) > 5
     labels:
         product: "registers"
     annotations:


### PR DESCRIPTION
We were getting erroneous alerts about staging apps crashing which are not urgent to action.