### PR TITLE
Add alert drill for govuk-coronavirus-services

### DIFF
--- a/terraform/modules/prom-ec2/alerts-config/alerts/govuk-coronavirus-services-alerts.yml
+++ b/terraform/modules/prom-ec2/alerts-config/alerts/govuk-coronavirus-services-alerts.yml
@@ -29,3 +29,14 @@ groups:
         summary: "App {{ $labels.app }} has high disk usage"
         message: "Application {{ $labels.app }} has an instance which is using over 80% disk."
         dashboard_url: https://grafana-paas.cloudapps.digital/d/N7NZbVrZz/coronavirus-form-services?refresh=1m&orgId=1
+  - alert: GOVUK_CORONAVIRUS_SERVICES_AlertDrill
+    annotations:
+      summary: Prometheus alert drill in progress...
+      message: |
+        This is an alert meant to ensure that the entire alerting pipeline is functional.
+        This alert is always firing, therefore it should always be firing in Alertmanager
+        and always fire against a receiver.
+    expr: vector(1)
+    labels:
+        product: "govuk-coronavirus-services"
+        severity: "warning"


### PR DESCRIPTION
This alert is intended to test GOV.UK's alerting pipeline (prometheus -> alertmanager -> pagerduty), for apps hosted on the PaaS.

It should constantly fire an alert, which pagerduty will discard unless the alert occurs during a scheduled drill time period.

I've taken this from the AlwaysAlert alert from Observe alerts, so should work the same.

https://trello.com/c/UI6sYR5Y/382