### PR TITLE
Fix observe alert

### DIFF
--- a/terraform/modules/prom-ec2/alerts-config/alerts/observe-alerts.yml
+++ b/terraform/modules/prom-ec2/alerts-config/alerts/observe-alerts.yml
@@ -49,19 +49,15 @@ groups:
         logs: "https://kibana.logit.io/s/8fd50110-7b0c-490a-bedf-7544daebbec4/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),index:'*-*',interval:auto,query:(query_string:(query:'tags:%20prometheus')),sort:!('@timestamp',desc))"
         runbook: "https://re-team-manual.cloudapps.digital/prometheus-for-gds-paas-users.html#re-observe-prometheus-disk-predicted-to-fill"
 
-  - alert: RE_Observe_No_FileSd_Targets
-    # Notes:
-    # - this alert will only fire if there are *no* file_sd targets.
-    # This is useful if we only have one source of file_sd config, but might not be
-    # if we have multiple ways of receiving file_sd configs and only one of them breaks.
-    expr: absent(prometheus_sd_file_timestamp)
+  - alert: RE_Observe_No_Paas_Targets
+    expr: prometheus_sd_discovered_targets{config=~"paas-(london|ireland)-targets"} == 0
     for: 10s
     labels:
         product: "prometheus"
         severity: "page"
     annotations:
-        summary: "No file_sd targets detected"
-        message: "No file_sd targets were detected.  Is there a problem accessing the targets bucket?"
+        summary: "No PaaS targets detected"
+        message: "No PaaS file_sd targets were detected from the service broker.  Is there a problem accessing the targets bucket?"
         logs: "https://kibana.logit.io/s/8fd50110-7b0c-490a-bedf-7544daebbec4/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),index:'*-*',interval:auto,query:(query_string:(query:'tags:%20prometheus')),sort:!('@timestamp',desc))"
         runbook: "https://re-team-manual.cloudapps.digital/prometheus-for-gds-paas-users.html#re-observe-no-filesd-targets"
 


### PR DESCRIPTION
We have an alert for missing targets from the service broker, to
detect if there's a problem with the plumbing from the service broker,
via the S3 bucket, to the prometheus targets.

This used to be based on detecting the absence of the metric
`prometheus_sd_file_timestamp`.  This has broken with the upgrade to
focal, bringing prometheus 2.15 with it, because the metric has been
renamed to `prometheus_sd_file_mtime_seconds`.

However, rather than use this metric, we can now use a better way of
solving this problem, which is the `prometheus_sd_discovered_targets`
metric, which actually tells us how many targets we have detected
directly.  This is better than using `absent()` because the metric is
more explicit about what we mean.