### PR TITLE
add emoji icon to slack alerts

### DIFF
--- a/terraform/modules/app-ecs-services/templates/alertmanager.tpl
+++ b/terraform/modules/app-ecs-services/templates/alertmanager.tpl
@@ -128,7 +128,7 @@ receivers:
     channel: '#re-autom8-alerts'
     icon_emoji: ':verify-shield:'
     username: alertmanager
-    pretext: '{{ .CommonLabels.alertname }}:{{ .CommonAnnotations.summary }}'
+    pretext: '{{ if eq .Status "firing" }}{{ if eq .CommonLabels.severity "warning" }}:warning:{{ else }}:rotating_light:{{ end }}{{ else }}:green_tick:{{ end }} {{ .CommonLabels.alertname }}:{{ .CommonAnnotations.summary }}'
     text: |-
       *Description:* {{ .CommonAnnotations.message }}
       {{ range .Alerts }}


### PR DESCRIPTION
It wasn't super clear which messages were alerts and which were
resolutions.

This adds an emoji to a slack notification.  The logic is:

  - if it's firing:
    - if it has `severity: warning`: :warning:
    - if not `severity: warning`: :rotating_light:
  - if not firing: :green_tick: