### PR TITLE
Continuous deployment pipeline for prom-ec2 project

### DIFF
--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -32,7 +32,7 @@ resources:
       paths:
         - terraform/modules/alertmanager
         - terraform/projects/alertmanager-*
-        - ci/tasks/deploy-project.yml
+        - ci/tasks
   - name: prometheus-git
     type: git
     source:
@@ -41,7 +41,7 @@ resources:
       paths:
         - terraform/modules/prom-ec2
         - terraform/projects/prom-ec2
-        - ci/tasks/deploy-project.yml
+        - ci/tasks
   - name: cf-app-discovery-git
     type: git
     source:
@@ -101,6 +101,22 @@ jobs:
           PROJECT: prom-ec2/paas-staging
           DEPLOYER_ARN: arn:aws:iam::027317422673:role/autom8-deployer
           GPG_PRIVATE_KEY: ((gpg_private_key))
+      - in_parallel:
+        - task: smoke-test-prom-1
+          timeout: 2m
+          file: prometheus-git/ci/tasks/http-ping.yml
+          params:
+            URL: https://prom-1.monitoring-staging.gds-reliability.engineering/healthz
+        - task: smoke-test-prom-2
+          timeout: 2m
+          file: prometheus-git/ci/tasks/http-ping.yml
+          params:
+            URL: https://prom-2.monitoring-staging.gds-reliability.engineering/healthz
+        - task: smoke-test-prom-3
+          timeout: 2m
+          file: prometheus-git/ci/tasks/http-ping.yml
+          params:
+            URL: https://prom-3.monitoring-staging.gds-reliability.engineering/healthz
 
   - name: deploy-prometheus-production
     serial: true
@@ -123,6 +139,22 @@ jobs:
           PROJECT: prom-ec2/paas-production
           DEPLOYER_ARN: arn:aws:iam::455214962221:role/autom8-deployer
           GPG_PRIVATE_KEY: ((gpg_private_key))
+      - in_parallel:
+        - task: smoke-test-prom-1
+          timeout: 2m
+          file: prometheus-git/ci/tasks/http-ping.yml
+          params:
+            URL: https://prom-1.monitoring.gds-reliability.engineering/healthz
+        - task: smoke-test-prom-2
+          timeout: 2m
+          file: prometheus-git/ci/tasks/http-ping.yml
+          params:
+            URL: https://prom-2.monitoring.gds-reliability.engineering/healthz
+        - task: smoke-test-prom-3
+          timeout: 2m
+          file: prometheus-git/ci/tasks/http-ping.yml
+          params:
+            URL: https://prom-3.monitoring.gds-reliability.engineering/healthz
 
   - name: deploy-alertmanager-staging
     serial: true
@@ -219,39 +251,24 @@ jobs:
       - in_parallel:
         - task: smoke-test-alertmanager
           timeout: 2m
-          config: &smoke-test-alertmanager
-            platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: governmentpaas/curl-ssl
-                tag: fe3e384e81ccb50842509d7237e3828b293de694
-            params:
-              ALERTMANAGER_DOMAIN: 'alerts.monitoring-staging.gds-reliability.engineering'
-            run:
-              path: sh
-              args:
-                - -euxc
-                - |
-                  getent ahosts ${ALERTMANAGER_DOMAIN} | cut -d ' ' -f1 | sort | uniq | xargs -n1 -I {} curl --resolve ${ALERTMANAGER_DOMAIN}:443:{} --silent --fail --max-time 5 "https://${ALERTMANAGER_DOMAIN}/-/healthy"
+          file: alertmanager-git/ci/tasks/http-ping.yml
+          params:
+            URL: https://alerts.monitoring-staging.gds-reliability.engineering/-/healthy
         - task: smoke-test-alertmanager-eu-west-1a
           timeout: 2m
-          config:
-            <<: *smoke-test-alertmanager
-            params:
-              ALERTMANAGER_DOMAIN: 'alerts-eu-west-1a.monitoring-staging.gds-reliability.engineering'
+          file: alertmanager-git/ci/tasks/http-ping.yml
+          params:
+            URL: https://alerts-eu-west-1a.monitoring-staging.gds-reliability.engineering/-/healthy
         - task: smoke-test-alertmanager-eu-west-1b
           timeout: 2m
