### PR TITLE
Update SHA256 for terraform download

### DIFF
--- a/ci/images/task/Dockerfile
+++ b/ci/images/task/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:20.04
 
 ENV TF_VERSION 0.13.3
+ENV TF_ZIP_SHA256 35c662be9d32d38815cde5fa4c9fa61a3b7f39952ecd50ebf92fd1b2ddd6109b
 
 LABEL ubuntu="20.04"
 LABEL terraform="$TF_VERSION"
@@ -24,7 +25,7 @@ RUN apt-get update  --yes && \
 WORKDIR /tmp
 
 RUN curl https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip > terraform.zip && \
-	echo 'a549486112f5350075fb540cfd873deb970a9baf8a028a86ee7b4472fc91e167  terraform.zip'  > terraform.sha && \
+	echo "${TF_ZIP_SHA256}  terraform.zip"  > terraform.sha && \
 	sha256sum -c terraform.sha && unzip terraform.zip && mv terraform /usr/bin/terraform                    && \
 	rm terraform.zip && rm terraform.sha
 


### PR DESCRIPTION
This Dockerfile kept the terraform version quite far away from the
validating hash.  I've pulled the hash to live next to the version so
that people might actually know/remember to update both.