### PR TITLE
Upgrade aws provider for most modules to v3

### DIFF
--- a/terraform/modules/prom-ec2/paas-config/variables.tf
+++ b/terraform/modules/prom-ec2/paas-config/variables.tf
@@ -2,7 +2,6 @@ variable "environment" {}
 variable "prometheus_config_bucket" {}
 variable "alerts_path" {}
 variable "private_zone_id" {}
-variable "private_subdomain" {}
 
 variable "prom_private_ips" {
   type = list(string)

--- a/terraform/projects/app-ecs-albs-production/versions.tf
+++ b/terraform/projects/app-ecs-albs-production/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "2.70"
+      version = "3.15"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/projects/app-ecs-albs-staging/versions.tf
+++ b/terraform/projects/app-ecs-albs-staging/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "2.70"
+      version = "3.15"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/projects/infra-networking-production/versions.tf
+++ b/terraform/projects/infra-networking-production/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "2.70"
+      version = "3.15"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/projects/infra-networking-staging/versions.tf
+++ b/terraform/projects/infra-networking-staging/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "2.70"
+      version = "3.15"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/projects/infra-security-groups-production/versions.tf
+++ b/terraform/projects/infra-security-groups-production/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "2.70"
+      version = "3.15"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/projects/infra-security-groups-staging/versions.tf
+++ b/terraform/projects/infra-security-groups-staging/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "2.70"
+      version = "3.15"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/projects/prom-ec2/paas-production/main.tf
+++ b/terraform/projects/prom-ec2/paas-production/main.tf
@@ -101,9 +101,8 @@ module "paas-config" {
   prometheus_config_bucket = module.prometheus.s3_config_bucket
   alerts_path              = "../../../modules/prom-ec2/alerts-config/alerts/"
 
-  prom_private_ips  = module.prometheus.private_ip_addresses
-  private_zone_id   = data.terraform_remote_state.infra_networking.outputs.private_zone_id
-  private_subdomain = data.terraform_remote_state.infra_networking.outputs.private_subdomain
+  prom_private_ips = module.prometheus.private_ip_addresses
+  private_zone_id  = data.terraform_remote_state.infra_networking.outputs.private_zone_id
 
   extra_scrape_configs = yamldecode(templatefile("${path.module}/extra-prometheus-scrape-configs.yml.tpl", {
     dm_elasticsearch_metrics_password = data.pass_password.dm_elasticsearch_metrics_password.password

--- a/terraform/projects/prom-ec2/paas-production/versions.tf
+++ b/terraform/projects/prom-ec2/paas-production/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "2.70"
+      version = "3.15"
     }
     pass = {
       source  = "camptocamp/pass"

--- a/terraform/projects/prom-ec2/paas-staging/main.tf
+++ b/terraform/projects/prom-ec2/paas-staging/main.tf
@@ -93,9 +93,8 @@ module "paas-config" {
   prometheus_config_bucket = module.prometheus.s3_config_bucket
   alerts_path              = "../../../modules/prom-ec2/alerts-config/alerts/"
 
-  prom_private_ips  = module.prometheus.private_ip_addresses
-  private_zone_id   = data.terraform_remote_state.infra_networking.outputs.private_zone_id
-  private_subdomain = data.terraform_remote_state.infra_networking.outputs.private_subdomain
+  prom_private_ips = module.prometheus.private_ip_addresses
+  private_zone_id  = data.terraform_remote_state.infra_networking.outputs.private_zone_id
 }
 
 output "instance_ids" {

--- a/terraform/projects/prom-ec2/paas-staging/versions.tf
+++ b/terraform/projects/prom-ec2/paas-staging/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "2.70"
+      version = "3.15"
     }
     pass = {
       source  = "camptocamp/pass"


### PR DESCRIPTION
This upgrades the AWS provider to v3.  There's a couple of nice things we get: notably `aws_route53_zone` now trims the trailing dot from the domain name so we don't have to.

Accompanying docs: [AWS provider v3 upgrade guide](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade).

This does all modules *except* for alertmanager.  Alertmanager will require some gardening:

 - when we update alertmanager, we'll want to remove the `trimsuffix` hacks on the subdomain, which will be easier after this terraform has been applied everywhere and the infra-networking statefile output has removed the trailing dot
 - SMTP creds have changed: [aws_iam_access_key.ses_smtp_password has been removed and replaced with ses_smtp_password_v4](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#resource-aws_iam_access_key), but [this requires a delete/recreate of the IAM User](https://github.com/hashicorp/terraform-provider-aws/issues/14529)

therefore, I'll do alertmanager in a separate PR.

