### PR TITLE
Detect device identifier of prometheus EBS volume for mounting.

### DIFF
--- a/terraform/modules/prom-ec2/prometheus/cloud.conf
+++ b/terraform/modules/prom-ec2/prometheus/cloud.conf
@@ -33,19 +33,35 @@ write_files:
         # if alerts bucket exists then sync it, otherwise this cron runs but has no effect
         * * * * * root [ "${alerts_bucket}" != "" ] && aws s3 sync s3://${alerts_bucket}/prometheus/alerts/ /etc/prometheus/alerts --region=${region} --delete
   - content: |
-       #!/bin/bash
-       if file -s /dev/nvme1n1 | grep -q "/dev/nvme1n1: data"; then
-         mkfs -t 'ext4' -L 'prometheus_disk' '/dev/nvme1n1'
-       else
-         echo "disk already formatted"
-       fi
-    path: /root/format_disk.sh
-    permissions: 0755
-  - content: |
-       #!/bin/bash
-       UUID=$(blkid /dev/nvme1n1 -s UUID -o value)
-       echo "UUID=$UUID /mnt ext4 defaults,nofail 0 2" >> /etc/fstab
-    path: /root/generate_fstab.sh
+        echo 'Configuring prometheus EBS'
+        vol=""
+        while [ -z "$vol" ]; do
+          # adapted from
+          # https://medium.com/@moonape1226/mount-aws-ebs-on-ec2-automatically-with-cloud-init-e5e837e5438a
+          # [Last accessed on 2020-04-02]
+          vol=$(lsblk | grep -e disk | awk '{sub("G","",$4)} {if ($4+0 == ${data_volume_size}) print $1}')
+          echo "still waiting for data volume ; sleeping 5"
+          sleep 5
+        done
+        echo "found volume /dev/$vol"
+        if [ -z "$(lsblk | grep "$vol" | awk '{print $7}')" ] ; then
+          if [ -z "$(blkid /dev/$vol | grep ext4)" ] ; then
+            echo "volume /dev/$vol is not formatted ; formatting"
+            mkfs -F -t ext4 -L 'prometheus_disk' "/dev/$vol"
+          else
+            echo "volume /dev/$vol is already formatted"
+          fi
+
+          echo "volume /dev/$vol is not mounted ; mounting"
+          mount "/dev/$vol" /mnt
+          UUID=$(blkid /dev/$vol -s UUID -o value)
+          if [ -z "$(grep $UUID /etc/fstab)" ] ; then
+            echo "writing fstab entry"
+
+            echo "UUID=$UUID /mnt ext4 defaults,nofail 0 2" >> /etc/fstab
+          fi
+        fi
+    path: /root/manage_data_volume.sh
     permissions: 0755
   - content: |
        #!/bin/bash
@@ -126,9 +142,7 @@ write_files:
 runcmd:
   - rm /etc/nginx/sites-enabled/default
   - "if [ -n '${logstash_host}' ]; then /root/setup_filebeat.sh; fi"
-  - [bash, -c, "/root/format_disk.sh"]
-  - [bash, -c, "mount /dev/nvme1n1 /mnt"]
-  - [bash, -c, "/root/generate_fstab.sh"]
+  - [bash, -c, "/root/manage_data_volume.sh"]
   - [bash, -c, "chown -R prometheus /mnt/"]
   - [bash, -c, "echo \"node_creation_time `date +%s`\" > /var/lib/prometheus/node-exporter/node-creation-time.prom"]
   - [reboot]

--- a/terraform/modules/prom-ec2/prometheus/main.tf
+++ b/terraform/modules/prom-ec2/prometheus/main.tf
@@ -50,7 +50,7 @@ resource "aws_ebs_volume" "prometheus-disk" {
   count = length(keys(var.availability_zones))
 
   availability_zone = element(keys(var.availability_zones), count.index)
-  size              = "50"
+  size              = var.data_volume_size
 
   tags = merge(local.default_tags, {
     Name = "prometheus-disk"
@@ -72,6 +72,7 @@ data "template_file" "user_data_script" {
     logstash_host          = var.logstash_host
     prometheus_htpasswd    = var.prometheus_htpasswd
     allowed_cidrs          = join("\n        ", formatlist("allow %s;", var.allowed_cidrs))
+    data_volume_size       = var.data_volume_size
   }
 }
 

--- a/terraform/modules/prom-ec2/prometheus/variables.tf
+++ b/terraform/modules/prom-ec2/prometheus/variables.tf
@@ -5,6 +5,11 @@ variable "device_mount_path" {
   default     = "/dev/sdh"
 }
 
+variable "data_volume_size" {
+  description = "The size of the volume that will contain the prometheus data"
+  default     = 50
+}
+
 variable "availability_zones" {
   description = "A map of availability zones to subnets"
 


### PR DESCRIPTION
EBS volumes are mapped to device identifiers in the kernel in a way that
is unpredictable (it gives numbers and letters based on the order in which
it becomes aware of them and so it cannot be relied upon). We are seeing
an issue whereby the ordering of the devices sometimes reverses and so an
attempt is made to mount the wrong device.

Also, the check for whether the disk was formatted was failing sometimes.
The `file -s` command wasn't returning the expected string and so a disk
that needed formatting wasn't being formatted. The mount command that
follows then fails because there's no filesystem to mount.

This change attempts to discover the identifier by looking it up by disk
size. It's a hack, but, for the moment, prometheus is only using a single
disk of that size. The failing `file -s` check has been replaced by a
check interrogating `blkid` which seems to be more reliable in testing.