### PR TITLE
observe alerts: add a low-severity alert for a single prometheus being down

### DIFF
--- a/terraform/modules/prom-ec2/alerts-config/alerts/observe-alerts.yml
+++ b/terraform/modules/prom-ec2/alerts-config/alerts/observe-alerts.yml
@@ -20,7 +20,7 @@ groups:
         product: "prometheus"
         severity: "page"
     annotations:
-        summary: "There is one or less Alertmanagers that can be scraped"
+        summary: "There is one or fewer Alertmanagers that can be scraped"
         runbook: "https://re-team-manual.cloudapps.digital/prometheus-for-gds-paas-users.html#re-observe-alertmanager-below-threshold"
 
   - alert: RE_Observe_Prometheus_Below_Threshold
@@ -30,7 +30,7 @@ groups:
         product: "prometheus"
         severity: "page"
     annotations:
-        summary: "There is one or less Prometheis that can be scraped"
+        summary: "There is one or fewer Prometheis that can be scraped"
         logs: "https://kibana.logit.io/s/8fd50110-7b0c-490a-bedf-7544daebbec4/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),index:'*-*',interval:auto,query:(query_string:(query:'tags:%20prometheus')),sort:!('@timestamp',desc))"
         runbook: "https://re-team-manual.cloudapps.digital/prometheus-for-gds-paas-users.html#re-observe-prometheus-below-threshold"
 

--- a/terraform/modules/prom-ec2/alerts-config/alerts/observe-alerts.yml
+++ b/terraform/modules/prom-ec2/alerts-config/alerts/observe-alerts.yml
@@ -34,6 +34,17 @@ groups:
         logs: "https://kibana.logit.io/s/8fd50110-7b0c-490a-bedf-7544daebbec4/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),index:'*-*',interval:auto,query:(query_string:(query:'tags:%20prometheus')),sort:!('@timestamp',desc))"
         runbook: "https://re-team-manual.cloudapps.digital/prometheus-for-gds-paas-users.html#re-observe-prometheus-below-threshold"
 
+  - alert: RE_Observe_Prometheus_AtLeastOneMissing
+    expr: sum(up{job="prometheus"}) < 3
+    for: 3m
+    labels:
+        product: "prometheus"
+        severity: "ticket"
+    annotations:
+        summary: "At least one Prometheus can't be scraped"
+        logs: "https://kibana.logit.io/s/8fd50110-7b0c-490a-bedf-7544daebbec4/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),index:'*-*',interval:auto,query:(query_string:(query:'tags:%20prometheus')),sort:!('@timestamp',desc))"
+        runbook: "https://re-team-manual.cloudapps.digital/prometheus-for-gds-paas-users.html#re-observe-prometheus-at-least-one-missing"
+
   - alert: RE_Observe_PrometheusDiskPredictedToFill
     expr: |
       predict_linear(


### PR DESCRIPTION
https://trello.com/c/H5pjav8d

Set it at 3 minutes so it hopefully (?) won't get triggered by the temporary downtime coming from a release. Should I go even further I wonder?