### PR TITLE
[slack] warnings should be warning-colored, not danger-colored

### DIFF
--- a/terraform/modules/app-ecs-services/templates/alertmanager.tpl
+++ b/terraform/modules/app-ecs-services/templates/alertmanager.tpl
@@ -128,6 +128,7 @@ receivers:
     channel: '#re-autom8-alerts'
     icon_emoji: ':verify-shield:'
     username: alertmanager
+    color: '{{ if eq .Status "firing" }}{{ if eq .CommonLabels.severity "warning" }}warning{{ else }}danger{{ end }}{{ else }}good{{ end }}'
     pretext: '{{ if eq .Status "firing" }}{{ if eq .CommonLabels.severity "warning" }}:warning:{{ else }}:rotating_light:{{ end }}{{ else }}:green_tick:{{ end }} {{ .CommonLabels.alertname }}:{{ .CommonAnnotations.summary }}'
     text: |-
       *Description:* {{ .CommonAnnotations.message }}


### PR DESCRIPTION
This tweaks the color of a slack alert to match the emoji.