### PR TITLE
fix canary scrape_config

### DIFF
--- a/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
+++ b/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
@@ -68,4 +68,4 @@ scrape_configs:
   - job_name: verify-gsp-canary
     scheme: https
     static_configs:
-      - targets: ['canary.london.verify.govsvc.uk']
+      - targets: ['canary.verify-main.london.verify.govsvc.uk']


### PR DESCRIPTION
We changed the DNS name for canary and this scrape_config is broken
now.

Question: do we still need this?  Not sure we do?