### PR TITLE
Brewfile: Allow aws-vault to be installed on Linux

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,7 @@
 brew "jq"
 brew "tfenv"
-cask "aws-vault"
+if OS.mac?
+  cask "aws-vault"
+else
+  brew "linuxbrew/extra/aws-vault"
+end


### PR DESCRIPTION
- Homebrew Casks don't work on Linux, so this `brew bundle` install
  wouldn't work with Homebrew on Linux. Now, a formula exists for Linux
  builds of `aws-vault`.