### PR TITLE
Switch the Prometheis to m5.large instances

### DIFF
--- a/terraform/modules/prom-ec2/prometheus/cloud.conf
+++ b/terraform/modules/prom-ec2/prometheus/cloud.conf
@@ -13,7 +13,7 @@ write_files:
     permissions: 0755
     content: |
         * * * * * root aws s3 sync s3://${config_bucket}/prometheus/ /etc/prometheus/ --region=${region}
-        @reboot root mount /dev/xvdh /mnt
+        @reboot root mount /dev/nvme0 /mnt
         @reboot root /root/watch_prometheus_dir
   - owner: root:root
     path: /etc/cron.d/targets_pull
@@ -29,8 +29,8 @@ write_files:
         * * * * * root [ "${alerts_bucket}" != "" ] && aws s3 sync s3://${alerts_bucket}/prometheus/alerts/ /etc/prometheus/alerts --region=${region} --delete
   - content: |
        #!/bin/bash
-       if file -s /dev/xvdh | grep -q "/dev/xvdh: data"; then
-         mkfs -t 'ext4' -L 'prometheus_disk' '/dev/xvdh'
+       if file -s /dev/nvme0 | grep -q "/dev/nvme0: data"; then
+         mkfs -t 'ext4' -L 'prometheus_disk' '/dev/nvme0'
        else
          echo "disk already formated"
        fi
@@ -114,7 +114,7 @@ runcmd:
   - rm /etc/nginx/sites-enabled/default
   - "if [ -n '${logstash_host}' ]; then /root/setup_filebeat.sh; fi"
   - [bash, -c, "/root/format_disk.sh"]
-  - [bash, -c, "mount /dev/xvdh /mnt"]
+  - [bash, -c, "mount /dev/nvme0 /mnt"]
   - [bash, -c, "chown -R prometheus /mnt/"]
   - [bash, -c, "echo \"node_creation_time `date +%s`\" > /var/lib/prometheus/node-exporter/node-creation-time.prom"]
   - [reboot]

--- a/terraform/modules/prom-ec2/prometheus/variables.tf
+++ b/terraform/modules/prom-ec2/prometheus/variables.tf
@@ -19,7 +19,7 @@ variable "subnet_ids" {
 variable "instance_size" {
   type        = "string"
   description = "This is the default instance size"
-  default     = "t2.medium"
+  default     = "m5.large"
 }
 
 variable "target_vpc" {

--- a/terraform/projects/prom-ec2/paas-production/main.tf
+++ b/terraform/projects/prom-ec2/paas-production/main.tf
@@ -78,7 +78,6 @@ module "prometheus" {
   product       = "${local.product}"
   environment   = "${local.environment}"
   config_bucket = "${local.config_bucket}"
-  instance_size = "m4.large"
   logstash_host = "${data.pass_password.logstash_endpoint.password}"
 
   prometheus_public_fqdns = "${data.terraform_remote_state.app_ecs_albs.prom_public_record_fqdns}"

--- a/terraform/projects/prom-ec2/paas-staging/main.tf
+++ b/terraform/projects/prom-ec2/paas-staging/main.tf
@@ -74,7 +74,6 @@ module "prometheus" {
   product       = "${local.product}"
   environment   = "${local.environment}"
   config_bucket = "${local.config_bucket}"
-  instance_size = "m4.large"
 
   prometheus_public_fqdns = "${data.terraform_remote_state.app_ecs_albs.prom_public_record_fqdns}"
 


### PR DESCRIPTION
- We recently discovered that the Prometheis for PaaS (the only ones we
  run via this Terraform) are m4.large. We can save ourselves some cash by
  switching them to m5.large, the next generation.
- We had more variables than we needed for this, which I think were left
  over from when we had ECS EC2 Prometheis, dev stacks, and the "enclave".
- This gets rid of those extra variable settings in
  prom-ec2/paas-<environment> projects and sets the default module
  instance_size variable to m5.large.