### PR TITLE
Remove old alertmanager ALB

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -190,53 +190,23 @@ jobs:
                 )
 
                 puts "Stable #{cluster_name}"
-      - in_parallel:
-        - task: smoke-test-alertmanager-1
-          timeout: 2m
-          config: &smoke-test-alertmanager
-            platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: governmentpaas/curl-ssl
-                tag: fe3e384e81ccb50842509d7237e3828b293de694
-            params:
-              ALERTMANAGER_URL: 'https://alerts-1.monitoring-staging.gds-reliability.engineering/-/healthy'
-            run:
-              path: sh
-              args:
-                - -euxc
-                - |
-                  curl --silent --fail --max-time 5 "$ALERTMANAGER_URL"
-        - task: smoke-test-alertmanager-2
-          timeout: 2m
-          config:
-            <<: *smoke-test-alertmanager
-            params:
-              ALERTMANAGER_URL: 'https://alerts-2.monitoring-staging.gds-reliability.engineering/-/healthy'
-        - task: smoke-test-alertmanager-3
-          timeout: 2m
-          config:
-            <<: *smoke-test-alertmanager
-            params:
-              ALERTMANAGER_URL: 'https://alerts-3.monitoring-staging.gds-reliability.engineering/-/healthy'
-        - task: smoke-test-alertmanager
-          timeout: 2m
-          config: &smoke-test-alertmanager-domain
-            platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: governmentpaas/curl-ssl
-                tag: fe3e384e81ccb50842509d7237e3828b293de694
-            params:
-              ALERTMANAGER_DOMAIN: 'alerts.monitoring-staging.gds-reliability.engineering'
-            run:
-              path: sh
-              args:
-                - -euxc
-                - |
-                  getent ahosts ${ALERTMANAGER_DOMAIN} | cut -d ' ' -f1 | sort | uniq | xargs -n1 -I {} curl --resolve ${ALERTMANAGER_DOMAIN}:443:{} --silent --fail --max-time 5 "https://${ALERTMANAGER_DOMAIN}/-/healthy"
+      - task: smoke-test-alertmanager
+        timeout: 2m
+        config: &smoke-test-alertmanager-domain
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/curl-ssl
+              tag: fe3e384e81ccb50842509d7237e3828b293de694
+          params:
+            ALERTMANAGER_DOMAIN: 'alerts.monitoring-staging.gds-reliability.engineering'
+          run:
+            path: sh
+            args:
+              - -euxc
+              - |
+                getent ahosts ${ALERTMANAGER_DOMAIN} | cut -d ' ' -f1 | sort | uniq | xargs -n1 -I {} curl --resolve ${ALERTMANAGER_DOMAIN}:443:{} --silent --fail --max-time 5 "https://${ALERTMANAGER_DOMAIN}/-/healthy"
 
   - name: deploy-app-ecs-services-production
     serial: true
@@ -280,31 +250,12 @@ jobs:
             AWS_REGION: 'eu-west-1'
             AWS_DEFAULT_REGION: 'eu-west-1'
           run: *run-wait-for-ecs          
-      - in_parallel:
-        - task: smoke-test-alertmanager-1
-          timeout: 2m
-          config:
-            <<: *smoke-test-alertmanager
-            params:
-              ALERTMANAGER_URL: 'https://alerts-1.monitoring.gds-reliability.engineering/-/healthy'
-        - task: smoke-test-alertmanager-2
-          timeout: 2m
-          config:
-            <<: *smoke-test-alertmanager
-            params:
-              ALERTMANAGER_URL: 'https://alerts-2.monitoring.gds-reliability.engineering/-/healthy'
-        - task: smoke-test-alertmanager-3
-          timeout: 2m
-          config:
-            <<: *smoke-test-alertmanager
-            params:
-              ALERTMANAGER_URL: 'https://alerts-3.monitoring.gds-reliability.engineering/-/healthy'
-        - task: smoke-test-alertmanager
-          timeout: 2m
-          config:
-            <<: *smoke-test-alertmanager-domain
-            params:
-              ALERTMANAGER_DOMAIN: 'alerts.monitoring.gds-reliability.engineering'
+      - task: smoke-test-alertmanager
+        timeout: 2m
+        config:
+          <<: *smoke-test-alertmanager-domain
+          params:
+            ALERTMANAGER_DOMAIN: 'alerts.monitoring.gds-reliability.engineering'
   - name: run-service-broker-tests
     plan:
       - get: cf-app-discovery-git

