### PR TITLE
Restrict Proxy Node alerts to the prod and integration namespaces

### DIFF
--- a/terraform/modules/app-ecs-services/templates/alertmanager.tpl
+++ b/terraform/modules/app-ecs-services/templates/alertmanager.tpl
@@ -65,7 +65,7 @@ route:
         namespace: (sandbox|verify)-doc-checking-.*
       receiver: dcs-slack
     - match_re:
-        namespace: (sandbox|verify)-(proxy-node.*|metadata-controller)
+        namespace: verify-proxy-node-(integration|prod)|verify-metadata-controller
       receiver: eidas-slack
   # Verify hub ECS
   - receiver: "verify-2ndline-slack"

--- a/terraform/modules/app-ecs-services/templates/alertmanager.tpl
+++ b/terraform/modules/app-ecs-services/templates/alertmanager.tpl
@@ -65,8 +65,11 @@ route:
         namespace: (sandbox|verify)-doc-checking-.*
       receiver: dcs-slack
     - match_re:
-        namespace: verify-proxy-node-(integration|prod)|verify-metadata-controller
+        namespace: verify-proxy-node-.*|verify-metadata-.*|verify-connector-.*
       receiver: eidas-slack
+    - match_re:
+        namespace: sandbox-proxy-node-.*|sandbox-metadata-.*|sandbox-connector-.*
+      receiver: "dev-null"
   # Verify hub ECS
   - receiver: "verify-2ndline-slack"
     match:


### PR DESCRIPTION
We're getting slack alerts when our gsp deployments are not healthy.

To ensure we care about these alerts, we should only get them for the integration and prod namespaces.

This PR will limit alerts to these namespaces.
