### PR TITLE
Add initial configuration for DCS on the PaaS

### DIFF
--- a/terraform/modules/alertmanager/templates/alertmanager.tpl
+++ b/terraform/modules/alertmanager/templates/alertmanager.tpl
@@ -56,6 +56,9 @@ route:
     match:
       layer: "infra"
       severity: "ticket"
+  - receiver: "dev-null"
+    match:
+      product: "doc-checking"
   # GSP clusters
   - match_re:
       clustername: london[.].*[.]govsvc[.]uk

--- a/terraform/modules/prom-ec2/alerts-config/alerts/doc-checking-alerts.yml
+++ b/terraform/modules/prom-ec2/alerts-config/alerts/doc-checking-alerts.yml
@@ -1,0 +1,53 @@
+groups:
+  - name: DocChecking
+    rules:
+    - alert: AuditEventsNotProcessing
+      annotations:
+        message: >-
+          The audit consumer should be writing audit events to the
+          database. This hasn't happened in a while.
+        runbook_url: https://dcs-service-manual.cloudapps.digital/supporting-dcs/responding-to-alerts/AuditEventsNotProcessing/
+      expr: |
+          sum without(instance) (rate(audit_consumer_events_processing_attempts_total[5m]))
+          -
+          sum without(instance) (rate(audit_consumer_events_processing_failures_total[5m]))
+          == 0
+      for: 10m
+      labels:
+        product: doc-checking
+        severity: p4
+    - alert: AuditEventsFailedProcessing
+      annotations:
+        message: >-
+          The audit consumer has a high error rate when attempting to
+          write audit events to the database.  Those events may have
+          ended up on the dead letter queue.
+        runbook_url: https://dcs-service-manual.cloudapps.digital/supporting-dcs/responding-to-alerts/AuditEventsFailedProcessing/
+      expr: |
+        sum without(instance) (rate(audit_consumer_events_processing_failures_total[2m])) > 3
+      for: 5m
+      labels:
+        product: doc-checking
+        severity: p4
+    - alert: AuditEventsOnTheDeadLetterQueue
+      annotations:
+        message: |
+          There are unprocessed audit events on the dead letter queue.
+        runbook_url: https://dcs-service-manual.cloudapps.digital/supporting-dcs/responding-to-alerts/AuditEventsOnTheDeadLetterQueue/
+      expr: |
+            max without(instance) (audit_consumer_dead_letter_queue_approximate_messages) > 0
+      for: 5m
+      labels:
+        product: doc-checking
+        severity: p4
+    - alert: RedisNotAvailable
+      annotations:
+        message: |
+          Redis is not available for rate limiting and quota.
+        runbook_url: https://dcs-service-manual.cloudapps.digital/supporting-dcs/responding-to-alerts/RedisNotAvailable/
+      expr: |
+        (avg by (job) (dcs_dmz_proxy_using_redis_for_rate_limiting) != 1) or (avg by (job) (dcs_agents_using_redis_for_rate_limiting) != 1)
+      for: 5m
+      labels:
+        product: doc-checking
+        severity: p2

--- a/terraform/modules/prom-ec2/paas-config/main.tf
+++ b/terraform/modules/prom-ec2/paas-config/main.tf
@@ -45,6 +45,13 @@ resource "aws_s3_bucket_object" "alerts-data-gov-uk-config" {
   etag   = filemd5("${var.alerts_path}data-gov-uk-alerts.yml")
 }
 
+resource "aws_s3_bucket_object" "alerts-doc-checking-config" {
+  bucket = var.prometheus_config_bucket
+  key    = "prometheus/alerts/doc-checking-alerts.yml"
+  source = "${var.alerts_path}doc-checking-alerts.yml"
+  etag   = filemd5("${var.alerts_path}doc-checking-alerts.yml")
+}
+
 resource "aws_s3_bucket_object" "alerts-govuk-accounts-config" {
   bucket = var.prometheus_config_bucket
   key    = "prometheus/alerts/govuk-accounts-alerts.yml"


### PR DESCRIPTION
This commit adds the Prometheus alerts configuration, as well as some
minimal alertmanager config which should avoid any premature pages for
people.

Once the alerts are in place, I'll setup some proper routing.