### PR TITLE
Spike: demonstrate prometheus-buildpack

### DIFF
--- a/prom-paas/manifest.yml
+++ b/prom-paas/manifest.yml
@@ -1,0 +1,23 @@
+---
+applications:
+  - name: prometheus
+    metadata:
+      labels:
+        prometheus: prometheus-delightful-oribi.apps.internal
+    buildpacks:
+    - https://github.com/alphagov/prometheus-buildpack.git
+    disk_quota: 4G
+    env:
+      PROMETHEUS_FLAGS: |
+        --storage.tsdb.retention.size=3GB --web.external-url=https://prometheus-delightful-oribi.cloudapps.digital
+    instances: 1
+    memory: 512M
+    routes:
+    - route: prometheus-delightful-oribi.cloudapps.digital
+    - route: prometheus-delightful-oribi.apps.internal
+    services:
+    - prom-influx
+    # sidecars:
+    # - name: updater
+    #   command: check-for-new-targets.sh
+    #   process_types: [web]

--- a/prom-paas/prometheus.yml
+++ b/prom-paas/prometheus.yml
@@ -1,0 +1,54 @@
+---
+global:
+  scrape_interval: 30s
+  evaluation_interval: 30s
+  external_labels:
+    org: gds-tech-ops
+rule_files:
+- rules/*.yaml
+
+# alerting:
+#   alertmanagers:
+#   - scheme: http
+#     dns_sd_configs:
+#       - names:
+#           - 'alertmanager.local.gds-reliability.engineering'
+#         type: 'A'
+#         port: 9093
+# rule_files:
+#   - "/etc/prometheus/alerts/*"
+scrape_configs:
+  - job_name: prometheus
+    dns_sd_configs:
+    - names:
+      - prometheus-delightful-oribi.apps.internal
+      type: A
+      port: 8080
+    relabel_configs:
+    - target_label: space
+      replacement: prometheus-staging
+  - job_name: rotas
+    dns_sd_configs:
+    - names:
+      - rotas.apps.internal
+      type: A
+      port: 8080
+    relabel_configs:
+    - target_label: space
+      replacement: re-internal-apps
+  - job_name: observe-paas-prometheus-exporter-staging
+    static_configs:
+    - targets:
+      - observe-paas-prometheus-exporter-staging.apps.internal:8080
+      labels:
+        space: prometheus-staging
+  # - job_name: alertmanager
+  #   dns_sd_configs:
+  #     - names:
+  #         - 'alertmanager.local.gds-reliability.engineering'
+  #       type: 'A'
+  #       port: 9093
+  # - job_name: notify-statsd-exporter
+  #   scheme: https
+  #   static_configs:
+  #     - targets: ['metrics.notify.tools']

--- a/prom-paas/rules/record.yaml
+++ b/prom-paas/rules/record.yaml
@@ -1,0 +1,5 @@
+groups:
+- name: example
+  rules:
+  - record: job:http_200s:rate
+    expr: sum without(instance,path,method)(rate(http_server_requests_total{code="200"}[1m]))


### PR DESCRIPTION
So I've been playing around with running prometheus on the PaaS using
the influxdb private beta.  I've got something working over at
alphagov/prometheus-buildpack and this commit shows how to use it.

The vague idea is that eventually we might be able to migrate Observe
Prometheus to run in PaaS itself, with influxdb as the backing store.
This commit gets us:

 - Prometheus running on PaaS
 - Using influxdb as a remote_write/remote_read endpoint for long-term
   storage

Things not yet done that we might want in order to migrate Observe to
PaaS:

 - A [sidecar][] to pull targets from an S3 bucket
 - Migrate to the [S3 broker][] (here and in cf_app_discovery)
 - An answer for how we do access control from Prometheus to the
   target apps (currently it's either via basic auth or via IP
   safelisting)
 - Consider moving away from the service broker to something else
   entirely (such as using [labels and selectors][] to discover apps
   to scrape)

The last two points are possibly interdependent.  In particular, when
running Prometheus on PaaS, we could choose to scrape targets over
private networking rather than public.  This neatly sidesteps the
access control issue, but raises another issue of how we enable
cross-org network security policies.  The problem is that a single
cloud foundry user needs SpaceDeveloper permission in both the space
where Prometheus runs and the space where the scrape target is
running.  If we were to go down this route, I'd imagine we'd want to
ditch the service broker in favour of a fresh labels-and-selectors
approach.

Alternatively, we can continue to scrape over the public internet.
The problem here is that we predominantly use IP safelisting, but this
is probably much less appropriate for a Prometheus running in PaaS,
which will share the same egress IPs as everything else running on
PaaS.

[labels and selectors]: https://v3-apidocs.cloudfoundry.org/version/3.78.0/index.html#labels-and-selectors
[S3 broker]: https://docs.cloud.service.gov.uk/deploying_services/s3/
[sidecar]: https://docs.cloudfoundry.org/devguide/sidecars.html