-          config:
-            <<: *smoke-test-alertmanager
-            params:
-              ALERTMANAGER_DOMAIN: 'alerts-eu-west-1b.monitoring-staging.gds-reliability.engineering'
+          file: alertmanager-git/ci/tasks/http-ping.yml
+          params:
+            URL: https://alerts-eu-west-1b.monitoring-staging.gds-reliability.engineering/-/healthy
         - task: smoke-test-alertmanager-eu-west-1c
           timeout: 2m
-          config:
-            <<: *smoke-test-alertmanager
-            params:
-              ALERTMANAGER_DOMAIN: 'alerts-eu-west-1c.monitoring-staging.gds-reliability.engineering'
+          file: alertmanager-git/ci/tasks/http-ping.yml
+          params:
+            URL: https://alerts-eu-west-1c.monitoring-staging.gds-reliability.engineering/-/healthy
 
   - name: deploy-alertmanager-production
     serial: true
@@ -292,28 +309,24 @@ jobs:
       - in_parallel:
         - task: smoke-test-alertmanager
           timeout: 2m
-          config:
-            <<: *smoke-test-alertmanager
-            params:
-              ALERTMANAGER_DOMAIN: 'alerts.monitoring.gds-reliability.engineering'
+          file: alertmanager-git/ci/tasks/http-ping.yml
+          params:
+            URL: https://alerts.monitoring.gds-reliability.engineering/-/healthy
         - task: smoke-test-alertmanager-eu-west-1a
           timeout: 2m
-          config:
-            <<: *smoke-test-alertmanager
-            params:
-              ALERTMANAGER_DOMAIN: 'alerts-eu-west-1a.monitoring.gds-reliability.engineering'
+          file: alertmanager-git/ci/tasks/http-ping.yml
+          params:
+            URL: https://alerts-eu-west-1a.monitoring.gds-reliability.engineering/-/healthy
         - task: smoke-test-alertmanager-eu-west-1b
           timeout: 2m
-          config:
-            <<: *smoke-test-alertmanager
-            params:
-              ALERTMANAGER_DOMAIN: 'alerts-eu-west-1b.monitoring.gds-reliability.engineering'
+          file: alertmanager-git/ci/tasks/http-ping.yml
+          params:
+            URL: https://alerts-eu-west-1b.monitoring.gds-reliability.engineering/-/healthy
         - task: smoke-test-alertmanager-eu-west-1c
           timeout: 2m
-          config:
-            <<: *smoke-test-alertmanager
-            params:
-              ALERTMANAGER_DOMAIN: 'alerts-eu-west-1c.monitoring.gds-reliability.engineering'
+          file: alertmanager-git/ci/tasks/http-ping.yml
+          params:
+            URL: https://alerts-eu-west-1c.monitoring.gds-reliability.engineering/-/healthy
 
   - name: run-service-broker-tests
     plan:

--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -21,14 +21,14 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/prometheus-aws-configuration-beta.git
-      branch: cd-pipeline
+      branch: master
       paths:
         - ci
   - name: alertmanager-git
     type: git
     source:
       uri: https://github.com/alphagov/prometheus-aws-configuration-beta.git
-      branch: cd-pipeline
+      branch: master
       paths:
         - terraform/modules/alertmanager
         - terraform/projects/alertmanager-*
@@ -36,7 +36,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/prometheus-aws-configuration-beta.git
-      branch: cd-pipeline
+      branch: master
       paths:
         - terraform/modules/prom-ec2
         - terraform/projects/prom-ec2

--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -17,31 +17,29 @@ resources:
     source:
       repository: ((readonly_private_ecr_repo_url))
       tag: prometheus-task-image
-  - name: task-image-git
+  - name: ci-git
     type: git
     source:
       uri: https://github.com/alphagov/prometheus-aws-configuration-beta.git
-      branch: master
+      branch: cd-pipeline
       paths:
-        - ci/images/task
+        - ci
   - name: alertmanager-git
     type: git
     source:
       uri: https://github.com/alphagov/prometheus-aws-configuration-beta.git
-      branch: master
+      branch: cd-pipeline
       paths:
         - terraform/modules/alertmanager
         - terraform/projects/alertmanager-*
