### PR TITLE
Add London targets configuration

### DIFF
--- a/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
+++ b/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
@@ -34,6 +34,12 @@ scrape_configs:
     file_sd_configs:
       - files: ['/etc/prometheus/targets/*.json']
         refresh_interval: 30s
+  - job_name: paas-london-targets
+    scheme: http
+    proxy_url: 'http://localhost:8080'
+    file_sd_configs:
+      - files: ['/etc/prometheus/targets/london/*.json']
+        refresh_interval: 30s
   - job_name: alertmanager
     dns_sd_configs:
       - names:

--- a/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
+++ b/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
@@ -40,6 +40,9 @@ scrape_configs:
     file_sd_configs:
       - files: ['/etc/prometheus/targets/london/*.json']
         refresh_interval: 30s
+    relabel_configs:
+      - target_label: region
+        replacement: london
   - job_name: alertmanager
     dns_sd_configs:
       - names:

--- a/terraform/modules/prom-ec2/prometheus/cloud.conf
+++ b/terraform/modules/prom-ec2/prometheus/cloud.conf
@@ -22,6 +22,12 @@ write_files:
         # if targets bucket exists then sync it, otherwise this cron runs but has no effect
         * * * * * root [ "${targets_bucket}" != "" ] && aws s3 sync s3://${targets_bucket}/active/ /etc/prometheus/targets --region=${region} --delete
   - owner: root:root
+    path: /etc/cron.d/london_targets_pull
+    permissions: 0755
+    content: |
+        # if targets bucket exists then sync it, otherwise this cron runs but has no effect
+        * * * * * root [ "${london_targets_bucket}" != "" ] && aws s3 sync s3://${london_targets_bucket}/active/ /etc/prometheus/targets/london --region=${region} --delete
+  - owner: root:root
     path: /etc/cron.d/alerts_pull
     permissions: 0755
     content: |

--- a/terraform/modules/prom-ec2/prometheus/main.tf
+++ b/terraform/modules/prom-ec2/prometheus/main.tf
@@ -66,14 +66,15 @@ data "template_file" "user_data_script" {
   template = "${file("${path.module}/cloud.conf")}"
 
   vars {
-    config_bucket       = "${aws_s3_bucket.prometheus_config.id}"
-    region              = "${var.region}"
-    targets_bucket      = "${aws_s3_bucket.prometheus_targets.id}"
-    alerts_bucket       = "${aws_s3_bucket.prometheus_config.id}"
-    prom_external_url   = "https://${var.prometheus_public_fqdns[count.index]}"
-    logstash_host       = "${var.logstash_host}"
-    prometheus_htpasswd = "${var.prometheus_htpasswd}"
-    allowed_cidrs       = "${join("\n        ",formatlist("allow %s;", var.allowed_cidrs))}"
+    config_bucket         = "${aws_s3_bucket.prometheus_config.id}"
+    region                = "${var.region}"
+    targets_bucket        = "${aws_s3_bucket.prometheus_targets.id}"
+    london_targets_bucket = "${aws_s3_bucket.prometheus_london_targets.id}"
+    alerts_bucket         = "${aws_s3_bucket.prometheus_config.id}"
+    prom_external_url     = "https://${var.prometheus_public_fqdns[count.index]}"
+    logstash_host         = "${var.logstash_host}"
+    prometheus_htpasswd   = "${var.prometheus_htpasswd}"
+    allowed_cidrs         = "${join("\n        ",formatlist("allow %s;", var.allowed_cidrs))}"
   }
 }
 

--- a/terraform/modules/prom-ec2/prometheus/targets.tf
+++ b/terraform/modules/prom-ec2/prometheus/targets.tf
@@ -36,6 +36,44 @@ resource "aws_iam_user_policy" "writer_has_full_access_to_targets_bucket" {
 EOF
 }
 
+resource "aws_s3_bucket" "prometheus_london_targets" {
+  bucket        = "govukobserve-london-targets-${var.environment}"
+  acl           = "private"
+  force_destroy = true
+
+  versioning {
+    enabled = true
+  }
+}
+
+resource "aws_iam_user" "london_targets_writer" {
+  name = "london-targets-writer"
+  path = "/${var.environment}/"
+}
+
+resource "aws_iam_user_policy" "london_writer_has_full_access_to_london_targets_bucket" {
+  name = "london_targets_bucket_full_access"
+  user = "${aws_iam_user.london_targets_writer.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${aws_s3_bucket.prometheus_london_targets.arn}/*",
+        "${aws_s3_bucket.prometheus_london_targets.arn}"
+      ]
+    }
+  ]
+}
+EOF
+}
+
 resource "aws_iam_role_policy" "prometheus_has_read_access_to_targets_bucket" {
   name = "targets_bucket_read_access"
   role = "${aws_iam_role.prometheus_role.name}"
@@ -53,6 +91,8 @@ resource "aws_iam_role_policy" "prometheus_has_read_access_to_targets_bucket" {
       "Resource": [
         "${aws_s3_bucket.prometheus_targets.arn}/*",
         "${aws_s3_bucket.prometheus_targets.arn}"
+        "${aws_s3_bucket.prometheus_london_targets.arn}/*",
+        "${aws_s3_bucket.prometheus_london_targets.arn}"
       ]
     }
   ]


### PR DESCRIPTION
- We want to be able to scrape PaaS targets in London PaaS orgs
- Create a new bucket for the file_sd_configs and add the cron
  job/scrape config to pick up new targets
- Might need the bucket applying first and folders called active
  and inactive creating in it