### PR TITLE
suppress default nginx server

### DIFF
--- a/terraform/modules/prom-ec2/prometheus/cloud.conf
+++ b/terraform/modules/prom-ec2/prometheus/cloud.conf
@@ -110,6 +110,12 @@ write_files:
     path: /etc/nginx/conf.d/.htpasswd
     owner: www-data:www-data
     permissions: 0600
+  # the package-provided default server conflicts with auth-proxy
+  # below and causes package installation to fail because of a
+  # duplicate default_server on port 80.  So we wipe the default
+  # server (and then remove it in runcmd at the bottom)
+  - content: ""
+    path: /etc/nginx/sites-enabled/default
   - content: |
       server {
         listen 80 default_server;


### PR DESCRIPTION
nginx failed to install because it had a duplicate default_server on
port 80.  This suppressed the built-in default server, hopefully.
Untested.