### PR TITLE
Make RE_Observe_No_Paas_Targets a bit less trigger-happy

### DIFF
--- a/terraform/modules/prom-ec2/alerts-config/alerts/observe-alerts.yml
+++ b/terraform/modules/prom-ec2/alerts-config/alerts/observe-alerts.yml
@@ -51,7 +51,7 @@ groups:
 
   - alert: RE_Observe_No_Paas_Targets
     expr: prometheus_sd_discovered_targets{config=~"paas-(london|ireland)-targets"} == 0
-    for: 10s
+    for: 10m
     labels:
         product: "prometheus"
         severity: "page"


### PR DESCRIPTION
This alert has been quite noisy recently, and it's only there to catch
a logical misconfiguration (rather than a reliability problem caused
by some sort of transient failure).

I think we can bump up the `for` clause to make it less trigger-happy.
It will still fire in a reasonably timely manner if we somehow mess up
the service broker configuration, but won't fire randomly just because
we deployed some code and rebuilt the prometheus servers.