### PR TITLE
[alertmanager] fix pipeline

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -167,7 +167,9 @@ jobs:
 
                 cluster_name = "#{DEPLOYMENT}-ecs-monitoring"
                 services     = [
-                  "#{DEPLOYMENT}-alertmanager",
+                  "#{DEPLOYMENT}-alertmanager-eu-west-1a",
+                  "#{DEPLOYMENT}-alertmanager-eu-west-1b",
+                  "#{DEPLOYMENT}-alertmanager-eu-west-1c",
                 ]
 
                 ECS.wait_until(


### PR DESCRIPTION
oops, I changed the ECS service names and now the pipeline can't find
them to wait for them to be stable