-        - ci/tasks
   - name: prometheus-git
     type: git
     source:
       uri: https://github.com/alphagov/prometheus-aws-configuration-beta.git
-      branch: master
+      branch: cd-pipeline
       paths:
         - terraform/modules/prom-ec2
         - terraform/projects/prom-ec2
-        - ci/tasks
   - name: cf-app-discovery-git
     type: git
     source:
@@ -75,13 +73,15 @@ resources:
 
 jobs:
 
-  - name: build-task-image
+  - name: configure-pipeline
     serial: true
     plan:
-    - get: task-image-git
+    - get: ci-git
       trigger: true
+    - set_pipeline: prometheus
+      file: ci-git/ci/deploy.yml
     - put: task-image
-      params: {build: task-image-git/ci/images/task}
+      params: {build: ci-git/ci/images/task}
       get_params: {skip_download: true}
 
   - name: deploy-prometheus-staging
@@ -92,12 +92,16 @@ jobs:
           trigger: true
         - get: re-secrets
           trigger: true
+        - get: ci-git
+          passed: [configure-pipeline]
+          trigger: true
         - get: task-image
-          passed: [build-task-image]
+          passed: [configure-pipeline]
+          trigger: true
       - task: apply-terraform
         image: task-image
         timeout: 15m
-        file: prometheus-git/ci/tasks/deploy-project.yml
+        file: ci-git/ci/tasks/deploy-project.yml
         input_mapping: {src: prometheus-git}
         params:
           PROJECT: prom-ec2/paas-staging
@@ -106,17 +110,17 @@ jobs:
       - in_parallel:
         - task: smoke-test-prom-1
           timeout: 2m
-          file: prometheus-git/ci/tasks/http-ping.yml
+          file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://prom-1.monitoring-staging.gds-reliability.engineering/healthz
         - task: smoke-test-prom-2
           timeout: 2m
-          file: prometheus-git/ci/tasks/http-ping.yml
+          file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://prom-2.monitoring-staging.gds-reliability.engineering/healthz
         - task: smoke-test-prom-3
           timeout: 2m
-          file: prometheus-git/ci/tasks/http-ping.yml
+          file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://prom-3.monitoring-staging.gds-reliability.engineering/healthz
 
@@ -130,12 +134,16 @@ jobs:
         - get: re-secrets
           passed: [deploy-prometheus-staging]
           trigger: true
+        - get: ci-git
+          passed: [deploy-prometheus-staging]
+          trigger: true
         - get: task-image
           passed: [deploy-prometheus-staging]
+          trigger: true
       - task: apply-terraform
         image: task-image
         timeout: 15m
-        file: prometheus-git/ci/tasks/deploy-project.yml
+        file: ci-git/ci/tasks/deploy-project.yml
         input_mapping: {src: prometheus-git}
         params:
           PROJECT: prom-ec2/paas-production
@@ -144,17 +152,17 @@ jobs:
       - in_parallel:
         - task: smoke-test-prom-1
           timeout: 2m
-          file: prometheus-git/ci/tasks/http-ping.yml
+          file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://prom-1.monitoring.gds-reliability.engineering/healthz
         - task: smoke-test-prom-2
           timeout: 2m
-          file: prometheus-git/ci/tasks/http-ping.yml
+          file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://prom-2.monitoring.gds-reliability.engineering/healthz
         - task: smoke-test-prom-3
           timeout: 2m
-          file: prometheus-git/ci/tasks/http-ping.yml
+          file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://prom-3.monitoring.gds-reliability.engineering/healthz
 
@@ -165,12 +173,17 @@ jobs:
         - get: alertmanager-git
           trigger: true
         - get: re-secrets
+          trigger: true
+        - get: ci-git
+          passed: [configure-pipeline]
+          trigger: true
         - get: task-image
-          passed: [build-task-image]
+          passed: [configure-pipeline]
+          trigger: true
       - task: apply-terraform
         image: task-image
         timeout: 15m
-        file: alertmanager-git/ci/tasks/deploy-project.yml
+        file: ci-git/ci/tasks/deploy-project.yml
         input_mapping: {src: alertmanager-git}
         params:
           PROJECT: alertmanager-staging
@@ -253,22 +266,22 @@ jobs:
       - in_parallel:
         - task: smoke-test-alertmanager
           timeout: 2m
