### PR TITLE
Add an alert for when Notify disk space fills up

### DIFF
--- a/terraform/modules/alertmanager/alertmanager-service.tf
+++ b/terraform/modules/alertmanager/alertmanager-service.tf
@@ -155,6 +155,10 @@ data "pass_password" "registers_zendesk" {
   path = "receivers/registers/zendesk"
 }
 
+data "pass_password" "notify_zendesk" {
+  path = "receivers/notify/zendesk"
+}
+
 data "pass_password" "autom8_email" {
   path = "receivers/autom8/email"
 
@@ -196,6 +200,7 @@ data "template_file" "alertmanager_config_file" {
     dcs_p2_pagerduty_key    = data.pass_password.dcs_p2_pagerduty_key.password
     slack_api_url           = data.pass_password.slack_api_url.password
     registers_zendesk       = data.pass_password.registers_zendesk.password
+    notify_zendesk          = data.pass_password.notify_zendesk.password
     smtp_from               = "alerts@${local.public_subdomain_notrailingdot}"
     # Port as requested by https://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-connect.html
     smtp_smarthost              = "email-smtp.${var.aws_region}.amazonaws.com:587"

--- a/terraform/modules/alertmanager/templates/alertmanager.tpl
+++ b/terraform/modules/alertmanager/templates/alertmanager.tpl
@@ -22,6 +22,11 @@ route:
     match:
       product: "prometheus"
       severity: "ticket"
+  - receiver: "notify-tickets"
+    repeat_interval: 7d
+    match:
+      product: "notify"
+      severity: "ticket"
   - receiver: "dgu-pagerduty"
     match:
       product: "data-gov-uk"
@@ -119,6 +124,9 @@ receivers:
 - name: "registers-zendesk"
   email_configs:
   - to: "${registers_zendesk}"
+- name: "notify-tickets"
+  email_configs:
+  - to: "${notify_zendesk}"
 - name: "observe-cronitor"
   webhook_configs:
   - send_resolved: false

--- a/terraform/modules/prom-ec2/alerts-config/alerts/notify-alerts.yml
+++ b/terraform/modules/prom-ec2/alerts-config/alerts/notify-alerts.yml
@@ -1,0 +1,12 @@
+groups:
+- name: GOVUK_Notify
+  rules:
+  - alert: GOVUK_Notify_Disk_75_percent_full
+    expr: max(disk_utilization{space="production", organisation="govuk-notify"}) by (app, space) > 75
+    for: 5m
+    labels:
+        product: "notify"
+        severity: "ticket"
+    annotations:
+        summary: "{{ $labels.space }}: disk usage for {{ $labels.app }} is over 75% full"
+        message: "{{ $labels.app }} needs to be re-deployed to avoid running out of disk space"

--- a/terraform/modules/prom-ec2/paas-config/main.tf
+++ b/terraform/modules/prom-ec2/paas-config/main.tf
@@ -45,6 +45,13 @@ resource "aws_s3_bucket_object" "alerts-data-gov-uk-config" {
   etag   = filemd5("${var.alerts_path}data-gov-uk-alerts.yml")
 }
 
+resource "aws_s3_bucket_object" "alerts-notify-config" {
+  bucket = var.prometheus_config_bucket
+  key    = "prometheus/alerts/notify-alerts.yml"
+  source = "${var.alerts_path}notify-alerts.yml"
+  etag   = filemd5("${var.alerts_path}notify-alerts.yml")
+}
+
 resource "aws_s3_bucket_object" "alerts-registers-config" {
   bucket = var.prometheus_config_bucket
   key    = "prometheus/alerts/registers-alerts.yml"


### PR DESCRIPTION
We want to know when disk space for our apps if filling up,
so that we can re-deploy those apps and avoid running out of
disk space.

In the future we may use this alert to automatically do the
re-deploy.

The threshold was chosen at 75%, because it takes one day for apps with quickly filling up disks to fill up 25% disk space. That means if the alert is triggered in the evening, after work, we still should have time in the morning to re-deploy the app and reset the disk usage.
It should not be much lower though, because then we can start getting too many alerts.

QUESTIONS:
- Can I test it at this point, before we merge it with master? Or do we do that afterwards?
- do we set up a receiver before or after? (best method would be a Zendesk ticket, because it's an alert that needs to be followed by a concrete action. Open ticket will remind person on support to solve it.)