### PR TITLE
Fix ALB target group

### DIFF
--- a/terraform/modules/alertmanager/alb.tf
+++ b/terraform/modules/alertmanager/alb.tf
@@ -81,16 +81,19 @@ resource "aws_lb_target_group" "alertmanager_per_az" {
   for_each             = toset(local.availability_zones)
   name                 = "${var.environment}-alertmanager-${each.key}"
   port                 = 9093
-  protocol             = "TCP"
+  protocol             = "HTTP"
   vpc_id               = local.vpc_id
   deregistration_delay = 30
   target_type          = "ip"
 
   health_check {
     interval            = 10
-    protocol            = "TCP"
+    path                = "/"
+    matcher             = "200"
+    protocol            = "HTTP"
     healthy_threshold   = 2
     unhealthy_threshold = 2
+    timeout             = "5"
   }
 }
 


### PR DESCRIPTION
For HTTPS ALBs, the target group MUST be of type HTTP, it cannot be of
type TCP.  As a bonus, this means we get HTTP healthchecks which are a
bit cleverer.