### PR TITLE
Read from the new targets bucket instead of the old

### DIFF
--- a/terraform/modules/prom-ec2/prometheus/iam.tf
+++ b/terraform/modules/prom-ec2/prometheus/iam.tf
@@ -1,15 +1,3 @@
-locals {
-  s3_bucket_resources = [
-    "arn:aws:s3:::${aws_s3_bucket.prometheus_config.id}/*",
-    "arn:aws:s3:::${aws_s3_bucket.prometheus_config.id}",
-    "arn:aws:s3:::${var.targets_bucket}/*",
-    "arn:aws:s3:::${var.targets_bucket}",
-  ]
-
-  aws_iam_instance_role_policy_resources = "${slice(local.s3_bucket_resources, 0, 
-    length(var.targets_bucket) > 0 ? length(local.s3_bucket_resources) : 2 )}"
-}
-
 #Prepare to attach role to instance
 resource "aws_iam_instance_profile" "prometheus_instance_profile" {
   name = "prometheus_${var.environment}_config_reader_profile"
@@ -60,7 +48,10 @@ data "aws_iam_policy_document" "instance_role_policy" {
       "s3:ListBucket",
     ]
 
-    resources = ["${local.aws_iam_instance_role_policy_resources}"]
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.prometheus_config.id}/*",
+      "arn:aws:s3:::${aws_s3_bucket.prometheus_config.id}",
+    ]
   }
 }
 

--- a/terraform/modules/prom-ec2/prometheus/main.tf
+++ b/terraform/modules/prom-ec2/prometheus/main.tf
@@ -68,7 +68,7 @@ data "template_file" "user_data_script" {
   vars {
     config_bucket       = "${aws_s3_bucket.prometheus_config.id}"
     region              = "${var.region}"
-    targets_bucket      = "${var.targets_bucket}"
+    targets_bucket      = "${aws_s3_bucket.prometheus_targets.id}"
     alerts_bucket       = "${aws_s3_bucket.prometheus_config.id}"
     prom_external_url   = "https://${var.prometheus_public_fqdns[count.index]}"
     logstash_host       = "${var.logstash_host}"

--- a/terraform/modules/prom-ec2/prometheus/variables.tf
+++ b/terraform/modules/prom-ec2/prometheus/variables.tf
@@ -61,10 +61,6 @@ variable "allowed_cidrs" {
 
 variable "config_bucket" {}
 
-variable "targets_bucket" {
-  default = ""
-}
-
 variable "prometheus_public_fqdns" {
   type = "list"
 }

--- a/terraform/projects/prom-ec2/paas-production/main.tf
+++ b/terraform/projects/prom-ec2/paas-production/main.tf
@@ -75,12 +75,11 @@ module "prometheus" {
   target_vpc = "${data.terraform_remote_state.infra_networking.vpc_id}"
   enable_ssh = false
 
-  product        = "${local.product}"
-  environment    = "${local.environment}"
-  config_bucket  = "${local.config_bucket}"
-  targets_bucket = "gds-prometheus-targets"
-  instance_size  = "m4.large"
-  logstash_host  = "${data.pass_password.logstash_endpoint.password}"
+  product       = "${local.product}"
+  environment   = "${local.environment}"
+  config_bucket = "${local.config_bucket}"
+  instance_size = "m4.large"
+  logstash_host = "${data.pass_password.logstash_endpoint.password}"
 
   prometheus_public_fqdns = "${data.terraform_remote_state.app_ecs_albs.prom_public_record_fqdns}"
 

--- a/terraform/projects/prom-ec2/paas-staging/main.tf
+++ b/terraform/projects/prom-ec2/paas-staging/main.tf
@@ -71,11 +71,10 @@ module "prometheus" {
   target_vpc = "${data.terraform_remote_state.infra_networking.vpc_id}"
   enable_ssh = false
 
-  product        = "${local.product}"
-  environment    = "${local.environment}"
-  config_bucket  = "${local.config_bucket}"
-  targets_bucket = "gds-prometheus-targets-${local.environment}"
-  instance_size  = "m4.large"
+  product       = "${local.product}"
+  environment   = "${local.environment}"
+  config_bucket = "${local.config_bucket}"
+  instance_size = "m4.large"
 
   prometheus_public_fqdns = "${data.terraform_remote_state.app_ecs_albs.prom_public_record_fqdns}"
 


### PR DESCRIPTION
This changes prometheus's cron job to pull from the new target bucket
defined in targets.tf instead of the old gds-prometheus-targets one
that exists in the gds-tech-ops account.

This needs to be merged and deployed with care:

 - we should first update the service brokers to point to the new
   buckets
 - then we should merge and deploy this
 - this will cause downtime to prometheus due to needing to respin the
   boxes, but it shouldn't be long