### PR TITLE
route "layer" label to #re-autom8-alerts only

### DIFF
--- a/terraform/modules/app-ecs-services/templates/alertmanager.tpl
+++ b/terraform/modules/app-ecs-services/templates/alertmanager.tpl
@@ -46,7 +46,6 @@ route:
   # GSP clusters
   - match_re:
       clustername: london[.].*[.]govsvc[.]uk
-    receiver: "autom8-gsp-alerts-slack"
     group_by:
       - alertname
       - product
@@ -70,6 +69,9 @@ route:
     - match_re:
         namespace: sandbox-proxy-node-.*|sandbox-metadata-.*|sandbox-connector-.*
       receiver: "dev-null"
+    - match:
+        layer: "cicd"
+      receiver: "autom8-gsp-alerts-slack"
   # Verify hub ECS
   - receiver: "verify-2ndline-slack"
     match:


### PR DESCRIPTION
the re-autom8-alert channel is so noisey it is unusable. Instead of
routing ALL the cluster alerts to the channel we will only route things
to the channel that have an explicit "layer" label.

The "label" label is already used elsewhere to denote a grouping of
components or a system of components.

For example:

`layer: cicd` would signal that the alert is related to the continuous
deployment tooling/systems

`layer: orchestration` could signal that the alert is related to the
scheduling and execution of containers

`layer: routing` might signal that the alert is related to ingress,
networking or load-balancing

right now we haven't started using this label, so we route any alert
that has not matched a previous receiver and has this label present to
`#re-autom8-alerts` slack channel.