### PR TITLE
revert alertmanager back to ALB

### DIFF
--- a/terraform/modules/alertmanager/alb.tf
+++ b/terraform/modules/alertmanager/alb.tf
@@ -1,0 +1,109 @@
+######################################################################
+# ----- alertmanager public ALB -------
+######################################################################
+#
+#
+# The ALB serves one main purpose: so we can use ACM certs instead of
+# managing our own.  We don't actually want it to load-balance; each
+# public domain name associated with alertmanager should route to
+# exactly one internal alertmanager instance.  We achieve this by
+# using listener rules, so that requests with a particular host:
+# header must go to a particular AZ, and running one alertmanager per
+# AZ.
+
+
+resource "aws_lb" "alertmanager_alb" {
+  name               = "${var.environment}-alertmanager-alb"
+  internal           = false
+  load_balancer_type = "application"
+
+  security_groups = [aws_security_group.alertmanager_alb.id]
+
+  subnets = data.terraform_remote_state.infra_networking.outputs.public_subnets
+
+  tags = merge(
+    local.default_tags,
+    {
+      Name    = "${var.environment}-alertmanager-alb"
+      Service = "alertmanager"
+    },
+  )
+}
+
+resource "aws_lb_listener" "alertmanager_listener_alb_http" {
+  load_balancer_arn = aws_lb.alertmanager_alb.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "alertmanager_listener_alb_https" {
+  load_balancer_arn = aws_lb.alertmanager_alb.arn
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
+  certificate_arn   = aws_acm_certificate_validation.alertmanager_cert.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.alertmanager.arn
+  }
+}
+
+resource "aws_lb_listener_rule" "alertmanager_listener_rule_per_az" {
+  count = length(local.availability_zones)
+
+  listener_arn = aws_lb_listener.alertmanager_listener_https.arn
+  priority     = 100 + count.index
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.alertmanager_per_az[local.availability_zones[count.index]].arn
+  }
+
+  condition {
+    host_header {
+      values = ["alerts-${count.index + 1}.*"]
+    }
+  }
+}
+
+resource "aws_lb_target_group" "alertmanager_per_az" {
+  for_each             = toset(local.availability_zones)
+  name                 = "${var.environment}-alertmanager-${each.key}"
+  port                 = 9093
+  protocol             = "TCP"
+  vpc_id               = local.vpc_id
+  deregistration_delay = 30
+  target_type          = "ip"
+
+  health_check {
+    interval            = 10
+    protocol            = "TCP"
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+  }
+}
+
+resource "aws_route53_record" "alerts_alias_per_az" {
+  count = length(local.availability_zones)
+
+  zone_id = local.zone_id
+  name    = "alerts-${count.index + 1}"
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.alertmanager_alb.dns_name
+    zone_id                = aws_lb.alertmanager_alb.zone_id
+    evaluate_target_health = false
+  }
+}

