### PR TITLE
Better tagging

### DIFF
--- a/terraform/modules/app-ecs-services/main.tf
+++ b/terraform/modules/app-ecs-services/main.tf
@@ -85,22 +85,4 @@ resource "aws_cloudwatch_log_group" "task_logs" {
   retention_in_days = 7
 }
 
-# TODO: delete this when we're confident we don't need it
-resource "aws_s3_bucket" "config_bucket" {
-  bucket_prefix = "ecs-monitoring-${var.stack_name}-config"
-  acl           = "private"
-
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
-
-  versioning {
-    enabled = true
-  }
-}
-
 ## Outputs

--- a/terraform/modules/app-ecs-services/main.tf
+++ b/terraform/modules/app-ecs-services/main.tf
@@ -32,7 +32,7 @@ variable "remote_state_bucket" {
   default     = "ecs-monitoring"
 }
 
-variable "stack_name" {
+variable "environment" {
   type        = string
   description = "Unique name for this collection of resources"
   default     = "ecs-monitoring"
@@ -42,6 +42,16 @@ variable "observe_cronitor" {
   type        = string
   description = "URL to send Observe heartbeats to"
   default     = ""
+}
+
+locals {
+  default_tags = {
+    Terraform   = "true"
+    Project     = "app-ecs-services"
+    Source      = "github.com/alphagov/prometheus-aws-configuration-beta"
+    Environment = var.environment
+    Service     = "alertmanager"
+  }
 }
 
 # Resources
@@ -81,8 +91,12 @@ data "terraform_remote_state" "app_ecs_albs" {
 ## Resources
 
 resource "aws_cloudwatch_log_group" "task_logs" {
-  name              = var.stack_name
+  name              = var.environment
   retention_in_days = 7
+
+  tags = merge(local.default_tags, {
+    Name = "${var.environment}-alertmanager-task-logs"
+  })
 }
 
 ## Outputs

--- a/terraform/modules/prom-ec2/prometheus/iam.tf
+++ b/terraform/modules/prom-ec2/prometheus/iam.tf
@@ -9,6 +9,10 @@ resource "aws_iam_role" "prometheus_role" {
   name = "prometheus_profile_${var.environment}"
 
   assume_role_policy = data.aws_iam_policy_document.prometheus_assume_role_policy.json
+
+  tags = merge(local.default_tags, {
+    Name = "${var.environment}-prometheus"
+  })
 }
 
 #Create permission to assume role

--- a/terraform/modules/prom-ec2/prometheus/targets.tf
+++ b/terraform/modules/prom-ec2/prometheus/targets.tf
@@ -6,11 +6,19 @@ resource "aws_s3_bucket" "prometheus_targets" {
   versioning {
     enabled = true
   }
+
+  tags = merge(local.default_tags, {
+    Name = "${var.environment}-ireland-targets"
+  })
 }
 
 resource "aws_iam_user" "targets_writer" {
   name = "targets-writer"
   path = "/${var.environment}/"
+
+  tags = merge(local.default_tags, {
+    Name = "${var.environment}-ireland-targets-writer"
+  })
 }
 
 resource "aws_iam_user_policy" "writer_has_full_access_to_targets_bucket" {
@@ -44,11 +52,19 @@ resource "aws_s3_bucket" "prometheus_london_targets" {
   versioning {
     enabled = true
   }
+
+  tags = merge(local.default_tags, {
+    Name = "${var.environment}-london-targets"
+  })
 }
 
 resource "aws_iam_user" "london_targets_writer" {
   name = "london-targets-writer"
   path = "/${var.environment}/"
+
+  tags = merge(local.default_tags, {
+    Name = "${var.environment}-london-targets-writer"
+  })
 }
 
 resource "aws_iam_user_policy" "london_writer_has_full_access_to_london_targets_bucket" {

--- a/terraform/modules/prom-ec2/prometheus/variables.tf
+++ b/terraform/modules/prom-ec2/prometheus/variables.tf
@@ -26,8 +26,6 @@ variable "target_vpc" {
   description = "The VPC in which the system will be deployed"
 }
 
-variable "product" {}
-
 variable "environment" {}
 
 variable "vpc_security_groups" {

--- a/terraform/projects/app-ecs-albs-production/main.tf
+++ b/terraform/projects/app-ecs-albs-production/main.tf
@@ -27,18 +27,6 @@ variable "remote_state_bucket" {
   default     = "prometheus-production"
 }
 
-variable "stack_name" {
-  type        = string
-  description = "Unique name for this collection of resources"
-  default     = "production"
-}
-
-variable "project" {
-  type        = string
-  description = "Project name for tag"
-  default     = "app-ecs-albs-production"
-}
-
 data "terraform_remote_state" "infra_networking" {
   backend = "s3"
 
@@ -53,9 +41,8 @@ module "app-ecs-albs" {
   source = "../../modules/app-ecs-albs/"
 
   aws_region          = var.aws_region
-  stack_name          = var.stack_name
+  environment         = "production"
   remote_state_bucket = var.remote_state_bucket
-  project             = var.project
   zone_id             = data.terraform_remote_state.infra_networking.outputs.public_zone_id
   subnets             = data.terraform_remote_state.infra_networking.outputs.public_subnets
 }

--- a/terraform/projects/app-ecs-albs-staging/main.tf
+++ b/terraform/projects/app-ecs-albs-staging/main.tf
@@ -27,18 +27,6 @@ variable "remote_state_bucket" {
   default     = "prometheus-staging"
 }
 
-variable "stack_name" {
-  type        = string
-  description = "Unique name for this collection of resources"
-  default     = "staging"
-}
-
-variable "project" {
-  type        = string
-  description = "Project name for tag"
-  default     = "app-ecs-albs-staging"
-}
-
 data "terraform_remote_state" "infra_networking" {
   backend = "s3"
 
@@ -53,9 +41,8 @@ module "app-ecs-albs" {
   source = "../../modules/app-ecs-albs/"
 
   aws_region          = var.aws_region
-  stack_name          = var.stack_name
+  environment         = "staging"
   remote_state_bucket = var.remote_state_bucket
-  project             = var.project
   zone_id             = data.terraform_remote_state.infra_networking.outputs.public_zone_id
   subnets             = data.terraform_remote_state.infra_networking.outputs.public_subnets
 }

--- a/terraform/projects/app-ecs-services-production/main.tf
+++ b/terraform/projects/app-ecs-services-production/main.tf
@@ -11,12 +11,6 @@ variable "aws_region" {
   default     = "eu-west-1"
 }
 
-variable "stack_name" {
-  type        = string
-  description = "Unique name for this collection of resources"
-  default     = "production"
-}
-
 data "pass_password" "cronitor_production_url" {
   path = "cronitor/cronitor-production-url"
 }
@@ -60,7 +54,7 @@ module "app-ecs-services" {
   source = "../../modules/app-ecs-services"
 
   remote_state_bucket = var.remote_state_bucket
-  stack_name          = var.stack_name
+  environment         = "production"
   observe_cronitor    = data.pass_password.cronitor_production_url.password
 }
 

--- a/terraform/projects/app-ecs-services-staging/main.tf
+++ b/terraform/projects/app-ecs-services-staging/main.tf
@@ -11,12 +11,6 @@ variable "aws_region" {
   default     = "eu-west-1"
 }
 
-variable "stack_name" {
-  type        = string
-  description = "Unique name for this collection of resources"
-  default     = "staging"
-}
-
 data "pass_password" "cronitor_staging_url" {
   path = "cronitor/cronitor-staging-url"
 }
@@ -60,7 +54,7 @@ module "app-ecs-services" {
   source = "../../modules/app-ecs-services"
 
   remote_state_bucket = var.remote_state_bucket
-  stack_name          = var.stack_name
+  environment         = "staging"
   observe_cronitor    = data.pass_password.cronitor_staging_url.password
 }
 

--- a/terraform/projects/infra-networking-production/main.tf
+++ b/terraform/projects/infra-networking-production/main.tf
@@ -19,30 +19,17 @@ variable "prometheus_subdomain" {
   default     = "monitoring"
 }
 
-variable "project" {
-  type        = string
-  description = "Which project, in which environment, we're running"
-  default     = "infra-networking-production"
-}
-
 variable "aws_region" {
   type        = string
   description = "The AWS region to use."
   default     = "eu-west-1"
 }
 
-variable "stack_name" {
-  type        = string
-  description = "Unique name for this collection of resources"
-  default     = "production"
-}
-
 module "infra-networking" {
   source = "../../modules/infra-networking"
 
-  stack_name           = var.stack_name
+  environment          = "production"
   prometheus_subdomain = var.prometheus_subdomain
-  project              = var.project
 }
 
 output "vpc_id" {

--- a/terraform/projects/infra-networking-staging/main.tf
+++ b/terraform/projects/infra-networking-staging/main.tf
@@ -19,30 +19,17 @@ variable "aws_region" {
   default     = "eu-west-1"
 }
 
-variable "stack_name" {
-  type        = string
-  description = "Unique name for this collection of resources"
-  default     = "staging"
-}
-
 variable "prometheus_subdomain" {
   type        = string
   description = "Subdomain for prometheus"
   default     = "monitoring-staging"
 }
 
-variable "project" {
-  type        = string
-  description = "Which project, in which environment, we're running"
-  default     = "infra-networking-staging"
-}
-
 module "infra-networking" {
   source = "../../modules/infra-networking"
 
-  stack_name           = var.stack_name
+  environment          = "staging"
   prometheus_subdomain = var.prometheus_subdomain
-  project              = var.project
 }
 
 output "vpc_id" {

--- a/terraform/projects/infra-security-groups-production/main.tf
+++ b/terraform/projects/infra-security-groups-production/main.tf
@@ -19,31 +19,12 @@ variable "aws_region" {
   default     = "eu-west-1"
 }
 
-variable "remote_state_bucket" {
-  type        = string
-  description = "S3 bucket we store our terraform state in"
-  default     = "prometheus-production"
-}
-
-variable "stack_name" {
-  type        = string
-  description = "Unique name for this collection of resources"
-  default     = "production"
-}
-
-variable "project" {
-  type        = string
-  description = "Project name for tag"
-  default     = "infra-security-groups-production"
-}
-
 module "infra-security-groups" {
   source = "../../modules/infra-security-groups/"
 
   aws_region          = var.aws_region
-  stack_name          = "production"
+  environment         = "production"
   remote_state_bucket = "prometheus-production"
-  project             = var.project
 
   allowed_cidrs = [
     # Office IPs

--- a/terraform/projects/infra-security-groups-staging/main.tf
+++ b/terraform/projects/infra-security-groups-staging/main.tf
@@ -19,31 +19,12 @@ variable "aws_region" {
   default     = "eu-west-1"
 }
 
-variable "remote_state_bucket" {
-  type        = string
-  description = "S3 bucket we store our terraform state in"
-  default     = "prometheus-staging"
-}
-
-variable "stack_name" {
-  type        = string
-  description = "Unique name for this collection of resources"
-  default     = "staging"
-}
-
-variable "project" {
-  type        = string
-  description = "Project name for tag"
-  default     = "infra-security-groups-staging"
-}
-
 module "infra-security-groups" {
   source = "../../modules/infra-security-groups/"
 
   aws_region          = var.aws_region
-  stack_name          = var.stack_name
-  remote_state_bucket = var.remote_state_bucket
-  project             = var.project
+  environment         = "staging"
+  remote_state_bucket = "prometheus-staging"
 }
 
 ## Outputs

--- a/terraform/projects/prom-ec2/paas-production/main.tf
+++ b/terraform/projects/prom-ec2/paas-production/main.tf
@@ -1,7 +1,6 @@
 locals {
-  product       = "paas"
   environment   = "production"
-  config_bucket = "gdsobserve-${local.product}-${local.environment}-config-store"
+  config_bucket = "gdsobserve-paas-${local.environment}-config-store"
 }
 
 terraform {
@@ -77,7 +76,6 @@ module "prometheus" {
   target_vpc = data.terraform_remote_state.infra_networking.outputs.vpc_id
   enable_ssh = false
 
-  product       = local.product
   environment   = local.environment
   config_bucket = local.config_bucket
   logstash_host = data.pass_password.logstash_endpoint.password

--- a/terraform/projects/prom-ec2/paas-staging/main.tf
+++ b/terraform/projects/prom-ec2/paas-staging/main.tf
@@ -1,7 +1,6 @@
 locals {
-  product       = "paas"
   environment   = "staging"
-  config_bucket = "gdsobserve-${local.product}-${local.environment}-config-store"
+  config_bucket = "gdsobserve-paas-${local.environment}-config-store"
 }
 
 terraform {
@@ -73,7 +72,6 @@ module "prometheus" {
   target_vpc = data.terraform_remote_state.infra_networking.outputs.vpc_id
   enable_ssh = false
 
-  product       = local.product
   environment   = local.environment
   config_bucket = local.config_bucket
 


### PR DESCRIPTION
This improves our tagging so that:

- we can get better information in Cost Explorer by using the approved cost tags (Name, Environment, Service, Source etc)
- more things have Name tags so we know what they are
- things are clearly tagged `Service: observe-prometheus` or `Service: alertmanager` so we know which bits do what
- tags are used more consistently
- we get rid of tags like `product` that always had the same value (like `paas`).
