### PR TITLE
add digital marketplace redis metrics config

### DIFF
--- a/terraform/projects/prom-ec2/paas-production/extra-prometheus-scrape-configs.yml.tpl
+++ b/terraform/projects/prom-ec2/paas-production/extra-prometheus-scrape-configs.yml.tpl
@@ -176,4 +176,4 @@
     source_labels: [__name__]
     target_label: __name__
     regex: (.*)
-    replacement: paas_redis_${1}
+    replacement: paas_redis_$${1}

--- a/terraform/projects/prom-ec2/paas-production/extra-prometheus-scrape-configs.yml.tpl
+++ b/terraform/projects/prom-ec2/paas-production/extra-prometheus-scrape-configs.yml.tpl
@@ -158,3 +158,22 @@
   # Drop the temporary label
   - regex: ^__store_this__$
     action: labeldrop
+- job_name: paas_redis_metrics_for_dm
+  scheme: https
+  basic_auth:
+    username: ${dm_paas_metrics_username}
+    password: ${dm_paas_metrics_password}
+  static_configs:
+  - targets:
+    - redis.metrics.cloud.service.gov.uk
+  metrics_path: /metrics
+  scrape_interval: 300s
+  scrape_timeout: 120s
+  honor_timestamps: true
+  metric_relabel_configs:
+  # Prepend `paas_redis_` so the metrics are easier to find
+  - action: replace
+    source_labels: [__name__]
+    target_label: __name__
+    regex: (.*)
+    replacement: paas_redis_${1}

--- a/terraform/projects/prom-ec2/paas-production/main.tf
+++ b/terraform/projects/prom-ec2/paas-production/main.tf
@@ -70,7 +70,7 @@ data "pass_password" "dm_paas_metrics_username" {
   path = "dm-paas-metrics-username"
 }
 
-data "pass_password" "dm_paas_metrics_password " {
+data "pass_password" "dm_paas_metrics_password" {
   path = "dm-paas-metrics-password"
 }
 

--- a/terraform/projects/prom-ec2/paas-production/main.tf
+++ b/terraform/projects/prom-ec2/paas-production/main.tf
@@ -114,6 +114,8 @@ module "paas-config" {
 
   extra_scrape_configs = yamldecode(templatefile("${path.module}/extra-prometheus-scrape-configs.yml.tpl", {
     dm_elasticsearch_metrics_password = data.pass_password.dm_elasticsearch_metrics_password.password
+    dm_paas_metrics_username          = data.pass_password.dm_paas_metrics_username.password
+    dm_paas_metrics_password          = data.pass_password.dm_paas_metrics_password.password
   }))
 }
 

--- a/terraform/projects/prom-ec2/paas-production/main.tf
+++ b/terraform/projects/prom-ec2/paas-production/main.tf
@@ -66,6 +66,14 @@ data "pass_password" "dm_elasticsearch_metrics_password" {
   path = "dm-elasticsearch-metrics-password"
 }
 
+data "pass_password" "dm_paas_metrics_username" {
+  path = "dm-paas-metrics-username"
+}
+
+data "pass_password" "dm_paas_metrics_password " {
+  path = "dm-paas-metrics-password"
+}
+
 module "ami" {
   source = "../../../modules/common/ami"
 }


### PR DESCRIPTION
_Please be gentle as I am unable to test this myself._ 

Attempted to follow steps in https://github.com/alphagov/paas-prometheus-endpoints/tree/main/src/redis#setup adding of credentials performed by @szd55gds in https://github.com/alphagov/re-secrets/pull/56 note, I was told the convention in the repository is to use hyphens in the credential filenames but our existing credential uses underscore so I am not sure if this is correct/will work.

CC paas peeps who have helped me with this @46bit @AP-Hunt @schmie

For @alphagov/digitalmarketplace this is ref: https://trello.com/c/vaR0HCCx/585-implement-redis-metrics-on-graphana

