### PR TITLE
Example of custom alertmanager email template

### DIFF
--- a/terraform/modules/alertmanager/templates/alertmanager.tpl
+++ b/terraform/modules/alertmanager/templates/alertmanager.tpl
@@ -128,7 +128,7 @@ receivers:
 - name: "notify-tickets"
   email_configs:
   - to: "${notify_zendesk}"
-  - html: '{{ template "zendesk.notify.html" . }}'
+  - html: '{{ template "zendesk.notify.text" . }}'
 - name: "observe-cronitor"
   webhook_configs:
   - send_resolved: false

--- a/terraform/modules/alertmanager/templates/alertmanager.tpl
+++ b/terraform/modules/alertmanager/templates/alertmanager.tpl
@@ -9,6 +9,7 @@ global:
 
 templates:
 - '/etc/alertmanager/default.tmpl'
+- '/etc/alertmanager/notify.tmpl'
 
 route:
   receiver: "re-observe-pagerduty"
@@ -127,6 +128,7 @@ receivers:
 - name: "notify-tickets"
   email_configs:
   - to: "${notify_zendesk}"
+  - html: '{{ template "zendesk.notify.html" . }}'
 - name: "observe-cronitor"
   webhook_configs:
   - send_resolved: false

--- a/terraform/modules/alertmanager/templates/notify.tmpl
+++ b/terraform/modules/alertmanager/templates/notify.tmpl
@@ -1,4 +1,4 @@
-{{ define "zendesk.notify.html" }}
+{{ define "zendesk.notify.text" }}
 
 {{ .Alerts | len }} alert{{ if gt (len .Alerts) 1 }}s{{ end }} for {{ range .GroupLabels.SortedPairs }}
 {{ .Name }}={{ .Value }} 

--- a/terraform/modules/alertmanager/templates/notify.tmpl
+++ b/terraform/modules/alertmanager/templates/notify.tmpl
@@ -1,0 +1,18 @@
+{{ define "zendesk.notify.html" }}
+
+{{ .Alerts | len }} alert{{ if gt (len .Alerts) 1 }}s{{ end }} for {{ range .GroupLabels.SortedPairs }}
+{{ .Name }}={{ .Value }} 
+{{ end }}
+
+[{{ .Alerts.Firing | len }}] Firing
+
+{{ range .Alerts.Firing }}
+Labels
+{{ range .Labels.SortedPairs }}{{ .Name }} = {{ .Value }}<br />{{ end }}
+{{ if gt (len .Annotations) 0 }}<strong>Annotations</strong><br />{{ end }}
+{{ range .Annotations.SortedPairs }}{{ .Name }} = {{ .Value }}<br />{{ end }}
+Source - {{ .GeneratorURL }}
+{{ end }}
+
+Sent by {{ template "__alertmanager" . }} - {{ .ExternalURL }}
+{{ end }}


### PR DESCRIPTION
This is what it would look like to do custom email templates to zendesk. It would mean zendesk alerts could look much prettier and only contain labels that teams need if they want to define their own templates.

Note, I haven't tested it and I haven't checked to see what the email would actually end up looking like but could put some time into this if need be.

Note, for zendesk, I believe all the html gets stripped and all we are left with is the the text so the approach would be to go for almost purely text based alerts rather than html.

Currently alerts look like:
![image](https://user-images.githubusercontent.com/7228605/99685774-db62e400-2a7a-11eb-8a0b-bec6a459e012.png)


For further reading/context

https://prometheus.io/docs/alerting/latest/configuration/#email_config
https://prometheus.io/blog/2016/03/03/custom-alertmanager-templates/
https://github.com/prometheus/alertmanager/blob/master/template/email.html

Problem that would need solving is how to get the custom templates files on to the alertmanager instance. At the moment it looks like this is being done using the ECS task entrypoint (https://github.com/alphagov/prometheus-aws-configuration-beta/blob/master/terraform/modules/alertmanager/task-definitions/alertmanager.json#L30) but might want to go for the approach being done for prometheus of putting the files in an s3 bucket