### PR TITLE
only route verify-doc-checking-prod alert to slack

### DIFF
--- a/terraform/modules/app-ecs-services/templates/alertmanager.tpl
+++ b/terraform/modules/app-ecs-services/templates/alertmanager.tpl
@@ -61,8 +61,8 @@ route:
     - match:
         severity: constant
       receiver: "dev-null"
-    - match_re:
-        namespace: (sandbox|verify)-doc-checking-.*
+    - match:
+        namespace: verify-doc-checking-prod
       receiver: dcs-slack
     - match_re:
         namespace: verify-proxy-node-.*|verify-metadata-.*|verify-connector-.*


### PR DESCRIPTION
ignore doc-checking alerts from the existing sandbox-* and *-build
deployments and only route alerts originating from the production (those
that are configured for the verify-doc-checking-prod namespace).

The dcs-alerts channel contains too much noise from the (totally normal)
ebb and flow of the build namespaces running/failing/passing tests, to
be useful... this will make channel something worth monitoring as it
will only contain alerts that have a potential impact on a production
deployment.

We may want to go further in the future and only route alerts that
directly impact users and are immediately actionable, but this is a good
start.