### PR TITLE
Set `--query.timeout` to 30 seconds

### DIFF
--- a/terraform/modules/prom-ec2/prometheus/cloud.conf
+++ b/terraform/modules/prom-ec2/prometheus/cloud.conf
@@ -7,7 +7,7 @@ write_files:
   - owner: root:root
     path: /etc/default/prometheus
     permissions: 0444
-    content: 'ARGS="--storage.tsdb.path=\"/mnt/\" --web.external-url=${prom_external_url} --storage.tsdb.retention=60d"'
+    content: 'ARGS="--storage.tsdb.path=\"/mnt/\" --web.external-url=${prom_external_url} --storage.tsdb.retention=60d --query.timeout=30s"'
   - owner: root:root
     path: /etc/cron.d/config_pull
     permissions: 0755


### PR DESCRIPTION
- This is an action from an incident review.
- We saw long-running queries against Prometheus, which users had no
  visibility of because they were just looking at Grafana dashboards. The
  lengthly queries were causing Prometheus to run out of memory, causing
  everything to crash.
- This sets a timeout on all queries to an arbitrarily chosen 30
  seconds. Let's see how this goes.