### PR TITLE
Add link to grafana for notify disk space alerts

### DIFF
--- a/terraform/modules/prom-ec2/alerts-config/alerts/notify-alerts.yml
+++ b/terraform/modules/prom-ec2/alerts-config/alerts/notify-alerts.yml
@@ -8,5 +8,5 @@ groups:
         product: "notify"
         severity: "ticket"
     annotations:
-        summary: "{{ $labels.space }}: disk usage for {{ $labels.app }} is over 75% full"
-        message: "{{ $labels.app }} needs to be re-deployed to avoid running out of disk space"
+        message: "{{ $labels.space }}: disk usage for {{ $labels.app }} is over 75% full. You should redeploy the app to avoid running out of disk space"
+        grafana: "https://grafana-paas.cloudapps.digital/d/_GlGBNbmk/notify-apps?orgId=2&var-space=production&var-app={{ $labels.app }}"


### PR DESCRIPTION
Adds an easy link to go look at grafana

Also move the summary and message into a single annotation as there is
no readability benefit in the zendesk ticket of having them as separate
things