### PR TITLE
observe alerts: add RE_Observe_No_Successful_Updates alert

### DIFF
--- a/terraform/modules/prom-ec2/alerts-config/alerts/observe-alerts.yml
+++ b/terraform/modules/prom-ec2/alerts-config/alerts/observe-alerts.yml
@@ -95,6 +95,17 @@ groups:
         message: "One of the {{ $labels.job }} targets has been down for 24 hours"
         runbook: "https://re-team-manual.cloudapps.digital/prometheus-for-gds-paas-users.html#re-observe-target-down"
 
+  - alert: RE_Observe_No_Successful_Updates
+    expr: sum(increase(observe_broker_http_requests_total{code="200", path="/update-targets", method="post"}[30m])) by (region) == 0
+    for: 12h
+    labels:
+        product: "prometheus"
+        severity: "ticket"
+    annotations:
+        summary: "No recent target updates in region '{{ $labels.region }}'"
+        message: "Target update in region '{{ $labels.region }}' hasn't completed successfully in at least 12h"
+        runbook: "https://re-team-manual.cloudapps.digital/prometheus-for-gds-paas-users.html#re-observe-no-successful-updates"
+
   - alert: AlwaysAlert
     annotations:
       message: |

--- a/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
+++ b/terraform/modules/prom-ec2/paas-config/prometheus.conf.tpl
@@ -34,6 +34,9 @@ scrape_configs:
     file_sd_configs:
       - files: ['/etc/prometheus/ireland-targets/*.json']
         refresh_interval: 30s
+    relabel_configs:
+      - target_label: region
+        replacement: ireland
   - job_name: paas-london-targets
     scheme: http
     proxy_url: 'http://localhost:8080'


### PR DESCRIPTION
https://trello.com/c/vAmktonY

This is an alert we want to fire when we haven't seen any successful targets updates in a region for a certain period. updates are triggered through the /update-targets endpoint, so luckily we should just be able to look at the 200 responses to these requests to see successful updates.

Wrap in an outer `sum()` aggregation to leave open the possibility of multiple app instances.

Open to discussions of what the time window(s) and severity for this should be. I've initially chosen an `increase()` window of 30m, a `for:` period of 12h, and `ticket` severity.

The manual link doesn't exist (yet).