### PR TITLE
WIP: run a prometheus on a graviton2 instance

### DIFF
--- a/terraform/modules/common/ami/main.tf
+++ b/terraform/modules/common/ami/main.tf
@@ -43,6 +43,51 @@ data "aws_ami" "ubuntu_focal" {
   owners = [local.canonical_account_id]
 }
 
+# 2020-07-01 focal arm64 has a broken snapd installation, so we can't
+# get ssm agent and other things
+# https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1881350
+data "aws_ami" "ubuntu_focal_arm" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["arm64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = [local.canonical_account_id]
+}
+
+data "aws_ami" "ubuntu_groovy_daily_arm" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images-testing/hvm-ssd/ubuntu-groovy-daily-arm64-server-*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["arm64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = [local.canonical_account_id]
+}
+
 ## Outputs
 
 output "ecs_optimized_ami_id" {
@@ -51,5 +96,13 @@ output "ecs_optimized_ami_id" {
 
 output "ubuntu_focal_ami_id" {
   value = data.aws_ami.ubuntu_focal.id
+}
+
+output "ubuntu_focal_arm_ami_id" {
+  value = data.aws_ami.ubuntu_focal_arm.id
+}
+
+output "ubuntu_groovy_arm_ami_id" {
+  value = data.aws_ami.ubuntu_groovy_daily_arm.id
 }
 

--- a/terraform/modules/prom-ec2/paas-config/main.tf
+++ b/terraform/modules/prom-ec2/paas-config/main.tf
@@ -7,7 +7,7 @@ data "template_file" "prometheus_config_template" {
 }
 
 resource "aws_route53_record" "prom_ec2_a_record" {
-  count = 3
+  count = length(var.prom_private_ips)
 
   zone_id = var.private_zone_id
   name    = "prom-ec2-${count.index + 1}"

--- a/terraform/modules/prom-ec2/prometheus/cloud.conf
+++ b/terraform/modules/prom-ec2/prometheus/cloud.conf
@@ -75,6 +75,7 @@ write_files:
     permissions: 0755
   - content: |
       #!/bin/bash
+      # TODO: make architecture-aware
       curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-6.4.2-amd64.deb && sudo dpkg -i filebeat-6.4.2-amd64.deb
       aws s3 sync s3://${config_bucket}/filebeat/ /etc/filebeat/ --region=${region}
       update-rc.d filebeat defaults

--- a/terraform/projects/prom-ec2/paas-staging-graviton/main.tf
+++ b/terraform/projects/prom-ec2/paas-staging-graviton/main.tf
@@ -1,0 +1,110 @@
+locals {
+  environment   = "staging"
+  config_bucket = "gdsobserve-paas-${local.environment}-graviton-config-store"
+}
+
+terraform {
+  required_version = "~> 0.12.19"
+
+  backend "s3" {
+    bucket  = "govukobserve-tfstate-prom-enclave-paas-staging-graviton"
+    key     = "prometheus.tfstate"
+    encrypt = true
+    region  = "eu-west-1"
+  }
+}
+
+provider "aws" {
+  version = "~> 2.45"
+
+  region              = "eu-west-1"
+  allowed_account_ids = ["027317422673"]
+}
+
+data "terraform_remote_state" "infra_networking" {
+  backend = "s3"
+
+  config = {
+    bucket = "prometheus-${local.environment}"
+    key    = "infra-networking-modular.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "infra_security_groups" {
+  backend = "s3"
+
+  config = {
+    bucket = "prometheus-${local.environment}"
+    key    = "infra-security-groups-modular.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "app_ecs_albs" {
+  backend = "s3"
+
+  config = {
+    bucket = "prometheus-${local.environment}"
+    key    = "app-ecs-albs-modular.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+provider "pass" {
+  store_dir     = "~/.password-store/re-secrets/observe"
+  refresh_store = true
+}
+
+data "pass_password" "prometheus_htpasswd" {
+  path = "prometheus-basic-auth-htpasswd"
+}
+
+module "ami" {
+  source = "../../../modules/common/ami"
+}
+
+module "prometheus" {
+  source = "../../../modules/prom-ec2/prometheus"
+
+  ami_id = module.ami.ubuntu_groovy_arm_ami_id
+
+  target_vpc = data.terraform_remote_state.infra_networking.outputs.vpc_id
+  enable_ssh = true
+
+  environment   = "${local.environment}-graviton"
+  config_bucket = local.config_bucket
+
+  prometheus_public_fqdns = data.terraform_remote_state.app_ecs_albs.outputs.prom_public_record_fqdns
+
+  instance_size = "m6g.large"
+
+  # graviton2 instances are only available in eu-west-1a and eu-west-1c in this account
+  subnet_ids = [data.terraform_remote_state.infra_networking.outputs.public_subnets[0], data.terraform_remote_state.infra_networking.outputs.public_subnets[2]]
+  availability_zones = {
+    "eu-west-1a" = data.terraform_remote_state.infra_networking.outputs.subnets_by_az["eu-west-1a"]
+    "eu-west-1c" = data.terraform_remote_state.infra_networking.outputs.subnets_by_az["eu-west-1c"]
+  }
+  vpc_security_groups = [data.terraform_remote_state.infra_security_groups.outputs.prometheus_ec2_sg_id]
+  region              = "eu-west-1"
+
+  prometheus_htpasswd          = data.pass_password.prometheus_htpasswd.password
+  prometheus_target_group_arns = [data.terraform_remote_state.app_ecs_albs.outputs.prometheus_target_group_arns[0], data.terraform_remote_state.app_ecs_albs.outputs.prometheus_target_group_arns[2]]
+}
+
+module "paas-config" {
+  source = "../../../modules/prom-ec2/paas-config"
+
+  environment = "${local.environment}-graviton"
+
+  prometheus_config_bucket = module.prometheus.s3_config_bucket
+  alerts_path              = "../../../modules/prom-ec2/alerts-config/alerts/"
+
+  prom_private_ips  = module.prometheus.private_ip_addresses
+  private_zone_id   = data.terraform_remote_state.infra_networking.outputs.private_zone_id
+  private_subdomain = data.terraform_remote_state.infra_networking.outputs.private_subdomain
+}
+
+output "instance_ids" {
+  value = "[\n    ${join("\n    ", module.prometheus.prometheus_instance_id)}\n]"
+}


### PR DESCRIPTION
This commit shows a PoC of prometheus running on an m6g.large (arm64
graviton2) instance.

This achieves:

 - running 2x prometheus on ARM \o/
   - the prometheis are able to discover and scrape each other and
     alertmanager

Unresolved issues:

 - [ubuntu focal arm64's snapd is broken][1] so this commit uses the
   daily build of groovy which is very much not supported.

 - this deploys a graviton2 staging prometheus alongside the existing
   amd64 prometheus, they both get added to the same target group and
   they fight over the route 53 record so terraform doesn't apply
   cleanly.  If we were doing this properly we'd remove the old one
   and add a whole new one, maybe migrating AZ-by-AZ.

 - we hardcode installing filebeat for amd64; if we were to do this
   properly we'd need to sort this out.  it doesn't seem like filebeat
   offers an arm64 binary download, we might need to build it
   ourselves.

 - graviton2 instances are only available in 2 AZs in ireland, and not
   in London at all.

[1]: https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1881350