### PR TITLE
AUTO: Add default route for GSP

### DIFF
--- a/terraform/modules/app-ecs-services/templates/alertmanager.tpl
+++ b/terraform/modules/app-ecs-services/templates/alertmanager.tpl
@@ -74,6 +74,13 @@ route:
     - receiver: "gsp-alerts-slack"
       match:
         deployment: gsp
+  - receiver: "gsp-alerts-slack"
+    match:
+      deployment: gsp
+      routes:
+        - match:
+            severity: constant
+          receiver: "dev-null"
 
 receivers:
 - name: "re-observe-pagerduty"
@@ -153,3 +160,4 @@ receivers:
   pagerduty_configs:
     - service_key: "${verify_p2_pagerduty_key}"
   slack_configs: *verify-2ndline-slack-configs
+- name: "dev-null"


### PR DESCRIPTION
- GSP are doing a load of local dev which involves starting up clusters
  on engineers machines
- These clusters are on the network so can reach Alert Manager to raise
  alerts and were using the default route of autom8 pagerduty
- GSP have agreed to add a default label of 'deployment: gsp' to all
  clusters (local and EKS)
- The Verify cluster routing should match the earlier rule so this will
  only catch alerts from non-Verify clusters
- /dev/null the constant alerts as we don't care about those for local
  development
- Slack GSP for everything else - they can decide if everyone's local
  clusters are too noisy