### PR TITLE
Escape Prometheus variable substitution

### DIFF
--- a/terraform/projects/prom-ec2/paas-production/extra-prometheus-scrape-configs.yml.tpl
+++ b/terraform/projects/prom-ec2/paas-production/extra-prometheus-scrape-configs.yml.tpl
@@ -16,7 +16,7 @@
     source_labels: [__name__]
     target_label: __name__
     regex: (.*)
-    replacement: paas_es_${1}
+    replacement: paas_es_$${1}
   # Dummy entry to be used below
   - &store_this_metric
     action: replace


### PR DESCRIPTION
Still trying to fix issues not anticipated in #404. 🤦 

This template uses Terraform templatefile variable substitution to create a Prometheus config. Prometheus will then do its own variable interpolation when interpreting the `metric_relabel_configs`. This commit fixes the Prometheus interpolation line so that Terraform won't perform (failed) substitution [1].

[1] https://github.com/hashicorp/terraform/issues/17899#issuecomment-382956001