-          file: alertmanager-git/ci/tasks/http-ping.yml
+          file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://alerts.monitoring-staging.gds-reliability.engineering/-/healthy
         - task: smoke-test-alertmanager-eu-west-1a
           timeout: 2m
-          file: alertmanager-git/ci/tasks/http-ping.yml
+          file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://alerts-eu-west-1a.monitoring-staging.gds-reliability.engineering/-/healthy
         - task: smoke-test-alertmanager-eu-west-1b
           timeout: 2m
-          file: alertmanager-git/ci/tasks/http-ping.yml
+          file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://alerts-eu-west-1b.monitoring-staging.gds-reliability.engineering/-/healthy
         - task: smoke-test-alertmanager-eu-west-1c
           timeout: 2m
-          file: alertmanager-git/ci/tasks/http-ping.yml
+          file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://alerts-eu-west-1c.monitoring-staging.gds-reliability.engineering/-/healthy
 
@@ -280,6 +293,9 @@ jobs:
           passed: [deploy-alertmanager-staging]
           trigger: true
         - get: re-secrets
+          passed: [deploy-alertmanager-staging]
+          trigger: true
+        - get: ci-git
           passed: [deploy-alertmanager-staging]
           trigger: true
         - get: task-image
@@ -311,22 +327,22 @@ jobs:
       - in_parallel:
         - task: smoke-test-alertmanager
           timeout: 2m
-          file: alertmanager-git/ci/tasks/http-ping.yml
+          file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://alerts.monitoring.gds-reliability.engineering/-/healthy
         - task: smoke-test-alertmanager-eu-west-1a
           timeout: 2m
-          file: alertmanager-git/ci/tasks/http-ping.yml
+          file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://alerts-eu-west-1a.monitoring.gds-reliability.engineering/-/healthy
         - task: smoke-test-alertmanager-eu-west-1b
           timeout: 2m
-          file: alertmanager-git/ci/tasks/http-ping.yml
+          file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://alerts-eu-west-1b.monitoring.gds-reliability.engineering/-/healthy
         - task: smoke-test-alertmanager-eu-west-1c
           timeout: 2m
-          file: alertmanager-git/ci/tasks/http-ping.yml
+          file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://alerts-eu-west-1c.monitoring.gds-reliability.engineering/-/healthy
 

--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -21,14 +21,14 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/prometheus-aws-configuration-beta.git
-      branch: cd-pipeline
+      branch: master
       paths:
         - ci/images/task
   - name: alertmanager-git
     type: git
     source:
       uri: https://github.com/alphagov/prometheus-aws-configuration-beta.git
-      branch: cd-pipeline
+      branch: master
       paths:
         - terraform/modules/alertmanager
         - terraform/projects/alertmanager-*
@@ -37,7 +37,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/prometheus-aws-configuration-beta.git
-      branch: cd-pipeline
+      branch: master
       paths:
         - terraform/modules/prom-ec2
         - terraform/projects/prom-ec2

--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -54,6 +54,8 @@ resources:
         ((re-secrets-ssh-key))
       uri: git@github.com:alphagov/re-secrets.git
       branch: master
+      paths:
+        - observe
   - name: service-broker-app-staging
     type: cf
     source:

--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -303,7 +303,7 @@ jobs:
       - task: apply-terraform
         image: task-image
         timeout: 15m
-        file: alertmanager-git/ci/tasks/deploy-project.yml
+        file: ci-git/ci/tasks/deploy-project.yml
         input_mapping: {src: alertmanager-git}
         params:
           PROJECT: alertmanager-production

--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -11,14 +11,37 @@ resource_types:
     tag: "1.6"
 
 resources:
+  - name: task-image
+    type: docker-image
+    icon: layers
+    source:
+      repository: ((readonly_private_ecr_repo_url))
+      tag: prometheus-task-image
+  - name: task-image-git
+    type: git
+    source:
+      uri: https://github.com/alphagov/prometheus-aws-configuration-beta.git
+      branch: cd-pipeline
+      paths:
+        - ci/images/task
   - name: alertmanager-git
     type: git
     source:
       uri: https://github.com/alphagov/prometheus-aws-configuration-beta.git
