### PR TITLE
[alertmanager] create separate ECS service per AZ

### DIFF
--- a/terraform/modules/alertmanager/alertmanager-service.tf
+++ b/terraform/modules/alertmanager/alertmanager-service.tf
@@ -89,10 +89,11 @@ resource "aws_ecs_task_definition" "alertmanager_nlb" {
 }
 
 resource "aws_ecs_service" "alertmanager_nlb" {
-  name            = "${var.environment}-alertmanager"
+  count           = length(data.aws_subnet.private_subnets)
+  name            = "${var.environment}-alertmanager-${data.aws_subnet.private_subnets[count.index].availability_zone}"
   cluster         = "${var.environment}-ecs-monitoring"
   task_definition = aws_ecs_task_definition.alertmanager_nlb.arn
-  desired_count   = length(data.terraform_remote_state.infra_networking.outputs.private_subnets)
+  desired_count   = 1
   launch_type     = "FARGATE"
 
   load_balancer {
@@ -102,7 +103,7 @@ resource "aws_ecs_service" "alertmanager_nlb" {
   }
 
   network_configuration {
-    subnets         = data.terraform_remote_state.infra_networking.outputs.private_subnets
+    subnets         = [data.aws_subnet.private_subnets[count.index].id]
     security_groups = [aws_security_group.alertmanager_task.id]
   }
 

--- a/terraform/modules/alertmanager/main.tf
+++ b/terraform/modules/alertmanager/main.tf
@@ -92,6 +92,11 @@ data "aws_subnet" "public_subnets" {
   id    = data.terraform_remote_state.infra_networking.outputs.public_subnets[count.index]
 }
 
+data "aws_subnet" "private_subnets" {
+  count = length(data.terraform_remote_state.infra_networking.outputs.private_subnets)
+  id    = data.terraform_remote_state.infra_networking.outputs.private_subnets[count.index]
+}
+
 ## Resources
 
 resource "aws_cloudwatch_log_group" "task_logs" {


### PR DESCRIPTION
Currently we have a single ECS service with desired_count = 3 and we
hope that the tasks will be launched one per AZ/subnet.  However this
isn't the behaviour we see.

This changes things so that we have three separate services, with a
desired count of 1 each, and each in a separate subnet (and hence
separate AZ).  The service names have the AZ name in them to make it
clear which one is which.