### PR TITLE
Remove hardcoded notify statsd exporter

### DIFF
--- a/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
+++ b/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
@@ -65,10 +65,6 @@ scrape_configs:
       - source_labels: ['__meta_ec2_instance_id']
         replacement: '$1:9100'
         target_label: instance
-  - job_name: notify-statsd-exporter
-    scheme: https
-    static_configs:
-      - targets: ['metrics.notify.tools']
   - job_name: verify-gsp-canary
     scheme: https
     static_configs:


### PR DESCRIPTION
This was added in 611616464187c965048e60dff65c137eec32174b.

It looks like the AWS-based statsd exporter was turned off (see
https://github.com/alphagov/notifications-aws/commit/66226ba1fb1884ab9e300877682af6c4beb7560c
if you have permission) but we forgot to turn off this scrape target.