### PR TITLE
Add Verify GSP canary target.

### DIFF
--- a/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
+++ b/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
@@ -69,4 +69,7 @@ scrape_configs:
     scheme: https
     static_configs:
       - targets: ['metrics.notify.tools']
-
+  - job_name: verify-gsp-canary
+    scheme: https
+    static_configs:
+      - targets: ['canary.london.verify.govsvc.uk']


### PR DESCRIPTION
We've been seeing intermittent connection failures from multi-tenant
concourse to the various canary deployments. We'd like to add a prometheus
target so we can gather more data about the state of the canary in the
Verify cluster.