### PR TITLE
Fix URL of Digital Marketplace Prometheus metrics

### DIFF
--- a/terraform/projects/prom-ec2/paas-production/extra-prometheus-scrape-configs.yml.tpl
+++ b/terraform/projects/prom-ec2/paas-production/extra-prometheus-scrape-configs.yml.tpl
@@ -9,7 +9,7 @@
     - "{job='aiven'}"
   static_configs:
   - targets:
-    - digitalmarketplace-es-metrics.london.cloudapps.digital
+    - digitalmarketplace-es-metrics.cloudapps.digital
   metric_relabel_configs:
   # Prepend `paas_es_` so the metrics are easier to find
   - action: replace


### PR DESCRIPTION
I accidentally left `london.` in when adapting this config from another tenant. DM run in Ireland.