-      branch: master
+      branch: cd-pipeline
       paths:
         - terraform/modules/alertmanager
         - terraform/projects/alertmanager-*
+        - ci/tasks/deploy-project.yml
+  - name: prometheus-git
+    type: git
+    source:
+      uri: https://github.com/alphagov/prometheus-aws-configuration-beta.git
+      branch: cd-pipeline
+      paths:
+        - terraform/modules/prom-ec2
+        - terraform/projects/prom-ec2
+        - ci/tasks/deploy-project.yml
   - name: cf-app-discovery-git
     type: git
     source:
@@ -49,73 +72,76 @@ resources:
       space: prometheus-production
 
 jobs:
+
+  - name: build-task-image
+    serial: true
+    plan:
+    - get: task-image-git
+      trigger: true
+    - put: task-image
+      params: {build: task-image-git/ci/images/task}
+      get_params: {skip_download: true}
+
+  - name: deploy-prometheus-staging
+    serial: true
+    plan:
+      - in_parallel:
+        - get: prometheus-git
+          trigger: true
+        - get: re-secrets
+          trigger: true
+        - get: task-image
+          passed: [build-task-image]
+      - task: apply-terraform
+        image: task-image
+        timeout: 15m
+        file: prometheus-git/ci/tasks/deploy-project.yml
+        input_mapping: {src: prometheus-git}
+        params:
+          PROJECT: prom-ec2/paas-staging
+          DEPLOYER_ARN: arn:aws:iam::027317422673:role/autom8-deployer
+          GPG_PRIVATE_KEY: ((gpg_private_key))
+
+  - name: deploy-prometheus-production
+    serial: true
+    plan:
+      - in_parallel:
+        - get: prometheus-git
+          passed: [deploy-prometheus-staging]
+          trigger: true
+        - get: re-secrets
+          passed: [deploy-prometheus-staging]
+          trigger: true
+        - get: task-image
+          passed: [deploy-prometheus-staging]
+      - task: apply-terraform
+        image: task-image
+        timeout: 15m
+        file: prometheus-git/ci/tasks/deploy-project.yml
+        input_mapping: {src: prometheus-git}
+        params:
+          PROJECT: prom-ec2/paas-production
+          DEPLOYER_ARN: arn:aws:iam::455214962221:role/autom8-deployer
+          GPG_PRIVATE_KEY: ((gpg_private_key))
+
   - name: deploy-alertmanager-staging
     serial: true
     plan:
-      - get: alertmanager-git
-        trigger: true
-      - get: re-secrets
+      - in_parallel:
+        - get: alertmanager-git
+          trigger: true
+        - get: re-secrets
+        - get: task-image
+          passed: [build-task-image]
       - task: apply-terraform
+        image: task-image
         timeout: 15m
-        config:
-          platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: gdsre/aws-terraform
-              tag: 18.04-0.12.19
-          inputs:
-            - name: alertmanager-git
-            - name: re-secrets
-          params:
-            DEPLOYMENT: staging
-            ACCOUNT_ID: '027317422673'
-            AWS_REGION: 'eu-west-1'
-            AWS_DEFAULT_REGION: 'eu-west-1'
-            GPG_PRIVATE_KEY: ((gpg_private_key))
-          run: &run-deployment
-            path: sh
-            args:
-              - -c
-              - |
-                set -ue
-
-                mkdir -p $HOME/.password-store
-                cp -R re-secrets $HOME/.password-store
-
-                # FIXME we should make this available in a better way
-                sed -i 's/archive.ubuntu.com/eu-west-2.ec2.archive.ubuntu.com/g' /etc/apt/sources.list
-                apt-get update -y
-                apt-get install -y --no-install-recommends gpg gpg-agent golang git
-                go get github.com/camptocamp/terraform-provider-pass
-                GOBIN=~/.terraform.d/plugins/linux_amd64 go install github.com/camptocamp/terraform-provider-pass
-
-                echo "Authenticating with AWS against $DEPLOYMENT in account $ACCOUNT_ID"
-                arn="arn:aws:iam::${ACCOUNT_ID}:role/autom8-deployer"
-                creds="$(aws \
-                         sts assume-role \
-                         --role-arn="$arn" \
-                         --role-session-name="deploy-concourse-$(date +%s)" \
-                         --duration 1800 \
-                )"
-
-                access_key="$(echo "$creds"    | jq -r ".Credentials.AccessKeyId")"
-                secret_key="$(echo "$creds"    | jq -r ".Credentials.SecretAccessKey")"
-                session_token="$(echo "$creds" | jq -r ".Credentials.SessionToken")"
-
-                export "AWS_ACCESS_KEY_ID=$access_key"
-                export "AWS_SECRET_ACCESS_KEY=$secret_key"
-                export "AWS_SESSION_TOKEN=$session_token"
-                export "AWS_DEFAULT_REGION=eu-west-1"
-
-                export PASSWORD_STORE_DIR="$(pwd)/re-secrets/observe"
-                echo "$GPG_PRIVATE_KEY" | gpg --import
-
-                # Show what command terraform is running
-                set -x
-                cd alertmanager-git/terraform/projects/alertmanager-$DEPLOYMENT
-                terraform init
-                terraform apply -auto-approve
+        file: alertmanager-git/ci/tasks/deploy-project.yml
+        input_mapping: {src: alertmanager-git}
+        params:
+          PROJECT: alertmanager-staging
+          DEPLOYER_ARN: arn:aws:iam::027317422673:role/autom8-deployer
+          GPG_PRIVATE_KEY: ((gpg_private_key))
       - task: wait-for-staging-ecs
         timeout: 15m
         config:
