### PR TITLE
Fix volume mounting

### DIFF
--- a/terraform/modules/prom-ec2/prometheus/cloud.conf
+++ b/terraform/modules/prom-ec2/prometheus/cloud.conf
@@ -13,7 +13,6 @@ write_files:
     permissions: 0755
     content: |
         * * * * * root aws s3 sync s3://${config_bucket}/prometheus/ /etc/prometheus/ --region=${region}
-        @reboot root mount /dev/nvme0 /mnt
         @reboot root /root/watch_prometheus_dir
   - owner: root:root
     path: /etc/cron.d/ireland_targets_pull
@@ -35,12 +34,18 @@ write_files:
         * * * * * root [ "${alerts_bucket}" != "" ] && aws s3 sync s3://${alerts_bucket}/prometheus/alerts/ /etc/prometheus/alerts --region=${region} --delete
   - content: |
        #!/bin/bash
-       if file -s /dev/nvme0 | grep -q "/dev/nvme0: data"; then
-         mkfs -t 'ext4' -L 'prometheus_disk' '/dev/nvme0'
+       if file -s /dev/nvme1n1 | grep -q "/dev/nvme1n1: data"; then
+         mkfs -t 'ext4' -L 'prometheus_disk' '/dev/nvme1n1'
        else
-         echo "disk already formated"
+         echo "disk already formatted"
        fi
     path: /root/format_disk.sh
+    permissions: 0755
+  - content: |
+       #!/bin/bash
+       UUID=$(ls -l /dev/disk/by-uuid | grep nvme1n1 | cut -d' ' -f9)
+       echo "UUID=$UUID /mnt ext4 defaults,nofail 0 2" >> /etc/fstab
+    path: /root/generate_fstab.sh
     permissions: 0755
   - content: |
        #!/bin/bash
@@ -120,7 +125,8 @@ runcmd:
   - rm /etc/nginx/sites-enabled/default
   - "if [ -n '${logstash_host}' ]; then /root/setup_filebeat.sh; fi"
   - [bash, -c, "/root/format_disk.sh"]
-  - [bash, -c, "mount /dev/nvme0 /mnt"]
+  - [bash, -c, "mount /dev/nvme1n1 /mnt"]
+  - [bash, -c, "/root/generate_fstab.sh"]
   - [bash, -c, "chown -R prometheus /mnt/"]
   - [bash, -c, "echo \"node_creation_time `date +%s`\" > /var/lib/prometheus/node-exporter/node-creation-time.prom"]
   - [reboot]


### PR DESCRIPTION
- When we re-deployed the Prometheis, we found that their volumes didn't attach unless we manually attached them. The cloud-init-output.log was complaining about `nvme0 is not a block device`. This appears to be very similar to the fix Autom8 had to do for Verify - alphagov/verify-infrastructure#235 - except we've also found that mounting /dev/nvme0 on first boot no longer works, we need /dev/nvme1n1.
- We suspect that Amazon changed something recently, as this was previously working fine even after we switched to m5 instances from m4s.

Co-Authored-By: Isabell Long <isabell.long@digital.cabinet-office.gov.uk>