### PR TITLE
Revert "Include changes to ECS ALB config in pipeline trigger"

### DIFF
--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -55,7 +55,6 @@ resources:
       branch: master
       paths:
         - terraform/modules/prom-ec2
-        - terraform/modules/app-ecs-albs
         - terraform/projects/prom-ec2
   - name: cf-app-discovery-git
     type: git


### PR DESCRIPTION
Reverts alphagov/prometheus-aws-configuration-beta#410

This is done properly in https://github.com/alphagov/prometheus-aws-configuration-beta/pull/412, https://github.com/alphagov/prometheus-aws-configuration-beta/pull/413, and https://github.com/alphagov/prometheus-aws-configuration-beta/pull/414.