### PR TITLE
Do not trigger accounts 5xx alert from the error app

### DIFF
--- a/terraform/modules/prom-ec2/alerts-config/alerts/govuk-accounts-alerts.yml
+++ b/terraform/modules/prom-ec2/alerts-config/alerts/govuk-accounts-alerts.yml
@@ -2,7 +2,7 @@ groups:
 - name: GovukAccounts
   rules:
   - alert: GovukAccounts_AppRequestsExcess5xx
-    expr: sum without(exported_instance, status_range) (rate(requests{org="govuk-accounts", space="production", status_range="5xx"}[5m])) / sum without(exported_instance, status_range) (rate(requests{org="govuk-accounts", space="production"}[5m])) >= 0.25
+    expr: sum without(exported_instance, status_range) (rate(requests{org="govuk-accounts", space="production", status_range="5xx", app!="govuk-account-static-errors"}[5m])) / sum without(exported_instance, status_range) (rate(requests{org="govuk-accounts", space="production"}[5m])) >= 0.25
     for: 120s
     labels:
         product: "govuk-accounts"


### PR DESCRIPTION
This is an nginx-buildpack app put up if we need to take the normal accounts system down, and always returns a 503 error.