### PR TITLE
route dcs integration environment alerts to slack

### DIFF
--- a/terraform/modules/alertmanager/templates/alertmanager.tpl
+++ b/terraform/modules/alertmanager/templates/alertmanager.tpl
@@ -64,8 +64,8 @@ route:
     - match:
         severity: constant
       receiver: "dev-null"
-    - match:
-        namespace: verify-doc-checking-prod
+    - match_re:
+        namespace: verify-doc-checking-prod|verify-dcs-integration
       receiver: dcs-slack
     - match_re:
         namespace: verify-proxy-node-.*|verify-metadata-.*|verify-connector-.*


### PR DESCRIPTION
## What

Route dcs integration environment alerts to slack.

## Why

Need to keep an eye on integration too.  Can use it to test alerting for prod.