### PR TITLE
Add alerts for GOV.UK Accounts

### DIFF
--- a/terraform/modules/alertmanager/templates/alertmanager.tpl
+++ b/terraform/modules/alertmanager/templates/alertmanager.tpl
@@ -35,6 +35,9 @@ route:
   - receiver: "dgu-pagerduty"
     match:
       product: "data-gov-uk"
+  - receiver: "govuk-pagerduty"
+    match:
+      product: "govuk-accounts"
   - receiver: "registers-zendesk"
     repeat_interval: 7d
     match:

--- a/terraform/modules/prom-ec2/alerts-config/govuk-accounts-alerts.yml
+++ b/terraform/modules/prom-ec2/alerts-config/govuk-accounts-alerts.yml
@@ -1,0 +1,21 @@
+groups:
+- name: GovukAccounts
+  rules:
+  - alert: GovukAccounts_AppRequestsExcess5xx
+    expr: sum without(exported_instance, status_range) (rate(requests{org="govuk-accounts", space="production", status_range="5xx"}[5m])) / sum without(exported_instance, status_range) (rate(requests{org="govuk-accounts", space="production"}[5m])) >= 0.25
+    for: 120s
+    labels:
+        product: "govuk-accounts"
+    annotations:
+        summary: "App {{ $labels.app }} has too many 5xx errors"
+        message: "App {{ $labels.app }} has 5xx errors in excess of 25% of total requests"
+        dashboard_orj: https://grafana-paas.cloudapps.digital/d/_g_9aRoMk/gov-uk-accounts?orgId=1&refresh=30s
+  - alert: GovukAccounts_90thQuartileResponseTimeExceeds500ms
+    expr: histogram_quantile(0.90, sum by (le) (rate(response_time_bucket{organisation="govuk-accounts",space="production"}[5m]))) > 0.5
+    for: 120s
+    labels:
+        product: "govuk-accounts"
+    annotations:
+        summary: "App {{ $labels.app }}'s 90th quartile response time too high"
+        message: "App {{ $labels.app }}'s 90th quartile response time is higher than 500ms"
+        dashboard_orj: https://grafana-paas.cloudapps.digital/d/_g_9aRoMk/gov-uk-accounts?orgId=1&refresh=30s

--- a/terraform/modules/prom-ec2/paas-config/main.tf
+++ b/terraform/modules/prom-ec2/paas-config/main.tf
@@ -45,6 +45,13 @@ resource "aws_s3_bucket_object" "alerts-data-gov-uk-config" {
   etag   = filemd5("${var.alerts_path}data-gov-uk-alerts.yml")
 }
 
+resource "aws_s3_bucket_object" "alerts-gov-uk-accounts-config" {
+  bucket = var.prometheus_config_bucket
+  key    = "prometheus/alerts/gov-uk-accounts-alerts.yml"
+  source = "${var.alerts_path}gov-uk-accounts-alerts.yml"
+  etag   = filemd5("${var.alerts_path}gov-uk-accounts-alerts.yml")
+}
+
 resource "aws_s3_bucket_object" "alerts-notify-config" {
   bucket = var.prometheus_config_bucket
   key    = "prometheus/alerts/notify-alerts.yml"


### PR DESCRIPTION
These alerts will trigger when either the 5xx rate is over 25% or the 90th quartile response time is over 500ms.

Triggering these alerts will result in an alert on the GOV.UK PagerDuty.

Trello card: https://trello.com/c/UreaVlZA