### PR TITLE
Add alert for covid-19 sidekiq mailers queue

### DIFF
--- a/terraform/modules/prom-ec2/alerts-config/alerts/govuk-coronavirus-services-alerts.yml
+++ b/terraform/modules/prom-ec2/alerts-config/alerts/govuk-coronavirus-services-alerts.yml
@@ -40,3 +40,15 @@ groups:
     labels:
         product: "govuk-coronavirus-services"
         severity: "warning"
+  - alert: GOVUK_CORONAVIRUS_SERVICES_MailersQueueLatency
+    # We alert if it takes over 30 minutes for an email or SMS to go out.
+    expr: sum by (job) (increase( sidekiq_mailers_queue_latency{org="govuk_development", space="production"}[5m] ) ) > 1800
+    for: 5m
+    labels:
+        product: "govuk-coronavirus-services"
+        severity: "warning"
+    annotations:
+        summary: "Emails and texts are sending slowly."
+        message: "It is taking over 30 minutes to send messages to users from {{ $labels.job }}."
+        dashboard_url: https://grafana-paas.cloudapps.digital/d/N7NZbVrZz/coronavirus-form-services?refresh=1m&orgId=1
+        runbook: https://docs.publishing.service.gov.uk/manual/covid-19-services.html#monitoring


### PR DESCRIPTION
This will alert if we see problems sending messages to people.

The messages are currently confirmation notifications, so this can be classed as a warning to deal with in-hours.

https://trello.com/c/oQmFtKpU/413-add-alerts-for-sidekiq-queues