### PR TITLE
Mark autom8 as owning this repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# See https://help.github.com/en/articles/about-code-owners
+* @alphagov/re-autom8


### PR DESCRIPTION
This will mean that:

 - @alphagov/re-autom8 will be notified of any PRs on this repo
 - members of that team can use the [review-requested][] feature to
   see outstanding PRs in one place rather than visiting each repo
   individually

[review-requested]: https://github.com/pulls/review-requested