### PR TITLE
[alertmanager] Fix NLB health checks

### DIFF
--- a/terraform/modules/app-ecs-services/main.tf
+++ b/terraform/modules/app-ecs-services/main.tf
@@ -97,6 +97,11 @@ data "aws_route53_zone" "public_zone" {
   zone_id = local.zone_id
 }
 
+data "aws_subnet" "public_subnets" {
+  count = length(data.terraform_remote_state.infra_networking.outputs.public_subnets)
+  id    = data.terraform_remote_state.infra_networking.outputs.public_subnets[count.index]
+}
+
 ## Resources
 
 resource "aws_cloudwatch_log_group" "task_logs" {

--- a/terraform/modules/app-ecs-services/security-group.tf
+++ b/terraform/modules/app-ecs-services/security-group.tf
@@ -22,6 +22,16 @@ resource "aws_security_group_rule" "ingress_from_allowed_cidrs_to_alertmanager_9
   cidr_blocks       = var.allowed_cidrs
 }
 
+# NLB health checks come from the public subnet IP range
+resource "aws_security_group_rule" "ingress_from_public_subnets_to_alertmanager_9093" {
+  security_group_id = aws_security_group.alertmanager_task.id
+  type              = "ingress"
+  from_port         = 9093
+  to_port           = 9093
+  protocol          = "tcp"
+  cidr_blocks       = data.aws_subnet.public_subnets.*.cidr_block
+}
+
 # TODO: could we make observe prometheus more consistent with external
 # prometheis and go via public NLB IPs?
 resource "aws_security_group_rule" "ingress_from_prometheus_ec2_to_alertmanager_task" {


### PR DESCRIPTION
NLBs don't have a security group so we have to allow based on CIDR
block.  The NLB is on the public subnets so we need to allow ingress
from these IP ranges.