### PR TITLE
BAU: Re-add prod only route

### DIFF
--- a/terraform/modules/app-ecs-services/templates/alertmanager.tpl
+++ b/terraform/modules/app-ecs-services/templates/alertmanager.tpl
@@ -61,16 +61,9 @@ route:
     - match:
         severity: constant
       receiver: "dev-null"
-    - match_re:
-          namespace: verify-doc-checking-.*
-        receiver: dev-null
-        routes:
-        - receiver: dcs-slack
-          match: 
-            type: pipeline-alert
-        - receiver: dcs-slack
-          match:
-            namespace: verify-doc-checking-prod
+    - match:
+        namespace: verify-doc-checking-prod
+      receiver: dcs-slack
     - match_re:
         namespace: verify-proxy-node-.*|verify-metadata-.*|verify-connector-.*
       receiver: eidas-slack


### PR DESCRIPTION
Also:
	- Remove old routes (non-prod)

## Why?

It seems too difficult to get the DCS pipeline alerts to be caught by the `AlertManager` this way. Will instead implement using the `slack-notifaction` task directly in the pipeline.