### PR TITLE
Actually fix terraform 0.13

### DIFF
--- a/ci/images/task/Dockerfile
+++ b/ci/images/task/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ENV TF_VERSION 0.12.19
+ENV TF_VERSION 0.13.3
 
 LABEL ubuntu="20.04"
 LABEL terraform="$TF_VERSION"


### PR DESCRIPTION
So yeah in #442 I was wrong about what the error message meant.  What
was actually happening was that CI was trying to run terraform 0.12
binaries with 0.13 code and it got confused.

This should fix that.