### PR TITLE
fix terraform 0.13

### DIFF
--- a/terraform/projects/alertmanager-production/main.tf
+++ b/terraform/projects/alertmanager-production/main.tf
@@ -31,12 +31,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.45"
-  region  = var.aws_region
-}
-
-provider "template" {
-  version = "~> 2.1"
+  region = var.aws_region
 }
 
 provider "pass" {

--- a/terraform/projects/alertmanager-production/versions.tf
+++ b/terraform/projects/alertmanager-production/versions.tf
@@ -1,13 +1,16 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = "2.70"
     }
     pass = {
-      source = "camptocamp/pass"
+      source  = "camptocamp/pass"
+      version = "1.4.0"
     }
     template = {
-      source = "hashicorp/template"
+      source  = "hashicorp/template"
+      version = "2.2.0"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/projects/alertmanager-staging/main.tf
+++ b/terraform/projects/alertmanager-staging/main.tf
@@ -31,12 +31,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.45"
-  region  = var.aws_region
-}
-
-provider "template" {
-  version = "~> 2.1"
+  region = var.aws_region
 }
 
 provider "pass" {

--- a/terraform/projects/alertmanager-staging/versions.tf
+++ b/terraform/projects/alertmanager-staging/versions.tf
@@ -1,13 +1,16 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = "2.70"
     }
     pass = {
-      source = "camptocamp/pass"
+      source  = "camptocamp/pass"
+      version = "1.4.0"
     }
     template = {
-      source = "hashicorp/template"
+      source  = "hashicorp/template"
+      version = "2.70"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/projects/app-ecs-albs-production/main.tf
+++ b/terraform/projects/app-ecs-albs-production/main.tf
@@ -11,8 +11,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.45"
-  region  = var.aws_region
+  region = var.aws_region
 }
 
 variable "aws_region" {

--- a/terraform/projects/app-ecs-albs-production/versions.tf
+++ b/terraform/projects/app-ecs-albs-production/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = "2.70"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/projects/app-ecs-albs-staging/main.tf
+++ b/terraform/projects/app-ecs-albs-staging/main.tf
@@ -11,8 +11,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.45"
-  region  = var.aws_region
+  region = var.aws_region
 }
 
 variable "aws_region" {

--- a/terraform/projects/app-ecs-albs-staging/versions.tf
+++ b/terraform/projects/app-ecs-albs-staging/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = "2.70"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/projects/infra-networking-production/main.tf
+++ b/terraform/projects/infra-networking-production/main.tf
@@ -9,8 +9,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.45"
-  region  = var.aws_region
+  region = var.aws_region
 }
 
 variable "prometheus_subdomain" {

--- a/terraform/projects/infra-networking-production/versions.tf
+++ b/terraform/projects/infra-networking-production/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = "2.70"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/projects/infra-networking-staging/main.tf
+++ b/terraform/projects/infra-networking-staging/main.tf
@@ -9,8 +9,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.45"
-  region  = var.aws_region
+  region = var.aws_region
 }
 
 variable "aws_region" {

--- a/terraform/projects/infra-networking-staging/versions.tf
+++ b/terraform/projects/infra-networking-staging/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = "2.70"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/projects/infra-security-groups-production/main.tf
+++ b/terraform/projects/infra-security-groups-production/main.tf
@@ -9,8 +9,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.45"
-  region  = var.aws_region
+  region = var.aws_region
 }
 
 variable "aws_region" {

--- a/terraform/projects/infra-security-groups-production/versions.tf
+++ b/terraform/projects/infra-security-groups-production/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = "2.70"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/projects/infra-security-groups-staging/main.tf
+++ b/terraform/projects/infra-security-groups-staging/main.tf
@@ -9,8 +9,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.45"
-  region  = var.aws_region
+  region = var.aws_region
 }
 
 variable "aws_region" {

--- a/terraform/projects/infra-security-groups-staging/versions.tf
+++ b/terraform/projects/infra-security-groups-staging/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = "2.70"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/projects/prom-ec2/paas-production/main.tf
+++ b/terraform/projects/prom-ec2/paas-production/main.tf
@@ -15,8 +15,6 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.45"
-
   region              = "eu-west-1"
   allowed_account_ids = ["455214962221"]
 }

--- a/terraform/projects/prom-ec2/paas-production/versions.tf
+++ b/terraform/projects/prom-ec2/paas-production/versions.tf
@@ -1,10 +1,12 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = "2.70"
     }
     pass = {
-      source = "camptocamp/pass"
+      source  = "camptocamp/pass"
+      version = "1.4.0"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/projects/prom-ec2/paas-staging/main.tf
+++ b/terraform/projects/prom-ec2/paas-staging/main.tf
@@ -15,8 +15,6 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.45"
-
   region              = "eu-west-1"
   allowed_account_ids = ["027317422673"]
 }

--- a/terraform/projects/prom-ec2/paas-staging/versions.tf
+++ b/terraform/projects/prom-ec2/paas-staging/versions.tf
@@ -1,10 +1,12 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = "2.70"
     }
     pass = {
-      source = "camptocamp/pass"
+      source  = "camptocamp/pass"
+      version = "1.4.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
This failed with:

    There are some problems with the configuration, described below.

    The Terraform configuration must be valid before initialization so that
    Terraform can determine which modules and providers need to be installed.

    Error: Invalid version constraint

    on versions.tf line 3, in terraform:
    3: aws = {
    4: source = "hashicorp/aws"
    5: }

    A string value is required for aws.

I'm not sure what's going on here but I *think* that a `version` is
required at the top-level module (but not at modules included from
elsewhere?).