### PR TITLE
[alertmanager] create DNS records for alertmanager in each AZ

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -190,23 +190,42 @@ jobs:
                 )
 
                 puts "Stable #{cluster_name}"
-      - task: smoke-test-alertmanager
-        timeout: 2m
-        config: &smoke-test-alertmanager-domain
-          platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/curl-ssl
-              tag: fe3e384e81ccb50842509d7237e3828b293de694
-          params:
-            ALERTMANAGER_DOMAIN: 'alerts.monitoring-staging.gds-reliability.engineering'
-          run:
-            path: sh
-            args:
-              - -euxc
-              - |
-                getent ahosts ${ALERTMANAGER_DOMAIN} | cut -d ' ' -f1 | sort | uniq | xargs -n1 -I {} curl --resolve ${ALERTMANAGER_DOMAIN}:443:{} --silent --fail --max-time 5 "https://${ALERTMANAGER_DOMAIN}/-/healthy"
+      - in_parallel:
+        - task: smoke-test-alertmanager
+          timeout: 2m
+          config: &smoke-test-alertmanager
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: governmentpaas/curl-ssl
+                tag: fe3e384e81ccb50842509d7237e3828b293de694
+            params:
+              ALERTMANAGER_DOMAIN: 'alerts.monitoring-staging.gds-reliability.engineering'
+            run:
+              path: sh
+              args:
+                - -euxc
+                - |
+                  getent ahosts ${ALERTMANAGER_DOMAIN} | cut -d ' ' -f1 | sort | uniq | xargs -n1 -I {} curl --resolve ${ALERTMANAGER_DOMAIN}:443:{} --silent --fail --max-time 5 "https://${ALERTMANAGER_DOMAIN}/-/healthy"
+        - task: smoke-test-alertmanager-eu-west-1a
+          timeout: 2m
+          config:
+            <<: *smoke-test-alertmanager
+            params:
+              ALERTMANAGER_DOMAIN: 'alerts-eu-west-1a.monitoring-staging.gds-reliability.engineering'
+        - task: smoke-test-alertmanager-eu-west-1b
+          timeout: 2m
+          config:
+            <<: *smoke-test-alertmanager
+            params:
+              ALERTMANAGER_DOMAIN: 'alerts-eu-west-1b.monitoring-staging.gds-reliability.engineering'
+        - task: smoke-test-alertmanager-eu-west-1c
+          timeout: 2m
+          config:
+            <<: *smoke-test-alertmanager
+            params:
+              ALERTMANAGER_DOMAIN: 'alerts-eu-west-1c.monitoring-staging.gds-reliability.engineering'
 
   - name: deploy-alertmanager-production
     serial: true
@@ -250,12 +269,32 @@ jobs:
             AWS_REGION: 'eu-west-1'
             AWS_DEFAULT_REGION: 'eu-west-1'
           run: *run-wait-for-ecs          
-      - task: smoke-test-alertmanager
-        timeout: 2m
-        config:
-          <<: *smoke-test-alertmanager-domain
-          params:
-            ALERTMANAGER_DOMAIN: 'alerts.monitoring.gds-reliability.engineering'
+      - in_parallel:
+        - task: smoke-test-alertmanager
+          timeout: 2m
+          config:
+            <<: *smoke-test-alertmanager
+            params:
+              ALERTMANAGER_DOMAIN: 'alerts.monitoring.gds-reliability.engineering'
+        - task: smoke-test-alertmanager-eu-west-1a
+          timeout: 2m
+          config:
+            <<: *smoke-test-alertmanager
+            params:
+              ALERTMANAGER_DOMAIN: 'alerts-eu-west-1a.monitoring.gds-reliability.engineering'
+        - task: smoke-test-alertmanager-eu-west-1b
+          timeout: 2m
+          config:
+            <<: *smoke-test-alertmanager
+            params:
+              ALERTMANAGER_DOMAIN: 'alerts-eu-west-1b.monitoring.gds-reliability.engineering'
+        - task: smoke-test-alertmanager-eu-west-1c
+          timeout: 2m
+          config:
+            <<: *smoke-test-alertmanager
+            params:
+              ALERTMANAGER_DOMAIN: 'alerts-eu-west-1c.monitoring.gds-reliability.engineering'
+
   - name: run-service-broker-tests
     plan:
       - get: cf-app-discovery-git

--- a/terraform/modules/alertmanager/main.tf
+++ b/terraform/modules/alertmanager/main.tf
@@ -87,6 +87,8 @@ data "aws_route53_zone" "public_zone" {
   zone_id = local.zone_id
 }
 
+data "aws_availability_zones" "available" {}
+
 data "aws_subnet" "public_subnets" {
   count = length(data.terraform_remote_state.infra_networking.outputs.public_subnets)
   id    = data.terraform_remote_state.infra_networking.outputs.public_subnets[count.index]

--- a/terraform/modules/alertmanager/nlb.tf
+++ b/terraform/modules/alertmanager/nlb.tf
@@ -53,6 +53,19 @@ resource "aws_route53_record" "alerts_alias" {
   }
 }
 
+resource "aws_route53_record" "alerts_az_alias" {
+  count   = length(data.aws_availability_zones.available.names)
+  zone_id = local.zone_id
+  name    = "alerts-${data.aws_availability_zones.available.names[count.index]}"
+  type    = "A"
+
+  alias {
+    name                   = "${data.aws_availability_zones.available.names[count.index]}.${aws_lb.alertmanager_nlb.dns_name}"
+    zone_id                = aws_lb.alertmanager_nlb.zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_lb" "alertmanager_nlb" {
   name               = "${var.environment}-alertmanager-nlb"
   internal           = false


### PR DESCRIPTION
This creates DNS records for, eg,
alerts-eu-west-1a.monitoring-staging.gds-reliability.engineering, so
that we can hit each alertmanager individually when trying to debug
things.  It also makes sure we smoke test them.

I have tested that alias records created in this way actually work,
via console clickops.