### PR TITLE
fix cf_app_discovery deployments

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -309,7 +309,6 @@ jobs:
         params:
           manifest: cf-app-discovery-git/manifest-staging.yml
           show_app_log: true
-          path: cf-app-discovery-git
   - name: deploy-service-broker-production
     plan:
       - get: cf-app-discovery-git
@@ -319,4 +318,3 @@ jobs:
         params:
           manifest: cf-app-discovery-git/manifest-production.yml
           show_app_log: true
-          path: cf-app-discovery-git


### PR DESCRIPTION
The concourse pipeline (in
prometheus-aws-configuration-beta/pipeline.yml) broke when we upgraded
to concourse 5.7.0.  There are various problems:

  - we use the default `cf` resource rather than pinning a specific
    version in `resource_types` :(
     - and it's hard to find out what the old version we were using
       even was D:
  - we specify the `path` parameter on our resource update
  - we have multiple apps in our manifest

A [recent update to the concourse cf-resource][1] changed how we push
apps, so that when you specify `path` it adds a `-p .` parameter to
the cf command line.  The cf cli then barfs with the error:

    Incorrect Usage: Command line flags (except -f and --no-start) cannot be applied when pushing multiple apps from a manifest file.

If we remove the `path`, it still fails, because it can't find the
code.

The fix is to specify the path as `.` in the manifest in the
cf_app_discover repo, then update the pipeline (here) to remove the
`path` parameter.

[1]: https://github.com/concourse/cf-resource/commit/e07c4c5a154cfb6a2950d84c07b53a70c7513e7d