### PR TITLE
BAU: Revert dcs prod only.

### DIFF
--- a/terraform/modules/app-ecs-services/templates/alertmanager.tpl
+++ b/terraform/modules/app-ecs-services/templates/alertmanager.tpl
@@ -61,8 +61,8 @@ route:
     - match:
         severity: constant
       receiver: "dev-null"
-    - match:
-        namespace: verify-doc-checking-prod
+    - match_re:
+        namespace: verify-doc-checking-*
       receiver: dcs-slack
     - match_re:
         namespace: verify-proxy-node-.*|verify-metadata-.*|verify-connector-.*


### PR DESCRIPTION
As we are adding a new alert that will make sure that developers are alerted if any of our pipelines are red, we can no longer restrict alerts to the prod-namespace.