--- a/terraform/modules/alertmanager/alertmanager-service.tf
+++ b/terraform/modules/alertmanager/alertmanager-service.tf
@@ -113,8 +113,11 @@ resource "aws_ecs_service" "alertmanager_nlb" {
 }
 
 resource "aws_ecs_service" "alertmanager_alb" {
-  count           = length(data.aws_subnet.private_subnets)
-  name            = "${var.environment}-alertmanager-alb-${data.aws_subnet.private_subnets[count.index].availability_zone}"
+  for_each = {
+    for _, subnet in data.aws_subnet.private_subnets :
+    subnet.id => subnet.availability_zone
+  }
+  name            = "${var.environment}-alertmanager-alb-${each.value}"
   cluster         = "${var.environment}-ecs-monitoring"
   task_definition = aws_ecs_task_definition.alertmanager_nlb.arn
   desired_count   = 1
@@ -127,13 +130,13 @@ resource "aws_ecs_service" "alertmanager_alb" {
   }
 
   load_balancer {
-    target_group_arn = aws_lb_target_group.alertmanager_per_subnet[count.index].arn
+    target_group_arn = aws_lb_target_group.alertmanager_per_az[each.value].arn
     container_name   = "alertmanager"
     container_port   = 9093
   }
 
   network_configuration {
-    subnets         = [data.aws_subnet.private_subnets[count.index].id]
+    subnets         = [each.key]
     security_groups = [aws_security_group.alertmanager_task.id]
   }
 

--- a/terraform/modules/alertmanager/alertmanager-service.tf
+++ b/terraform/modules/alertmanager/alertmanager-service.tf
@@ -102,6 +102,12 @@ resource "aws_ecs_service" "alertmanager_nlb" {
     container_port   = 9093
   }
 
+  load_balancer {
+    target_group_arn = aws_lb_target_group.alertmanager_per_subnet[count.index].arn
+    container_name   = "alertmanager"
+    container_port   = 9093
+  }
+
   network_configuration {
     subnets         = [data.aws_subnet.private_subnets[count.index].id]
     security_groups = [aws_security_group.alertmanager_task.id]

--- a/terraform/modules/alertmanager/main.tf
+++ b/terraform/modules/alertmanager/main.tf
@@ -54,9 +54,10 @@ locals {
     Environment = var.environment
     Service     = "alertmanager"
   }
-  vpc_id    = data.terraform_remote_state.infra_networking.outputs.vpc_id
-  zone_id   = data.terraform_remote_state.infra_networking.outputs.public_zone_id
-  subdomain = replace(data.aws_route53_zone.public_zone.name, "/\\.$/", "")
+  vpc_id             = data.terraform_remote_state.infra_networking.outputs.vpc_id
+  zone_id            = data.terraform_remote_state.infra_networking.outputs.public_zone_id
+  subdomain          = replace(data.aws_route53_zone.public_zone.name, "/\\.$/", "")
+  availability_zones = data.aws_subnet.public_subnets.*.availability_zone
 }
 
 # Resources

--- a/terraform/modules/alertmanager/security-group.tf
+++ b/terraform/modules/alertmanager/security-group.tf
@@ -1,3 +1,16 @@
+resource "aws_security_group" "alertmanager_alb" {
+  name        = "${var.environment}-alertmanager-alb"
+  vpc_id      = local.vpc_id
+  description = "Alertmanager ALB"
+
+  tags = merge(
+    local.default_tags,
+    {
+      Name = "alertmanager-alb",
+    },
+  )
+}
+
 resource "aws_security_group" "alertmanager_task" {
   name        = "${var.environment}-alertmanager-task"
   vpc_id      = local.vpc_id
@@ -22,6 +35,26 @@ resource "aws_security_group_rule" "ingress_from_allowed_cidrs_to_alertmanager_9
   cidr_blocks       = var.allowed_cidrs
 }
 
+# Alertmanager ALB needs to allow ingress from the allowed public
+# internet cidrs
+resource "aws_security_group_rule" "ingress_from_allowed_cidrs_to_alertmanager_alb_http" {
+  security_group_id = aws_security_group.alertmanager_alb.id
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = var.allowed_cidrs
+}
+
+resource "aws_security_group_rule" "ingress_from_allowed_cidrs_to_alertmanager_alb_https" {
+  security_group_id = aws_security_group.alertmanager_alb.id
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = var.allowed_cidrs
+}
+
 # NLB health checks come from the public subnet IP range
 resource "aws_security_group_rule" "ingress_from_public_subnets_to_alertmanager_9093" {
   security_group_id = aws_security_group.alertmanager_task.id
@@ -30,6 +63,25 @@ resource "aws_security_group_rule" "ingress_from_public_subnets_to_alertmanager_
   to_port           = 9093
   protocol          = "tcp"
   cidr_blocks       = data.aws_subnet.public_subnets.*.cidr_block
+}
+
+resource "aws_security_group_rule" "ingress_from_alertmanager_alb_to_alertmanager_9093" {
+  security_group_id        = aws_security_group.alertmanager_task.id
+  source_security_group_id = aws_security_group.alertmanager_alb.id
+  type                     = "ingress"
+  from_port                = 9093
+  to_port                  = 9093
+  protocol                 = "tcp"
+}
+
+resource "aws_security_group_rule" "egress_from_alertmanager_alb_to_alertmanager_9093" {
+  security_group_id = aws_security_group.alertmanager_alb.id
+  # source_security_group_id means destination for egress rules
+  source_security_group_id = aws_security_group.alertmanager_task.id
+  type                     = "egress"
+  from_port                = 9093
+  to_port                  = 9093
+  protocol                 = "tcp"
 }
 
 # TODO: could we make observe prometheus more consistent with external


### PR DESCRIPTION
This adds back an ALB for serving alertmanager traffic.

It can't go live because adding a target group to an ECS Service
forces destroy/recreate and we don't want to risk an alertmanager
outage.