### PR TITLE
Break alertmanager yml to test smoketests

### DIFF
--- a/terraform/modules/app-ecs-services/templates/alertmanager.tpl
+++ b/terraform/modules/app-ecs-services/templates/alertmanager.tpl
@@ -1,7 +1,7 @@
 global:
   resolve_timeout: 5m
 
-  smtp_from: "${smtp_from}"
+ smtp_from: "${smtp_from}"
   smtp_smarthost: "${smtp_smarthost}"
   smtp_auth_username: "${smtp_username}"
   smtp_auth_password: "${smtp_password}"


### PR DESCRIPTION
We want to test the ci smoketests, this commit breaks the yml

Single: matthewcullum-gds