### PR TITLE
Make autom8 alerts more consistent

### DIFF
--- a/terraform/modules/alertmanager/alertmanager-service.tf
+++ b/terraform/modules/alertmanager/alertmanager-service.tf
@@ -155,8 +155,9 @@ data "pass_password" "registers_zendesk" {
   path = "receivers/registers/zendesk"
 }
 
-data "pass_password" "observe_zendesk" {
-  path = "receivers/observe/zendesk"
+data "pass_password" "autom8_email" {
+  path = "receivers/autom8/email"
+
 }
 
 data "pass_password" "verify_gsp_cronitor" {
@@ -200,7 +201,7 @@ data "template_file" "alertmanager_config_file" {
     smtp_smarthost              = "email-smtp.${var.aws_region}.amazonaws.com:587"
     smtp_username               = aws_iam_access_key.smtp.id
     smtp_password               = aws_iam_access_key.smtp.ses_smtp_password
-    ticket_recipient_email      = data.pass_password.observe_zendesk.password
+    autom8_recipient_email      = data.pass_password.autom8_email.password
     observe_cronitor            = var.observe_cronitor
     verify_gsp_cronitor         = data.pass_password.verify_gsp_cronitor.password
     verify_joint_cronitor       = data.pass_password.verify_joint_cronitor.password

--- a/terraform/modules/alertmanager/templates/alertmanager.tpl
+++ b/terraform/modules/alertmanager/templates/alertmanager.tpl
@@ -17,7 +17,7 @@ route:
     - product
     - deployment
   routes:
-  - receiver: "re-observe-ticket-alert"
+  - receiver: "autom8-tickets"
     repeat_interval: 7d
     match:
       product: "prometheus"
@@ -39,7 +39,7 @@ route:
     match:
       product: "prometheus"
       severity: "constant"
-  - receiver: "autom8-alerts-slack"
+  - receiver: "autom8-tickets"
     match:
       layer: "infra"
       severity: "ticket"
@@ -110,9 +110,6 @@ receivers:
 - name: "re-observe-pagerduty"
   pagerduty_configs:
     - service_key: "${observe_pagerduty_key}"
-- name: "re-observe-ticket-alert"
-  email_configs:
-  - to: "${autom8_recipient_email}"
 - name: "dgu-pagerduty"
   pagerduty_configs:
     - service_key: "${dgu_pagerduty_key}"
@@ -148,7 +145,9 @@ receivers:
     channel: '#verify-2ndline'
     icon_emoji: ':verify-shield:'
     username: alertmanager
-- name: "autom8-alerts-slack"
+- name: "autom8-tickets"
+  email_configs:
+  - to: "${autom8_recipient_email}"
   slack_configs:
   - send_resolved: true
     channel: '#re-autom8-alerts'

--- a/terraform/modules/alertmanager/templates/alertmanager.tpl
+++ b/terraform/modules/alertmanager/templates/alertmanager.tpl
@@ -112,7 +112,7 @@ receivers:
     - service_key: "${observe_pagerduty_key}"
 - name: "re-observe-ticket-alert"
   email_configs:
-  - to: "${ticket_recipient_email}"
+  - to: "${autom8_recipient_email}"
 - name: "dgu-pagerduty"
   pagerduty_configs:
     - service_key: "${dgu_pagerduty_key}"


### PR DESCRIPTION
# What

* replaced the zendesk ticket creation with an email
* combined the emailed 'ticket' with the pre-existing Slack notification.

# Why

Autom8 team did not use Zendesk as a regular tool and it is sensible to email and alert via slack to improve visibility of alerts.