@@ -230,30 +256,24 @@ jobs:
   - name: deploy-alertmanager-production
     serial: true
     plan:
-      - get: alertmanager-git
-        trigger: true
-        passed: [deploy-alertmanager-staging]
-      - get: re-secrets
-        passed: [deploy-alertmanager-staging]
+      - in_parallel:
+        - get: alertmanager-git
+          passed: [deploy-alertmanager-staging]
+          trigger: true
+        - get: re-secrets
+          passed: [deploy-alertmanager-staging]
+          trigger: true
+        - get: task-image
+          passed: [deploy-alertmanager-staging]
       - task: apply-terraform
+        image: task-image
         timeout: 15m
-        config:
-          platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: gdsre/aws-terraform
-              tag: 18.04-0.12.19
-          inputs:
-            - name: alertmanager-git
-            - name: re-secrets
-          params:
-            DEPLOYMENT: production
-            ACCOUNT_ID: '455214962221'
-            AWS_REGION: 'eu-west-1'
-            AWS_DEFAULT_REGION: 'eu-west-1'
-            GPG_PRIVATE_KEY: ((gpg_private_key))
-          run: *run-deployment
+        file: alertmanager-git/ci/tasks/deploy-project.yml
+        input_mapping: {src: alertmanager-git}
+        params:
+          PROJECT: alertmanager-production
+          DEPLOYER_ARN: arn:aws:iam::455214962221:role/autom8-deployer
+          GPG_PRIVATE_KEY: ((gpg_private_key))
       - task: wait-for-production-ecs
         timeout: 15m
         config:
@@ -268,7 +288,7 @@ jobs:
             ACCOUNT_ID: '027317422673'
             AWS_REGION: 'eu-west-1'
             AWS_DEFAULT_REGION: 'eu-west-1'
-          run: *run-wait-for-ecs          
+          run: *run-wait-for-ecs
       - in_parallel:
         - task: smoke-test-alertmanager
           timeout: 2m

--- a/ci/images/task/Dockerfile
+++ b/ci/images/task/Dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:18.04
+
+ENV TF_VERSION 0.12.19
+
+LABEL ubuntu="18.04"
+LABEL terraform="$TF_VERSION"
+
+ENV TZ=Europe/London
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get update  --yes && \
+	apt-get install --yes --no-install-recommends \
+	ca-certificates \
+	awscli \
+	jq \
+	curl \
+	dnsutils \
+	unzip \
+	gpg \
+	gpg-agent \
+	golang \
+	git
+
+WORKDIR /tmp
+
+RUN curl https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip > terraform.zip && \
+	echo 'a549486112f5350075fb540cfd873deb970a9baf8a028a86ee7b4472fc91e167  terraform.zip'  > terraform.sha && \
+	sha256sum -c terraform.sha && unzip terraform.zip && mv terraform /usr/bin/terraform                    && \
+	rm terraform.zip && rm terraform.sha
+
+RUN go get -v github.com/camptocamp/terraform-provider-pass && \
+	mkdir -p ~/.terraform.d/plugins/linux_amd64 && \
+	mv ~/go/bin/terraform-provider-pass ~/.terraform.d/plugins/linux_amd64/
+
+# prom-ec2 terraform expects a pub ssh key even if it doesn't use it
+RUN mkdir -p $HOME/.ssh/ && touch $HOME/.ssh/id_rsa.pub
+
+COPY assume-role /usr/bin/assume-role
+
+ENTRYPOINT ["bash"]

