### PR TITLE
Fix prometheus EC2 service discovery

### DIFF
--- a/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
+++ b/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
@@ -20,8 +20,8 @@ scrape_configs:
       - source_labels: ['__meta_ec2_tag_Environment']
         regex: '${environment}'
         action: keep
-      - source_labels: ['__meta_ec2_tag_Job']
-        regex: 'prometheus'
+      - source_labels: ['__meta_ec2_tag_Service']
+        regex: 'observe-prometheus'
         action: keep
       - source_labels: ['__meta_ec2_availability_zone']
         target_label: availability_zone
@@ -57,8 +57,8 @@ scrape_configs:
       - source_labels: ['__meta_ec2_tag_Environment']
         regex: '${environment}'
         action: keep
-      - source_labels: ['__meta_ec2_tag_Job']
-        regex: 'prometheus'
+      - source_labels: ['__meta_ec2_tag_Service']
+        regex: 'observe-prometheus'
         action: keep
       - source_labels: ['__meta_ec2_availability_zone']
         target_label: availability_zone


### PR DESCRIPTION
I removed the Job tag and now prometheus can't scrape itself, which is
causing alerts..