### PR TITLE
Clearer k8s alert fields in slack

### DIFF
--- a/terraform/modules/app-ecs-services/templates/alertmanager.tpl
+++ b/terraform/modules/app-ecs-services/templates/alertmanager.tpl
@@ -187,8 +187,16 @@ receivers:
       value: '{{ .CommonLabels.product }}'
     - title: Namespace
       value: '{{ .CommonLabels.namespace }}'
+{{ if .CommonLabels.job_name }}
+    - title: Job
+      value: '{{ .CommonLabels.job_name }}'
+{{ else if .CommonLabels.deployment }}
+    - title: Deployment
+      value: '{{ .CommonLabels.deployment }}'
+{{ else if eq .CommonLabels.alertname "KubePodCrashLooping" }}
     - title: Pod
       value: '{{ .CommonLabels.pod }}'
+{{ end }}
     actions:
     - type: button
       text: Runbook

--- a/terraform/modules/app-ecs-services/templates/alertmanager.tpl
+++ b/terraform/modules/app-ecs-services/templates/alertmanager.tpl
@@ -193,7 +193,7 @@ receivers:
 {{ else if .CommonLabels.deployment }}
     - title: Deployment
       value: '{{ .CommonLabels.deployment }}'
-{{ else if eq .CommonLabels.alertname "KubePodCrashLooping" }}
+{{ else if match "^KubePod" .CommonLabels.alertname }}
     - title: Pod
       value: '{{ .CommonLabels.pod }}'
 {{ end }}


### PR DESCRIPTION
Currently, we output kubernetes-originating alerts to Slack with three
common fields: Product, Namespace and Pod.  However, the Pod field can
be quite confusing, because it's not at all clear whether the `pod`
label refers to:

 - a pod that is having a problem
 - a pod that is reporting a problem elsewhere

Therefore, I think we shouldn't output a Pod field for all alerts.

Instead, I thought we could:

 - add a Deployment field if there's a `deployment` label
 - add a Job field if there's a `job_name` label
 - add a Pod field only if we know it's an alert about a failing
   pod (right now, this is done by matching the alertname against
   `KubePodCrashLooping`)