### PR TITLE
BAU: add routes for DCS alerts

### DIFF
--- a/terraform/modules/app-ecs-services/templates/alertmanager.tpl
+++ b/terraform/modules/app-ecs-services/templates/alertmanager.tpl
@@ -62,8 +62,15 @@ route:
         severity: constant
       receiver: "dev-null"
     - match_re:
-        namespace: verify-doc-checking-.*
-      receiver: dcs-slack
+          namespace: verify-doc-checking-.*
+        receiver: dev-null
+        routes:
+        - receiver: dcs-slack
+          match: 
+            type: pipeline-alert
+        - receiver: dcs-slack
+          match:
+            namespace: verify-doc-checking-prod
     - match_re:
         namespace: verify-proxy-node-.*|verify-metadata-.*|verify-connector-.*
       receiver: eidas-slack


### PR DESCRIPTION
Added two routes for potential DCS alerts; they need to either:
* Be sent from the `prod` namespace or,
* Have the label and value `type: pipeline-alert`.

If none of them match, the alert is discarded.

This way we can get pipeline alerts from other namespaces than the `prod` namespace.