### PR TITLE
retry the "ping" tests prom/alertmanager deploy

### DIFF
--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -109,16 +109,19 @@ jobs:
           GPG_PRIVATE_KEY: ((gpg_private_key))
       - in_parallel:
         - task: smoke-test-prom-1
+          attempts: 3
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://prom-1.monitoring-staging.gds-reliability.engineering/healthz
         - task: smoke-test-prom-2
+          attempts: 3
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://prom-2.monitoring-staging.gds-reliability.engineering/healthz
         - task: smoke-test-prom-3
+          attempts: 3
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:
@@ -151,16 +154,19 @@ jobs:
           GPG_PRIVATE_KEY: ((gpg_private_key))
       - in_parallel:
         - task: smoke-test-prom-1
+          attempts: 3
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://prom-1.monitoring.gds-reliability.engineering/healthz
         - task: smoke-test-prom-2
+          attempts: 3
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://prom-2.monitoring.gds-reliability.engineering/healthz
         - task: smoke-test-prom-3
+          attempts: 3
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:
@@ -265,21 +271,25 @@ jobs:
                 puts "Stable #{cluster_name}"
       - in_parallel:
         - task: smoke-test-alertmanager
+          attempts: 3
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://alerts.monitoring-staging.gds-reliability.engineering/-/healthy
         - task: smoke-test-alertmanager-eu-west-1a
+          attempts: 3
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://alerts-eu-west-1a.monitoring-staging.gds-reliability.engineering/-/healthy
         - task: smoke-test-alertmanager-eu-west-1b
+          attempts: 3
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://alerts-eu-west-1b.monitoring-staging.gds-reliability.engineering/-/healthy
         - task: smoke-test-alertmanager-eu-west-1c
+          attempts: 3
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:
@@ -326,21 +336,25 @@ jobs:
           run: *run-wait-for-ecs
       - in_parallel:
         - task: smoke-test-alertmanager
+          attempts: 3
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://alerts.monitoring.gds-reliability.engineering/-/healthy
         - task: smoke-test-alertmanager-eu-west-1a
+          attempts: 3
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://alerts-eu-west-1a.monitoring.gds-reliability.engineering/-/healthy
         - task: smoke-test-alertmanager-eu-west-1b
+          attempts: 3
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://alerts-eu-west-1b.monitoring.gds-reliability.engineering/-/healthy
         - task: smoke-test-alertmanager-eu-west-1c
+          attempts: 3
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:


### PR DESCRIPTION
adds 3 retries to the "smoke" tests for the prom/alertmanager deployment
jobs.

sometimes it takes a couple of mins for prometheus to come back (say
after a disk resize) which can lead to these tests appearing to fail
when they should just wait a little longer.