### PR TITLE
Tune prometheus alert for 5xx rate

### DIFF
--- a/terraform/modules/prom-ec2/alerts-config/alerts/govuk-coronavirus-services-alerts.yml
+++ b/terraform/modules/prom-ec2/alerts-config/alerts/govuk-coronavirus-services-alerts.yml
@@ -2,7 +2,7 @@ groups:
 - name: GOVUK
   rules:
   - alert: GOVUK_CORONAVIRUS_SERVICES_RequestsExcess5xx
-    expr: sum by(app) (rate(requests{org="govuk_development", space="production", status_range="5xx"}[5m])) / sum by(app) (rate(requests{org="govuk_development", space="production"}[5m])) >= 0.1
+    expr: sum by(app) (rate(requests{org="govuk_development", space="production", status_range="5xx"}[5m])) / sum by(app) (rate(requests{org="govuk_development", space="production"}[5m])) >= 0.01
     for: 2m
     labels:
       product: "govuk-coronavirus-services"


### PR DESCRIPTION
This makes the alert more sensitive to 500 errors.

We had an incident on Monday that this alert wouldn't have caught, so this tunes the alert so that we will get paged about this out of hours.

Co-authored-by: @leenagupte 

https://trello.com/c/JuJX7GV1/584-make-prometheus-alerts-more-sensitive