### PR TITLE
Remove `trust-ad` from `options` line in /etc/resolv.conf

### DIFF
--- a/terraform/modules/prom-ec2/prometheus/cloud.conf
+++ b/terraform/modules/prom-ec2/prometheus/cloud.conf
@@ -153,4 +153,5 @@ runcmd:
   - [bash, -c, "/root/manage_data_volume.sh"]
   - [bash, -c, "chown -R prometheus /mnt/"]
   - [bash, -c, "echo \"node_creation_time `date +%s`\" > /var/lib/prometheus/node-exporter/node-creation-time.prom"]
+  - [bash, -c, "rm /etc/resolv.conf && sed -e 's/ trust-ad//' < /run/systemd/resolve/stub-resolv.conf > /etc/resolv.conf"]
   - [reboot]


### PR DESCRIPTION
Prometheus stopped working for us, with panics that look like this:

    panic: runtime error: slice bounds out of range [:9] with length 8
    goroutine 425 [running]:
    github.com/miekg/dns.ClientConfigFromReader(0x1b914a0, 0xc051786b38, 0x0, 0xc000000000, 0xc051786b38)
            github.com/miekg/dns/clientconfig.go:94 +0x8d1
    github.com/miekg/dns.ClientConfigFromFile(0x1900ba4, 0x10, 0x0, 0x0, 0x0)
            github.com/miekg/dns/clientconfig.go:29 +0xde
    github.com/prometheus/prometheus/discovery/dns.lookupWithSearchPath(0xc050c8ccf0, 0x2e, 0xc0518d0001, 0x1b8f4c0, 0xc0515a1e00, 0xc051873758, 0xc00041e678, 0x7b30d0)
            github.com/prometheus/prometheus/discovery/dns/dns.go:245 +0x48
    github.com/prometheus/prometheus/discovery/dns.(*Discovery).refreshOne(0xc0513c91d0, 0x1bb6140, 0xc0000d3a80, 0xc050c8ccf0, 0x2e, 0xc0519304e0, 0x26ed320, 0x164a5e0)
            github.com/prometheus/prometheus/discovery/dns/dns.go:173 +0x77
    github.com/prometheus/prometheus/discovery/dns.(*Discovery).refresh.func1(0xc0513c91d0, 0x1bb6140, 0xc0000d3a80, 0xc0519304e0, 0xc0516c9250, 0xc050c8ccf0, 0x2e)
            github.com/prometheus/prometheus/discovery/dns/dns.go:154 +0x81
    created by github.com/prometheus/prometheus/discovery/dns.(*Discovery).refresh
            github.com/prometheus/prometheus/discovery/dns/dns.go:153 +0x175

This looked like it was barfing on the `options` line in
/etc/resolv.conf, on a string of length 8.

In June, a change was made to systemd-resolved to change the options
line from `options edns0` to `options edns0 trust-ad`.  It looks like
this change is causing the panic in the miekd/dns library.

This change removes `trust-ad` from the `options` line because a) we
don't care about DNSSEC, and b) we think it's breaking things.

Note that systemd-resolved automatically determines whether it should
manage /etc/resolv.conf or not based on whether it is a symlink and
whether it includes 127.0.0.53 as a nameserver.  So we think that
replacing the symlink will Do The Right Thing.  We tested by manually
changing /etc/resolv.conf on a machine and rebooting it to see if it
still worked, and it did.

See https://jlk.fjfi.cvut.cz/arch/manpages/man/systemd-resolved.8#/ETC/RESOLV.CONF

> Note that the selected mode of operation for this file is detected
> fully automatically, depending on whether /etc/resolv.conf is a
> symlink to /run/systemd/resolve/resolv.conf or lists 127.0.0.53 as
> DNS server.

Co-authored-by: chrisfarms <chris.farmiloe@digital.cabinet-office.gov.uk>
Co-authored-by: Robert Scott <robert.scott@digital.cabinet-office.gov.uk>