### PR TITLE
Brewfile: Casks are auto-skipped on Linux, so remove some complexity

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,7 +1,4 @@
 brew "jq"
 brew "tfenv"
-if OS.mac?
-  cask "aws-vault"
-else
-  brew "linuxbrew/extra/aws-vault"
-end
+brew "linuxbrew/extra/aws-vault" if OS.linux?
+cask "aws-vault"


### PR DESCRIPTION
- We still need to have the Linux aws-vault formula in `if OS.linux?`,
  though.