### PR TITLE
s9SNoTta: config to route dcs p2 alerts to pagerduty

### DIFF
--- a/terraform/modules/alertmanager/alertmanager-service.tf
+++ b/terraform/modules/alertmanager/alertmanager-service.tf
@@ -134,6 +134,10 @@ data "pass_password" "verify_p2_pagerduty_key" {
   path = "pagerduty/integration-keys/verify-p2"
 }
 
+data "pass_password" "dcs_p2_pagerduty_key" {
+  path = "pagerduty/integration-keys/dcs-p2"
+}
+
 data "pass_password" "slack_api_url" {
   path = "slack-api-url"
 }
@@ -175,6 +179,7 @@ data "template_file" "alertmanager_config_file" {
     govuk_pagerduty_key     = data.pass_password.govuk_pagerduty_key.password
     verify_p1_pagerduty_key = data.pass_password.verify_p1_pagerduty_key.password
     verify_p2_pagerduty_key = data.pass_password.verify_p2_pagerduty_key.password
+    dcs_p2_pagerduty_key    = data.pass_password.dcs_p2_pagerduty_key.password
     slack_api_url           = data.pass_password.slack_api_url.password
     registers_zendesk       = data.pass_password.registers_zendesk.password
     smtp_from               = "alerts@${data.terraform_remote_state.infra_networking.outputs.public_subdomain}"

--- a/terraform/modules/alertmanager/templates/alertmanager.tpl
+++ b/terraform/modules/alertmanager/templates/alertmanager.tpl
@@ -67,6 +67,10 @@ route:
     - match_re:
         namespace: verify-doc-checking-prod|verify-dcs-integration
       receiver: dcs-slack
+    - match:
+        namespace: verify-doc-checking-prod
+        severity: p2
+      receiver: "dcs-p2"
     - match_re:
         namespace: verify-proxy-node-.*|verify-metadata-.*|verify-connector-.*
       receiver: eidas-slack
@@ -221,6 +225,9 @@ receivers:
   slack_configs:
     - <<: *gsp-slack-config
       channel: '#verify-dcs-gsp-alerts'
+- name: "dcs-p2"
+  pagerduty_configs:
+    - service_key: "${dcs_p2_pagerduty_key}"
 - name: "verify-p1"
   pagerduty_configs:
     - service_key: "${verify_p1_pagerduty_key}"

--- a/terraform/modules/alertmanager/templates/alertmanager.tpl
+++ b/terraform/modules/alertmanager/templates/alertmanager.tpl
@@ -67,10 +67,11 @@ route:
     - match_re:
         namespace: verify-doc-checking-prod|verify-dcs-integration
       receiver: dcs-slack
-    - match:
-        namespace: verify-doc-checking-prod
-        severity: p2
-      receiver: "dcs-p2"
+      routes:
+      - match:
+          namespace: verify-doc-checking-prod
+          severity: p2
+        receiver: "dcs-p2"
     - match_re:
         namespace: verify-proxy-node-.*|verify-metadata-.*|verify-connector-.*
       receiver: eidas-slack


### PR DESCRIPTION
Add new receiver and key for dcs p2 alerts.