### PR TITLE
Change how we match GSP alerts

### DIFF
--- a/terraform/modules/app-ecs-services/templates/alertmanager.tpl
+++ b/terraform/modules/app-ecs-services/templates/alertmanager.tpl
@@ -70,13 +70,13 @@ route:
             deployment: staging
           receiver: "verify-staging-cronitor"
         - match:
-            deployment: gsp
+            clustername: london.verify.govsvc.uk
           receiver: "verify-gsp-cronitor"
     - receiver: "autom8-alerts-slack"
       match:
-        deployment: gsp
-  - match:
-      deployment: gsp
+        clustername: london.verify.govsvc.uk
+  - match_re:
+      clustername: london[.].*[.]govsvc[.]uk
     receiver: "autom8-alerts-slack"
     routes:
       - match:


### PR DESCRIPTION
The problem with matching on `deployment: gsp` is that we apply
`deployment: gsp` as an external label.  But external labels are only
applied when the underlying alert does not already have the
`deployment` label.  And Kubernetes has things called Deployments, and
we generate alerts for Deployments that have a `deployment` label that
identifies the Deployment.

So, these alerts have been finding their way into the verify-2ndline
receiver, and confusing people.

As a (hacky) workaround, I'm matching on the `clustername` label
instead.  For verify, it'll be `london.verify.govsvc.uk`; I'm assuming
that all other clusternames will be of a particular form.  That's a
bad assumption and we should find a better solution.  But this commit
will fix the immediate problem.