### PR TITLE
cd pipeline http ping task: provide more useful output

### DIFF
--- a/ci/tasks/http-ping.yml
+++ b/ci/tasks/http-ping.yml
@@ -12,8 +12,11 @@ run:
     - -euxc
     - |
       DOMAIN=$(echo "${URL}" | awk -F/ '{print $3}')
-      getent ahosts ${DOMAIN} | cut -d ' ' -f1 | sort | uniq | xargs -n1 -I {} curl \
+      getent ahosts ${DOMAIN} | cut -d ' ' -f1 | sort | uniq | tee /dev/stderr | xargs -n1 -I {} curl \
         --resolve ${DOMAIN}:443:{} \
         --silent \
         --fail \
+        --write-out $'{} %{http_code} %{time_total}s\n' \
+        --output /dev/null \
         --max-time 5 "${URL}"
+


### PR DESCRIPTION
https://trello.com/c/yVWHlTnh

The first step in discovering why these checks might be flaky is to get them to produce enough detail to allow us to diagnose failures.

This adds output of the final list of IPs to be checked and the status code for each one (along with the total time taken so we can see if it was likely a timeout problem)

Seems to work as tested with `fly execute`.
