### PR TITLE
Bump Prometheus data volumes

### DIFF
--- a/terraform/modules/prom-ec2/prometheus/main.tf
+++ b/terraform/modules/prom-ec2/prometheus/main.tf
@@ -53,7 +53,7 @@ resource "aws_ebs_volume" "prometheus-disk" {
   count = "${length(keys(var.availability_zones))}"
 
   availability_zone = "${element(keys(var.availability_zones), count.index)}"
-  size              = "21"
+  size              = "50"
 
   tags {
     Name = "prometheus-disk"


### PR DESCRIPTION
We're close to running out of disk on 2/3 `prom`s. We have run out
entirely of disk on `prom-1`. The disk usage appears to be accelerating
even though the rate of metric ingestion seems largely unchanged. We're
going to bump the disk size for the time being.