### PR TITLE
Add alerts for GOV.UK coronavirus services

### DIFF
--- a/terraform/modules/alertmanager/alertmanager-service.tf
+++ b/terraform/modules/alertmanager/alertmanager-service.tf
@@ -122,6 +122,10 @@ data "pass_password" "dgu_pagerduty_key" {
   path = "pagerduty/integration-keys/dgu"
 }
 
+data "pass_password" "govuk_pagerduty_key" {
+  path = "pagerduty/integration-keys/govuk"
+}
+
 data "pass_password" "verify_p1_pagerduty_key" {
   path = "pagerduty/integration-keys/verify-p1"
 }
@@ -168,6 +172,7 @@ data "template_file" "alertmanager_config_file" {
   vars = {
     observe_pagerduty_key   = data.pass_password.observe_pagerduty_key.password
     dgu_pagerduty_key       = data.pass_password.dgu_pagerduty_key.password
+    govuk_pagerduty_key     = data.pass_password.govuk_pagerduty_key.password
     verify_p1_pagerduty_key = data.pass_password.verify_p1_pagerduty_key.password
     verify_p2_pagerduty_key = data.pass_password.verify_p2_pagerduty_key.password
     slack_api_url           = data.pass_password.slack_api_url.password

--- a/terraform/modules/alertmanager/templates/alertmanager.tpl
+++ b/terraform/modules/alertmanager/templates/alertmanager.tpl
@@ -25,6 +25,9 @@ route:
   - receiver: "dgu-pagerduty"
     match:
       product: "data-gov-uk"
+  - receiver: "govuk-pagerduty"
+    match:
+      product: "govuk-coronavirus-services"
   - receiver: "registers-zendesk"
     repeat_interval: 7d
     match:
@@ -111,6 +114,9 @@ receivers:
 - name: "dgu-pagerduty"
   pagerduty_configs:
     - service_key: "${dgu_pagerduty_key}"
+- name: "govuk-pagerduty"
+  pagerduty_configs:
+    - service_key: "${govuk_pagerduty_key}"
 - name: "registers-zendesk"
   email_configs:
   - to: "${registers_zendesk}"

--- a/terraform/modules/prom-ec2/alerts-config/alerts/govuk-coronavirus-services-alerts.yml
+++ b/terraform/modules/prom-ec2/alerts-config/alerts/govuk-coronavirus-services-alerts.yml
@@ -12,3 +12,20 @@ groups:
       dashboard_url: https://grafana-paas.cloudapps.digital/d/N7NZbVrZz/coronavirus-form-services?refresh=1m&orgId=1
       runbook: "https://docs.publishing.service.gov.uk/manual/covid-19-services.html#monitoring"
       logs: "https://kibana.logit.io/s/04b46992-f653-4c14-965c-236e9a6c2777/app/kibana#/discover"
+  - alert: GOVUK_CORONAVIRUS_SERVICES_HighCpuUsage
+    expr: avg(cpu{org="govuk_development", app=~"govuk-coronavirus-.*", space="production"}) without (exported_instance) >= 80
+    for: 5m
+    labels:
+        product: "govuk-coronavirus-services"
+    annotations:
+        summary: "App {{ $labels.app }} has high CPU usage"
+        message: "Application {{ $labels.app }} has been using over 80% CPU (averaged over all instances) for 5 minutes or more"
+        dashboard_url: https://grafana-paas.cloudapps.digital/d/N7NZbVrZz/coronavirus-form-services?refresh=1m&orgId=1
+  - alert: GOVUK_CORONAVIRUS_SERVICES_HighDiskUsage
+    expr: max(disk_utilization{org="govuk_development", app=~"govuk-coronavirus-.*", space="production"}) without (exported_instance) >= 80
+    labels:
+        product: "govuk-coronavirus-services"
+    annotations:
+        summary: "App {{ $labels.app }} has high disk usage"
+        message: "Application {{ $labels.app }} has an instance which is using over 80% disk."
+        dashboard_url: https://grafana-paas.cloudapps.digital/d/N7NZbVrZz/coronavirus-form-services?refresh=1m&orgId=1

--- a/terraform/modules/prom-ec2/alerts-config/alerts/govuk-coronavirus-services-alerts.yml
+++ b/terraform/modules/prom-ec2/alerts-config/alerts/govuk-coronavirus-services-alerts.yml
@@ -1,0 +1,14 @@
+groups:
+- name: GOVUK
+  rules:
+  - alert: GOVUK_CORONAVIRUS_SERVICES_RequestsExcess5xx
+    expr: sum by(app) (rate(requests{org="govuk_development", space="production", status_range="5xx"}[5m])) / sum by(app) (rate(requests{org="govuk_development", space="production"}[5m])) >= 0.1
+    for: 2m
+    labels:
+      product: "govuk-coronavirus-services"
+    annotations:
+      summary: "App {{ $labels.app }} has too many 5xx errors"
+      description: "App {{ $labels.app }} has 5xx errors in excess of 10% of total requests"
+      dashboard_url: https://grafana-paas.cloudapps.digital/d/N7NZbVrZz/coronavirus-form-services?refresh=1m&orgId=1
+      runbook: "https://docs.publishing.service.gov.uk/manual/covid-19-services.html#monitoring"
+      logs: "https://kibana.logit.io/s/04b46992-f653-4c14-965c-236e9a6c2777/app/kibana#/discover"

--- a/terraform/modules/prom-ec2/paas-config/main.tf
+++ b/terraform/modules/prom-ec2/paas-config/main.tf
@@ -38,10 +38,16 @@ resource "aws_s3_bucket_object" "alerts-data-gov-uk-config" {
   etag   = filemd5("${var.alerts_path}data-gov-uk-alerts.yml")
 }
 
+resource "aws_s3_bucket_object" "alerts-govuk-coronavirus-services-config" {
+  bucket = var.prometheus_config_bucket
+  key    = "prometheus/alerts/govuk-coronavirus-services-alerts.yml"
+  source = "${var.alerts_path}govuk-coronavirus-services-alerts.yml"
+  etag   = filemd5("${var.alerts_path}govuk-coronavirus-services-alerts.yml")
+}
+
 resource "aws_s3_bucket_object" "alerts-registers-config" {
   bucket = var.prometheus_config_bucket
   key    = "prometheus/alerts/registers-alerts.yml"
   source = "${var.alerts_path}registers-alerts.yml"
   etag   = filemd5("${var.alerts_path}registers-alerts.yml")
 }
-


### PR DESCRIPTION
This adds some alerts for the GOV.UK coronavirus services hosted on GOV.UK PaaS.

These alerts should page the GOV.UK on-call team via PagerDuty.

The PagerDuty Integration Key has been added to `pagerduty/integration-keys/govuk` in re-secrets.

Trello: https://trello.com/c/UI6sYR5Y/382