### PR TITLE
Trim trailing full stop to try to get AlertManager emails flowing again

### DIFF
--- a/terraform/modules/alertmanager/alertmanager-service.tf
+++ b/terraform/modules/alertmanager/alertmanager-service.tf
@@ -179,6 +179,10 @@ data "pass_password" "verify_prod_cronitor" {
   path = "cronitor/verify-prod-url"
 }
 
+locals {
+  public_subdomain_notrailingdot = trimsuffix(data.terraform_remote_state.infra_networking.outputs.public_subdomain, ".")
+}
+
 data "template_file" "alertmanager_config_file" {
   template = file("${path.module}/templates/alertmanager.tpl")
 
@@ -191,7 +195,7 @@ data "template_file" "alertmanager_config_file" {
     dcs_p2_pagerduty_key    = data.pass_password.dcs_p2_pagerduty_key.password
     slack_api_url           = data.pass_password.slack_api_url.password
     registers_zendesk       = data.pass_password.registers_zendesk.password
-    smtp_from               = "alerts@${data.terraform_remote_state.infra_networking.outputs.public_subdomain}"
+    smtp_from               = "alerts@${local.public_subdomain_notrailingdot}"
     # Port as requested by https://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-connect.html
     smtp_smarthost              = "email-smtp.${var.aws_region}.amazonaws.com:587"
     smtp_username               = aws_iam_access_key.smtp.id


### PR DESCRIPTION
These appear to have been broken since 23rd (ish) of January and the error AlertManager is outputting is this:
level=error ts=2020-09-08T08:11:47.804Z caller=dispatch.go:309 component=dispatcher msg="Notify for alerts failed" num_alerts=1 err="re-observe-ticket-alert/email[0]: notify retry canceled due to unrecoverable error after 1 attempts: parse 'from' addresses: mail: no angle-addr"
With the from address being "alerts@monitoring.gds-reliability.engineering."

It looks like Golang has never allowed the trailing full stop, so I'm suspicious this was caused by Terraform doing something related to https://github.com/terraform-providers/terraform-provider-aws/issues/241, maybe while applying 050dfc9513ca68a517c6582aecbdaea466a4864c