### PR TITLE
use ec2 ubuntu mirror

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -48,6 +48,7 @@ jobs:
                 cp -R re-secrets $HOME/.password-store
 
                 # FIXME we should make this available in a better way
+                sed -i 's/archive.ubuntu.com/eu-west-2.ec2.archive.ubuntu.com/g' /etc/apt/sources.list
                 apt-get update -y
                 apt-get install -y golang
                 go get github.com/camptocamp/terraform-provider-pass


### PR DESCRIPTION
archive.ubuntu.com can be sloooow, let's at least use a local mirror.

This is the difference between

> timeout exceeded

and

> Fetched 15.6 MB in 7s (2403 kB/s)