--- a/ci/images/task/assume-role
+++ b/ci/images/task/assume-role
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -eu
+
+arn="$1"
+creds="$(aws \
+		 sts assume-role \
+		 --role-arn="$arn" \
+		 --role-session-name="deploy-concourse-$(date +%s)" \
+		 --duration 1800 \
+)"
+
+access_key="$(echo "$creds"    | jq -r ".Credentials.AccessKeyId")"
+secret_key="$(echo "$creds"    | jq -r ".Credentials.SecretAccessKey")"
+session_token="$(echo "$creds" | jq -r ".Credentials.SessionToken")"
+
+echo "export AWS_ACCESS_KEY_ID=\"$access_key\""
+echo "export AWS_SECRET_ACCESS_KEY=\"$secret_key\""
+echo "export AWS_SESSION_TOKEN=\"$session_token\""
+echo "export AWS_DEFAULT_REGION=\"eu-west-1\""
+

--- a/ci/tasks/deploy-project.yml
+++ b/ci/tasks/deploy-project.yml
@@ -1,0 +1,30 @@
+  platform: linux
+  inputs:
+    - name: src
+    - name: re-secrets
+  params:
+    PROJECT:
+    DEPLOYER_ARN:
+    GPG_PRIVATE_KEY:
+    AWS_REGION: 'eu-west-1'
+    AWS_DEFAULT_REGION: 'eu-west-1'
+    PASSWORD_STORE_DIR: "re-secrets/observe"
+  run:
+    path: bash
+    args:
+      - -eu
+      - -c
+      - |
+
+        echo "configuring aws client..."
+        eval $(assume-role "${DEPLOYER_ARN}")
+
+        echo "configuring re-secrets store..."
+        echo "${GPG_PRIVATE_KEY}" | gpg --import
+        mkdir -p $HOME/.password-store
+        cp -R re-secrets $HOME/.password-store
+
+        echo "terraforming..."
+        cd "src/terraform/projects/${PROJECT}"
+        terraform init
+        terraform apply -auto-approve

--- a/ci/tasks/http-ping.yml
+++ b/ci/tasks/http-ping.yml
@@ -1,0 +1,19 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/curl-ssl
+    tag: fe3e384e81ccb50842509d7237e3828b293de694
+params:
+  URL:
+run:
+  path: sh
+  args:
+    - -euxc
+    - |
+      DOMAIN=$(echo "${URL}" | awk -F/ '{print $3}')
+      getent ahosts ${DOMAIN} | cut -d ' ' -f1 | sort | uniq | xargs -n1 -I {} curl \
+        --resolve ${DOMAIN}:443:{} \
+        --silent \
+        --fail \
+        --max-time 5 "${URL}"


### PR DESCRIPTION
## What

Continuously deploy prom-ec2 project from master

* Splits out terraform task so it can be shared
* Deploys the prom-ec2 staging project ... performs a simple curl check to see if it's up
* Repeats for production
* Builds a task image to avoid having to do lots of apt-get still in every single task run
* Adds a set_pipeline step so pipeline is also continuously deployed.

## Why

Because deploying by hand is a faff and since alertmanager config is already continuously deployed it causes confusion.

## Pipeline

You can see the pipeline here: https://cd.gds-reliability.engineering/teams/autom8/pipelines/prometheus

It is already set-piplined ... but the configure job is paused as it will error until this is merged.

## Note

This deploys all three in one big go... I seriously considered making it target them one-by-one ... but it just isn't very practical because: we do not know the alert config terraform "target" (they are dynamic / new ones get added) ... so we cannot "target" just that part

One improvement could be to try "just one" without any of the config changes, "just to check" before moving on to all three .... but I think that is just going to confuse things.


