### PR TITLE
digitalmarketplace _metrics endpoint hack: add "-router" hostname to exceptions list

### DIFF
--- a/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
+++ b/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
@@ -50,6 +50,10 @@ scrape_configs:
         regex: '(.*)/metrics;digitalmarketplace;.*-frontend'
         target_label: '__metrics_path__'
         replacement: '$1/_metrics'
+      - source_labels: ['__metrics_path__', 'org', 'job']
+        regex: '(.*)/metrics;digitalmarketplace;.*-router'
+        target_label: '__metrics_path__'
+        replacement: '$1/_metrics'
   - job_name: alertmanager
     dns_sd_configs:
       - names:


### PR DESCRIPTION
Original hack PR https://github.com/alphagov/prometheus-aws-configuration-beta/pull/268

We now need to be able to do this for our equivalently-named `-router` apps.

:grin: I have clearly not tested this :grin: