### PR TITLE
Correct parenthesis grouping

### DIFF
--- a/terraform/modules/prom-ec2/alerts-config/alerts/observe-alerts.yml
+++ b/terraform/modules/prom-ec2/alerts-config/alerts/observe-alerts.yml
@@ -35,7 +35,12 @@ groups:
         runbook: "https://re-team-manual.cloudapps.digital/prometheus-for-gds-paas-users.html#re-observe-prometheus-below-threshold"
 
   - alert: RE_Observe_PrometheusDiskPredictedToFill
-    expr: predict_linear(node_filesystem_avail{ mountpoint="/mnt", job="prometheus_node" }[12h], 3 * 86400)  and on (instance) (time() - node_creation_time) > 43200 <= 0
+    expr: |
+      predict_linear(
+        node_filesystem_avail{job="prometheus_node", mountpoint="/mnt"}[12h], 3 * 24 * 60 * 60
+      ) <= 0
+      and on(instance)
+      (time() - node_creation_time > 12 * 60 * 60)
     labels:
         product: "prometheus"
         severity: "ticket"


### PR DESCRIPTION
The parentheses on this were off which meant in such a way that they
parsed correctly(!) but didn't do what was expected.

This change fixes the grouping and tries to be more explicit about where
some of the magic numbers come from.

The goal of this alert is to predict disks that will be full in the next
3 days but only on nodes that have been up for the last 12 hours. We
ignore new instances from the prediction because the prediction often
causes false positives for new instances.