### PR TITLE
Use HTTP 1.1 for proxied requests

### DIFF
--- a/terraform/modules/prom-ec2/prometheus/cloud.conf
+++ b/terraform/modules/prom-ec2/prometheus/cloud.conf
@@ -72,8 +72,10 @@ write_files:
           if ($arg_cf_app_instance ~* "^(.*)%3A(.*)$") {
             set $cleaned_header $1:$2;
           }
+          proxy_http_version 1.1;
           proxy_pass https://$host$uri;
           proxy_ssl_server_name on;
+          proxy_set_header Connection "";
           proxy_set_header X-CF-APP-INSTANCE $cleaned_header;
           proxy_set_header XX-CF-APP-INSTANCE $cleaned_header;
           proxy_set_header Authorization "Bearer $arg_cf_app_guid";


### PR DESCRIPTION
What
----

By default nginx uses HTTP 1.0 for proxied upstreams and HTTP 1.0 does not support keepalives.

If the upstream being proxied uses keepalives then nginx may experience
networking issues.

Set the Connection header to empty, let nginx and the upstream to decide
when to close the underlying TCP connection.

How to review
----

- Read the documentation on [`proxy_http_version`](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_http_version)
- Read the documentation on [`proxy_set_header`](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header)
- See [this](https://github.com/alphagov/notifications-aws/pull/600) related pull request for GOV.UK Notify doing the same
- See [this](https://github.com/uktrade/cf-nginx-ip-filter/pull/9) related pull request for UKTrade doing the same