--- a/terraform/modules/app-ecs-albs/main.tf
+++ b/terraform/modules/app-ecs-albs/main.tf
@@ -1,7 +1,7 @@
 /**
 * ## Module: app-ecs-albs
 *
-* Load balancers for Prometheus and Alertmanager
+* Load balancer for Prometheus
 *
 */
 
@@ -36,12 +36,6 @@ variable "prometheus_count" {
   default     = "3"
 }
 
-variable "alertmanager_count" {
-  type        = string
-  description = "Number of alertmanager instances to create listener rules and target groups for"
-  default     = "3"
-}
-
 # locals
 # --------------------------------------------------------------
 
@@ -53,8 +47,7 @@ locals {
     Environment = var.environment
   }
 
-  alerts_records_count = var.alertmanager_count
-  prom_records_count   = var.prometheus_count
+  prom_records_count = var.prometheus_count
 
   # data.aws_route_53.XXX.name has a trailing dot which we remove with replace() to make ACM happy
   subdomain = replace(data.aws_route53_zone.public_zone.name, "/\\.$/", "")
@@ -233,149 +226,6 @@ resource "aws_lb_target_group" "prometheus_tg" {
   }
 }
 
-######################################################################
-# ----- alertmanager public ALB -------
-######################################################################
-
-# AWS should manage the certificate renewal automatically
-# https://docs.aws.amazon.com/acm/latest/userguide/managed-renewal.html
-# If this fails, AWS will email associated with the AWS account
-resource "aws_acm_certificate" "alertmanager_cert" {
-  domain_name       = "foo.${local.subdomain}"
-  validation_method = "DNS"
-
-  subject_alternative_names = aws_route53_record.alerts_alias.*.fqdn
-
-  lifecycle {
-    # We can't destroy a certificate that's in use, and we can't stop
-    # using it until the new one is ready.  Hence
-    # create_before_destroy here.
-    create_before_destroy = true
-  }
-}
-
-resource "aws_route53_record" "alertmanager_cert_validation" {
-  # Count matches the domain_name plus each `subject_alternative_domain`
-  count = 1 + local.alerts_records_count
-
-  name       = aws_acm_certificate.alertmanager_cert.domain_validation_options[count.index]["resource_record_name"]
-  type       = aws_acm_certificate.alertmanager_cert.domain_validation_options[count.index]["resource_record_type"]
-  zone_id    = var.zone_id
-  records    = [aws_acm_certificate.alertmanager_cert.domain_validation_options[count.index]["resource_record_value"]]
-  ttl        = 60
-  depends_on = [aws_acm_certificate.alertmanager_cert]
-}
-
-resource "aws_acm_certificate_validation" "alertmanager_cert" {
-  certificate_arn         = aws_acm_certificate.alertmanager_cert.arn
-  validation_record_fqdns = aws_route53_record.alertmanager_cert_validation.*.fqdn
-}
-
-resource "aws_route53_record" "alerts_alias" {
-  count = local.alerts_records_count
-
-  zone_id = var.zone_id
-  name    = "alerts-${count.index + 1}"
-  type    = "A"
-
-  alias {
-    name                   = aws_lb.alertmanager_alb.dns_name
-    zone_id                = aws_lb.alertmanager_alb.zone_id
-    evaluate_target_health = false
-  }
-}
-
-resource "aws_lb" "alertmanager_alb" {
-  name               = "${var.environment}-alertmanager-alb"
-  internal           = false
-  load_balancer_type = "application"
-
-  security_groups = [data.terraform_remote_state.infra_security_groups.outputs.alertmanager_alb_sg_id]
-
-  subnets = var.subnets
-
-  tags = merge(
-    local.default_tags,
-    {
-      Name    = "${var.environment}-alertmanager-alb"
-      Service = "alertmanager"
-    },
-  )
-}
-
-resource "aws_lb_listener" "alertmanager_listener_http" {
-  load_balancer_arn = aws_lb.alertmanager_alb.arn
-  port              = "80"
-  protocol          = "HTTP"
-
-  default_action {
-    type = "redirect"
-
-    redirect {
-      port        = "443"
-      protocol    = "HTTPS"
-      status_code = "HTTP_301"
-    }
-  }
-}
-
-resource "aws_lb_listener" "alertmanager_listener_https" {
-  load_balancer_arn = aws_lb.alertmanager_alb.arn
-  port              = "443"
-  protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
-  certificate_arn   = aws_acm_certificate_validation.alertmanager_cert.certificate_arn
-
-  default_action {
-    type = "fixed-response"
-
-    fixed_response {
-      content_type = "text/plain"
-      message_body = "Not found"
-      status_code  = "404"
-    }
-  }
-}
-
-resource "aws_lb_listener_rule" "alerts_listener_https" {
-  count = var.alertmanager_count
-
-  listener_arn = aws_lb_listener.alertmanager_listener_https.arn
-  priority     = 100 + count.index
-
-  action {
-    type             = "forward"
-    target_group_arn = element(aws_lb_target_group.alertmanager_fargate.*.arn, count.index)
-  }
-
-  condition {
-    host_header {
-      values = ["alerts-${count.index + 1}.*"]
-    }
-  }
-}
-
-resource "aws_lb_target_group" "alertmanager_fargate" {
-  count = var.alertmanager_count
-
-  name                 = "${var.environment}-alerts-${count.index + 1}-fargate"
-  port                 = 9093
-  protocol             = "HTTP"
-  vpc_id               = local.vpc_id
-  deregistration_delay = 30
-  target_type          = "ip"
-
-  health_check {
-    interval            = "10"
-    path                = "/"
-    matcher             = "200"
-    protocol            = "HTTP"
-    healthy_threshold   = 2
-    unhealthy_threshold = 2
-    timeout             = "5"
-  }
-}
-
 ## Outputs
 
 output "prom_public_record_fqdns" {
@@ -383,18 +233,7 @@ output "prom_public_record_fqdns" {
   description = "Prometheus public DNS FQDNs"
 }
 
-output "alerts_public_record_fqdns" {
-  value       = aws_route53_record.alerts_alias.*.fqdn
-  description = "Alertmanagers public DNS FQDNs"
-}
-
 output "prometheus_target_group_ids" {
   value       = aws_lb_target_group.prometheus_tg.*.arn
   description = "Prometheus target group IDs"
 }
-
-output "alertmanager_ip_target_group_ids" {
-  value       = aws_lb_target_group.alertmanager_fargate.*.arn
-  description = "Alertmanager IP-type target group IDs"
-}
-

--- a/terraform/modules/app-ecs-services/alertmanager-service.tf
+++ b/terraform/modules/app-ecs-services/alertmanager-service.tf
@@ -1,10 +1,6 @@
 /**
 * ECS service that runs alertmanager
 *
-* This service consists of two containers.  The first, `s3-config-grabber`, fetches alertmanager configuration from our config S3 bucket, and stores it on a shared volume.  Then `alertmanager` runs and consumes that config.
-*
-* There is a known race condition between the two tasks - there is no guarantee that `s3-config-grabber` will grab the config before `alertmanager` starts.
-*
 */
 
 ## Variables

--- a/terraform/modules/app-ecs-services/alertmanager-service.tf
+++ b/terraform/modules/app-ecs-services/alertmanager-service.tf
@@ -10,11 +10,6 @@ variable "prometheis_total" {
   default     = "3"
 }
 
-## Locals
-locals {
-  alertmanager_public_fqdns = data.terraform_remote_state.app_ecs_albs.outputs.alerts_public_record_fqdns
-}
-
 ### container, task, service definitions
 
 resource "aws_ecs_cluster" "prometheus_cluster" {
@@ -73,67 +68,6 @@ resource "aws_iam_role_policy_attachment" "execution_execution" {
   role       = aws_iam_role.execution.name
   policy_arn = aws_iam_policy.execution.arn
 }
-
-# These are the old alertmanager services and task definitions, one
-# per AZ.  Once we're sure everyone's using the new alertmanager, we
-# can phase these out.
-
-data "template_file" "alertmanager_container_defn" {
-  count    = length(local.alertmanager_public_fqdns)
-  template = file("${path.module}/task-definitions/alertmanager.json")
-
-  vars = {
-    alertmanager_config_base64 = base64encode(data.template_file.alertmanager_config_file.rendered)
-    templates_base64           = base64encode(file("${path.module}/templates/default.tmpl"))
-    alertmanager_url           = "--web.external-url=https://${local.alertmanager_public_fqdns[count.index]}"
-    log_group                  = aws_cloudwatch_log_group.task_logs.name
-    region                     = var.aws_region
-  }
-}
-
-resource "aws_ecs_task_definition" "alertmanager" {
-  count                    = length(local.alertmanager_public_fqdns)
-  family                   = "${var.environment}-alertmanager-${count.index + 1}"
-  container_definitions    = data.template_file.alertmanager_container_defn[count.index].rendered
-  network_mode             = "awsvpc"
-  execution_role_arn       = aws_iam_role.execution.arn
-  requires_compatibilities = ["FARGATE"]
-  cpu                      = 256
-  memory                   = 512
-
-  tags = merge(local.default_tags, {
-    Name = "${var.environment}-alertmanager-${count.index + 1}"
-  })
-}
-
-resource "aws_ecs_service" "alertmanager" {
-  count = var.prometheis_total
-
-  name            = "${var.environment}-alertmanager-${count.index + 1}"
-  cluster         = "${var.environment}-ecs-monitoring"
-  task_definition = aws_ecs_task_definition.alertmanager[count.index].arn
-  desired_count   = 1
-  launch_type     = "FARGATE"
-
-  load_balancer {
-    target_group_arn = data.terraform_remote_state.app_ecs_albs.outputs.alertmanager_ip_target_group_arns[count.index]
-    container_name   = "alertmanager"
-    container_port   = 9093
-  }
-
-  network_configuration {
-    subnets         = [data.terraform_remote_state.infra_networking.outputs.private_subnets[count.index]]
-    security_groups = [data.terraform_remote_state.infra_security_groups.outputs.alertmanager_ec2_sg_id]
-  }
-
-  service_registries {
-    registry_arn = aws_service_discovery_service.alertmanager.arn
-  }
-
-  depends_on = [aws_ecs_task_definition.alertmanager]
-}
-
-# This is the new alertmanager service, to replace the above
 
 data "template_file" "alertmanager_nlb_container_defn" {
   template = file("${path.module}/task-definitions/alertmanager.json")
@@ -340,4 +274,3 @@ resource "aws_iam_user_policy" "smtp_ro" {
 EOF
 
 }
-

--- a/terraform/modules/app-ecs-services/alertmanager-service.tf
+++ b/terraform/modules/app-ecs-services/alertmanager-service.tf
@@ -3,13 +3,6 @@
 *
 */
 
-## Variables
-variable "prometheis_total" {
-  type        = string
-  description = "Desired number of prometheus servers.  Maximum 3."
-  default     = "3"
-}
-
 ### container, task, service definitions
 
 resource "aws_ecs_cluster" "prometheus_cluster" {
@@ -99,7 +92,7 @@ resource "aws_ecs_service" "alertmanager_nlb" {
   name            = "${var.environment}-alertmanager"
   cluster         = "${var.environment}-ecs-monitoring"
   task_definition = aws_ecs_task_definition.alertmanager_nlb.arn
-  desired_count   = var.prometheis_total
+  desired_count   = length(data.terraform_remote_state.infra_networking.outputs.private_subnets)
   launch_type     = "FARGATE"
 
   load_balancer {

--- a/terraform/modules/app-ecs-services/main.tf
+++ b/terraform/modules/app-ecs-services/main.tf
@@ -83,16 +83,6 @@ data "terraform_remote_state" "infra_security_groups" {
   }
 }
 
-data "terraform_remote_state" "app_ecs_albs" {
-  backend = "s3"
-
-  config = {
-    bucket = var.remote_state_bucket
-    key    = "app-ecs-albs-modular.tfstate"
-    region = var.aws_region
-  }
-}
-
 data "aws_route53_zone" "public_zone" {
   zone_id = local.zone_id
 }

--- a/terraform/projects/app-ecs-albs-production/main.tf
+++ b/terraform/projects/app-ecs-albs-production/main.tf
@@ -52,16 +52,6 @@ output "prom_public_record_fqdns" {
   description = "Prometheus public DNS FQDNs"
 }
 
-output "alerts_public_record_fqdns" {
-  value       = module.app-ecs-albs.alerts_public_record_fqdns
-  description = "Alertmanagers public DNS FQDNs"
-}
-
 output "prometheus_target_group_arns" {
   value = module.app-ecs-albs.prometheus_target_group_ids
 }
-
-output "alertmanager_ip_target_group_arns" {
-  value = module.app-ecs-albs.alertmanager_ip_target_group_ids
-}
-

--- a/terraform/projects/app-ecs-albs-staging/main.tf
+++ b/terraform/projects/app-ecs-albs-staging/main.tf
@@ -52,16 +52,6 @@ output "prom_public_record_fqdns" {
   description = "Prometheus public DNS FQDNs"
 }
 
-output "alerts_public_record_fqdns" {
-  value       = module.app-ecs-albs.alerts_public_record_fqdns
-  description = "Alertmanagers public DNS FQDNs"
-}
-
 output "prometheus_target_group_arns" {
   value = module.app-ecs-albs.prometheus_target_group_ids
 }
-
-output "alertmanager_ip_target_group_arns" {
-  value = module.app-ecs-albs.alertmanager_ip_target_group_ids
-}
-

--- a/terraform/projects/infra-security-groups-production/main.tf
+++ b/terraform/projects/infra-security-groups-production/main.tf
@@ -25,59 +25,6 @@ module "infra-security-groups" {
   aws_region          = var.aws_region
   environment         = "production"
   remote_state_bucket = "prometheus-production"
-
-  allowed_cidrs = [
-    # Office IPs
-    "213.86.153.212/32",
-
-    "213.86.153.213/32",
-    "213.86.153.214/32",
-    "213.86.153.235/32",
-    "213.86.153.236/32",
-    "213.86.153.237/32",
-    "85.133.67.244/32",
-
-    # verify prod
-    "35.178.25.41/32",
-
-    "35.177.2.97/32",
-    "35.176.169.64/32",
-
-    # verify integration
-    "3.8.68.252/32",
-
-    "3.8.41.125/32",
-    "3.8.225.106/32",
-
-    # verify staging
-    "35.177.140.5/32",
-
-    "18.130.58.164/32",
-    "35.176.196.169/32",
-
-    # verify joint
-    "35.176.160.191/32",
-
-    "35.177.182.230/32",
-    "35.177.122.134/32",
-
-    # concourse
-    "35.177.37.128/32",
-
-    "35.176.252.164/32",
-
-    # verify gsp
-    "18.130.62.225/32",
-
-    "3.8.38.79/32",
-    "52.56.126.222/32",
-
-    # gsp sandbox
-    "35.176.96.51/32",
-
-    "18.130.5.112/32",
-    "3.9.81.68/32",
-  ]
 }
 
 ## Outputs
@@ -91,14 +38,3 @@ output "prometheus_alb_sg_id" {
   value       = module.infra-security-groups.prometheus_alb_sg_id
   description = "security group prometheus_alb ID"
 }
-
-output "alertmanager_ec2_sg_id" {
-  value       = module.infra-security-groups.alertmanager_ec2_sg_id
-  description = "security group alertmanager_ec2 ID"
-}
-
-output "alertmanager_alb_sg_id" {
-  value       = module.infra-security-groups.alertmanager_alb_sg_id
-  description = "security group alertmanager_alb ID"
-}
-

--- a/terraform/projects/infra-security-groups-staging/main.tf
+++ b/terraform/projects/infra-security-groups-staging/main.tf
@@ -38,14 +38,3 @@ output "prometheus_alb_sg_id" {
   value       = module.infra-security-groups.prometheus_alb_sg_id
   description = "security group prometheus_alb ID"
 }
-
-output "alertmanager_ec2_sg_id" {
-  value       = module.infra-security-groups.alertmanager_ec2_sg_id
-  description = "security group alertmanager_ec2 ID"
-}
-
-output "alertmanager_alb_sg_id" {
-  value       = module.infra-security-groups.alertmanager_alb_sg_id
-  description = "security group alertmanager_alb ID"
-}
-

--- a/tools/prometheus-configs/send-an-alert/prometheus.yml
+++ b/tools/prometheus-configs/send-an-alert/prometheus.yml
@@ -20,11 +20,12 @@ alerting:
   # Here is an example configuration for sending to a specific alertmanager:
   # it is commented out by default to avoid annoying the support person
   - scheme: https
-    static_configs:
-    - targets:
-      - 'alerts-1.monitoring-staging.gds-reliability.engineering'
-      - 'alerts-2.monitoring-staging.gds-reliability.engineering'
-      - 'alerts-3.monitoring-staging.gds-reliability.engineering'
+    tls_config:
+      server_name: alerts.monitoring-staging.gds-reliability.engineering
+    dns_sd_configs:
+    - names: [ alerts.monitoring-staging.gds-reliability.engineering ]
+      type: A
+      port: 443
 
 scrape_configs:
   - job_name: prometheus


### PR DESCRIPTION
This needs to be applied in the order:

 - app-ecs-services (concourse will do this continuously)
 - app-ecs-albs
 - infra-security-groups

Not to be merged until noone is using the old one