### PR TITLE
Remove the ecs_optimized_ami_id output as it is unused

### DIFF
--- a/terraform/modules/common/ami/main.tf
+++ b/terraform/modules/common/ami/main.tf
@@ -6,22 +6,6 @@ locals {
 
 ## Data sources
 
-data "aws_ami" "ecs_optimized" {
-  most_recent = true
-
-  filter {
-    name   = "name"
-    values = ["amzn-ami-*-amazon-ecs-optimized"]
-  }
-
-  filter {
-    name   = "architecture"
-    values = ["x86_64"]
-  }
-
-  owners = ["amazon"]
-}
-
 data "aws_ami" "ubuntu_focal" {
   most_recent = true
 
@@ -44,10 +28,6 @@ data "aws_ami" "ubuntu_focal" {
 }
 
 ## Outputs
-
-output "ecs_optimized_ami_id" {
-  value = data.aws_ami.ecs_optimized.id
-}
 
 output "ubuntu_focal_ami_id" {
   value = data.aws_ami.ubuntu_focal.id


### PR DESCRIPTION
I believe the last use was removed in [1].

1: f5f49866fe4152e69b0be3e8b2083b115a1d8db9