### PR TITLE
Add notify alert for disk space 95% full

### DIFF
--- a/terraform/modules/alertmanager/alertmanager-service.tf
+++ b/terraform/modules/alertmanager/alertmanager-service.tf
@@ -161,6 +161,10 @@ data "pass_password" "notify_zendesk" {
   path = "receivers/notify/zendesk"
 }
 
+data "pass_password" "notify_p2_pagerduty_key" {
+  path = "receivers/notify/p2_pagerduty"
+}
+
 data "pass_password" "autom8_email" {
   path = "receivers/autom8/email"
 
@@ -199,6 +203,7 @@ data "template_file" "alertmanager_config_file" {
     slack_api_url           = data.pass_password.slack_api_url.password
     registers_zendesk       = data.pass_password.registers_zendesk.password
     notify_zendesk          = data.pass_password.notify_zendesk.password
+    notify_p2_pagerduty_key = data.pass_password.notify_p2_pagerduty_key.password
     smtp_from               = "alerts@${data.terraform_remote_state.infra_networking.outputs.public_subdomain}"
     # Port as requested by https://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-connect.html
     smtp_smarthost              = "email-smtp.${var.aws_region}.amazonaws.com:587"

--- a/terraform/modules/alertmanager/templates/alertmanager.tpl
+++ b/terraform/modules/alertmanager/templates/alertmanager.tpl
@@ -27,6 +27,11 @@ route:
     match:
       product: "notify"
       severity: "ticket"
+  - receiver: "notify-p2"
+    repeat_interval: 7d
+    match:
+      product: "notify"
+      severity: "p2"
   - receiver: "dgu-pagerduty"
     match:
       product: "data-gov-uk"
@@ -127,6 +132,9 @@ receivers:
 - name: "notify-tickets"
   email_configs:
   - to: "${notify_zendesk}"
+- name: "notify-p2"
+  pagerduty_configs:
+    - service_key: "${notify_p2_pagerduty_key}"
 - name: "observe-cronitor"
   webhook_configs:
   - send_resolved: false

--- a/terraform/modules/prom-ec2/alerts-config/alerts/notify-alerts.yml
+++ b/terraform/modules/prom-ec2/alerts-config/alerts/notify-alerts.yml
@@ -11,7 +11,7 @@ groups:
         message: "{{ $labels.space }}: disk usage for {{ $labels.app }} is over 75% full. You should redeploy the app to avoid running out of disk space"
         grafana: "https://grafana-paas.cloudapps.digital/d/_GlGBNbmk/notify-apps?orgId=2&var-space=production&var-app={{ $labels.app }}"
   - alert: GOVUK_Notify_Disk_95_percent_full
-    expr: max(disk_utilization{space="production", organisation="govuk-notify"}) by (app, space) > 95
+    expr: max(disk_utilization{space="production", organisation="govuk-notify", app!~"(.*conduit.*)|(.*exporter)"}) by (app, space) > 95
     for: 5m
     labels:
         product: "notify"

--- a/terraform/modules/prom-ec2/alerts-config/alerts/notify-alerts.yml
+++ b/terraform/modules/prom-ec2/alerts-config/alerts/notify-alerts.yml
@@ -15,7 +15,7 @@ groups:
     for: 5m
     labels:
         product: "notify"
-        severity: "page"
+        severity: "p2"
     annotations:
         summary: "{{ $labels.space }}: disk usage for {{ $labels.app }} is over 95% full. You should redeploy the app to avoid running out of disk space"
         grafana: "https://grafana-paas.cloudapps.digital/d/_GlGBNbmk/notify-apps?orgId=2&var-space=production&var-app={{ $labels.app }}"

--- a/terraform/modules/prom-ec2/alerts-config/alerts/notify-alerts.yml
+++ b/terraform/modules/prom-ec2/alerts-config/alerts/notify-alerts.yml
@@ -10,3 +10,12 @@ groups:
     annotations:
         message: "{{ $labels.space }}: disk usage for {{ $labels.app }} is over 75% full. You should redeploy the app to avoid running out of disk space"
         grafana: "https://grafana-paas.cloudapps.digital/d/_GlGBNbmk/notify-apps?orgId=2&var-space=production&var-app={{ $labels.app }}"
+  - alert: GOVUK_Notify_Disk_95_percent_full
+    expr: max(disk_utilization{space="production", organisation="govuk-notify"}) by (app, space) > 95
+    for: 5m
+    labels:
+        product: "notify"
+        severity: "page"
+    annotations:
+        summary: "{{ $labels.space }}: disk usage for {{ $labels.app }} is over 95% full"
+        message: "{{ $labels.app }} needs to be urgently re-deployed to avoid running out of disk space"

--- a/terraform/modules/prom-ec2/alerts-config/alerts/notify-alerts.yml
+++ b/terraform/modules/prom-ec2/alerts-config/alerts/notify-alerts.yml
@@ -17,5 +17,5 @@ groups:
         product: "notify"
         severity: "page"
     annotations:
-        summary: "{{ $labels.space }}: disk usage for {{ $labels.app }} is over 95% full"
-        message: "{{ $labels.app }} needs to be urgently re-deployed to avoid running out of disk space"
+        summary: "{{ $labels.space }}: disk usage for {{ $labels.app }} is over 95% full. You should redeploy the app to avoid running out of disk space"
+        grafana: "https://grafana-paas.cloudapps.digital/d/_GlGBNbmk/notify-apps?orgId=2&var-space=production&var-app={{ $labels.app }}"


### PR DESCRIPTION
This alert should page Notify's pagerduty, as it means disk space for a production app will run out shortly.

We also have a Zendesk ticket level alert for disk space being
75% full should. In most cases we should be able to react to that
less urgent alert in time. This will prevent this pagerduty fallback
alert from being set off.

Pagerduty alert is in case disk space fills up before we see the
Zendesk ticket.

Note, we see invididual commit messages for why we decided this is a p2 pagerduty rather than a p1.

Will require our pagerduty p2 service key being added to the autom8 password store for this to be merged.