### PR TITLE
create a new targets bucket

### DIFF
--- a/terraform/modules/prom-ec2/prometheus/targets.tf
+++ b/terraform/modules/prom-ec2/prometheus/targets.tf
@@ -1,0 +1,61 @@
+resource "aws_s3_bucket" "prometheus_targets" {
+  bucket        = "govukobserve-targets-${var.environment}"
+  acl           = "private"
+  force_destroy = true
+
+  versioning {
+    enabled = true
+  }
+}
+
+resource "aws_iam_user" "targets_writer" {
+  name = "targets-writer"
+  path = "/${var.environment}/"
+}
+
+resource "aws_iam_user_policy" "writer_has_full_access_to_targets_bucket" {
+  name = "targets_bucket_full_access"
+  user = "${aws_iam_user.targets_writer.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${aws_s3_bucket.prometheus_targets.arn}/*",
+        "${aws_s3_bucket.prometheus_targets.arn}"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "prometheus_has_read_access_to_targets_bucket" {
+  name = "targets_bucket_read_access"
+  role = "${aws_iam_role.prometheus_role.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:Get*",
+        "s3:List*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${aws_s3_bucket.prometheus_targets.arn}/*",
+        "${aws_s3_bucket.prometheus_targets.arn}"
+      ]
+    }
+  ]
+}
+EOF
+}


### PR DESCRIPTION
Create a new targets bucket.  We're planning to move away from
gds-prometheus-targets{,-staging} (which live in the central
gds-tech-ops account) and have buckets live alongside the prometheus
they supply targets to.

This commit creates a new targets bucket that prometheus can read, and
creates an IAM user that can write to the bucket.

This *doesn't* set up access keys for the new IAM user.  It'll be a
manual step to do that and to set the key up on the cf_app_discovery
instance.