### PR TITLE
Start no alert managers to test smoke tests.

### DIFF
--- a/terraform/modules/app-ecs-services/alertmanager-service.tf
+++ b/terraform/modules/app-ecs-services/alertmanager-service.tf
@@ -11,7 +11,7 @@
 variable "prometheis_total" {
   type        = "string"
   description = "Desired number of prometheus servers.  Maximum 3."
-  default     = "3"
+  default     = "0"
 }
 
 ## Locals


### PR DESCRIPTION
We need ECS to be stable but no alert managers to be running so the
smoketests break.

Single: @matthewculum-gds