### PR TITLE
deploy pipeline: increase number of http ping attempts for smoke tests to 4

### DIFF
--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -223,19 +223,19 @@ jobs:
           GPG_PRIVATE_KEY: ((gpg_private_key))
       - in_parallel:
         - task: smoke-test-prom-1
-          attempts: 3
+          attempts: 4
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://prom-1.monitoring-staging.gds-reliability.engineering/healthz
         - task: smoke-test-prom-2
-          attempts: 3
+          attempts: 4
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://prom-2.monitoring-staging.gds-reliability.engineering/healthz
         - task: smoke-test-prom-3
-          attempts: 3
+          attempts: 4
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:
@@ -271,19 +271,19 @@ jobs:
           GPG_PRIVATE_KEY: ((gpg_private_key))
       - in_parallel:
         - task: smoke-test-prom-1
-          attempts: 3
+          attempts: 4
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://prom-1.monitoring.gds-reliability.engineering/healthz
         - task: smoke-test-prom-2
-          attempts: 3
+          attempts: 4
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://prom-2.monitoring.gds-reliability.engineering/healthz
         - task: smoke-test-prom-3
-          attempts: 3
+          attempts: 4
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:
@@ -392,25 +392,25 @@ jobs:
                 puts "Stable #{cluster_name}"
       - in_parallel:
         - task: smoke-test-alertmanager
-          attempts: 3
+          attempts: 4
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://alerts.monitoring-staging.gds-reliability.engineering/-/healthy
         - task: smoke-test-alertmanager-eu-west-1a
-          attempts: 3
+          attempts: 4
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://alerts-eu-west-1a.monitoring-staging.gds-reliability.engineering/-/healthy
         - task: smoke-test-alertmanager-eu-west-1b
-          attempts: 3
+          attempts: 4
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://alerts-eu-west-1b.monitoring-staging.gds-reliability.engineering/-/healthy
         - task: smoke-test-alertmanager-eu-west-1c
-          attempts: 3
+          attempts: 4
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:
@@ -460,25 +460,25 @@ jobs:
           run: *run-wait-for-ecs
       - in_parallel:
         - task: smoke-test-alertmanager
-          attempts: 3
+          attempts: 4
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://alerts.monitoring.gds-reliability.engineering/-/healthy
         - task: smoke-test-alertmanager-eu-west-1a
-          attempts: 3
+          attempts: 4
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://alerts-eu-west-1a.monitoring.gds-reliability.engineering/-/healthy
         - task: smoke-test-alertmanager-eu-west-1b
-          attempts: 3
+          attempts: 4
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:
             URL: https://alerts-eu-west-1b.monitoring.gds-reliability.engineering/-/healthy
         - task: smoke-test-alertmanager-eu-west-1c
-          attempts: 3
+          attempts: 4
           timeout: 2m
           file: ci-git/ci/tasks/http-ping.yml
           params:


### PR DESCRIPTION
https://trello.com/c/yVWHlTnh

Highly scientific pull request here.

After adding some more debugging output to the smoke tests, it appears all the failures are 502s so far. I haven't seen another release that exceeds its 3-ping-attempt limit (and thus fails) yet, but ones that make it up to their 3-ping-attempt limit are all getting 502s up to that point.

I think cautiously increasing the number of attempts to 4 would make it less likely to get annoying failures again, yet still cause us to take notice if it goes over this, being able to diagnose more serious problems with the new output.

