### PR TITLE
AUTO-413: Add Notify statsd exporter

### DIFF
--- a/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
+++ b/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
@@ -76,3 +76,8 @@ scrape_configs:
       - source_labels: ['__meta_ec2_instance_id']
         replacement: '$1:9100'
         target_label: instance
+  - job_name: notify-statsd-exporter
+    scheme: https
+    static_configs:
+      - targets: ['metrics.notify.tools']
+


### PR DESCRIPTION
- We want to scrape metrics from a statsd exporter that has been stood
  up in AWS for Notify's metrics
- We can't run it on the PaaS due to static IP restrictions and so can't
  use the service broker thus needs an explicit scrape config