### PR TITLE
add /last-config endpoint to prometheus nodes 

### DIFF
--- a/terraform/modules/prom-ec2/paas-config/outputs.tf
+++ b/terraform/modules/prom-ec2/paas-config/outputs.tf
@@ -1,0 +1,3 @@
+output "prometheus_config_etag" {
+  value = aws_s3_bucket_object.prometheus_config.etag
+}

--- a/terraform/modules/prom-ec2/prometheus/cloud.conf
+++ b/terraform/modules/prom-ec2/prometheus/cloud.conf
@@ -1,7 +1,7 @@
 #cloud-config
 package_update: true
 package_upgrade: true
-packages: ['prometheus', 'prometheus-node-exporter', 'awscli', 'inotify-tools', 'nginx']
+packages: ['prometheus', 'prometheus-node-exporter', 'awscli', 'inotify-tools', 'nginx', 'jq']
 
 write_files:
   - owner: root:root
@@ -12,7 +12,7 @@ write_files:
     path: /etc/cron.d/config_pull
     permissions: 0755
     content: |
-        * * * * * root aws s3 sync s3://${config_bucket}/prometheus/ /etc/prometheus/ --region=${region}
+        * * * * * root flock -w 30 /run/lock/prometheus-config-updates aws s3 sync s3://${config_bucket}/prometheus/ /etc/prometheus/ --region=${region}
         @reboot root /root/watch_prometheus_dir
   - owner: root:root
     path: /etc/cron.d/ireland_targets_pull
@@ -67,9 +67,32 @@ write_files:
     permissions: 0755
   - content: |
        #!/bin/bash
+       STATUS_JSON='/srv/prometheus-last-config.json'
+
+       attempt_reload() {
+         (
+           # take out lock to ensure updater doesn't switch the config between the time we
+           # calculate NEW_HASH and prometheus reads it
+           flock 321
+
+           # why md5? because it should be the same as the s3 etag and so easy to check
+           export NEW_HASH=$(md5sum /etc/prometheus/prometheus.yml | cut -d ' ' -f 1)
+           if systemctl reload prometheus ; then
+             jq -n '{last_successful_config: env.NEW_HASH, last_reload_successful: true}' > $STATUS_JSON
+           else
+             touch $STATUS_JSON
+             jq '{last_successful_config: .last_successful_config, last_reload_successful: false, failed_config: env.NEW_HASH}' $STATUS_JSON > $STATUS_JSON
+           fi
+
+         ) 321>/run/lock/prometheus-config-updates
+       }
+
+       systemctl start prometheus  # ensure prometheus is started before initial attempt_reload
+       attempt_reload
+
        inotifywait -e modify,create,delete,move -m -r /etc/prometheus |
        while read -r directory events; do
-         systemctl reload prometheus
+         attempt_reload
        done
     path: /root/watch_prometheus_dir
     permissions: 0755
@@ -126,6 +149,10 @@ write_files:
           # This location is not protected by basic auth because of
           # https://stackoverflow.com/questions/40447376/auth-basic-within-location-block-doesnt-work-when-return-is-specified
           return 200 "Static health check";
+        }
+
+        location = /last-config {
+          alias /srv/prometheus-last-config.json;
         }
 
         location / {

--- a/terraform/modules/prom-ec2/prometheus/cloud.conf
+++ b/terraform/modules/prom-ec2/prometheus/cloud.conf
@@ -90,7 +90,7 @@ write_files:
        systemctl start prometheus  # ensure prometheus is started before initial attempt_reload
        attempt_reload
 
-       inotifywait -e modify,create,delete,move -m -r /etc/prometheus |
+       inotifywait -e modify,create,delete,move -m /etc/prometheus |
        while read -r directory events; do
          attempt_reload
        done

--- a/terraform/projects/prom-ec2/paas-production/main.tf
+++ b/terraform/projects/prom-ec2/paas-production/main.tf
@@ -122,3 +122,7 @@ module "paas-config" {
 output "instance_ids" {
   value = "[\n    ${join("\n    ", module.prometheus.prometheus_instance_id)}\n]"
 }
+
+output "prometheus_config_etag" {
+  value = module.paas-config.prometheus_config_etag
+}

--- a/terraform/projects/prom-ec2/paas-staging/main.tf
+++ b/terraform/projects/prom-ec2/paas-staging/main.tf
@@ -100,3 +100,7 @@ module "paas-config" {
 output "instance_ids" {
   value = "[\n    ${join("\n    ", module.prometheus.prometheus_instance_id)}\n]"
 }
+
+output "prometheus_config_etag" {
+  value = module.paas-config.prometheus_config_etag
+}


### PR DESCRIPTION
https://trello.com/c/H5pjav8d

This should allow us to reliably tell when a new config has successfully been applied to the running prometheus, whether the machine needed to be restarted or not.

Monitoring `prometheus_config_last_reload_successful` and/or `prometheus_config_last_reload_success_timestamp_seconds` doesn't appear to be sufficient in our case as:

 - bad configs don't actually tend to get _seen_ by the running prometheus daemon as they get rejected early by the init script
 - they would always get tripped on a restart-requiring deployment, whether the desired config has made it out to the node or not.

Wrap the updates in a `flock` call to ensure we don't have a funny race condition involving the reading of the config file and I can cast the thought from my brain entirely. 30s acquisition timeout when used from the `s3 sync` end because we know another attempt will be along in a minute to try again. No timeout on the reload-loop end as we'll only get one notification per modification and can't afford to throw that away.

Considered making this a prometheus-metrics-formatted file so we could monitor it from prometheus, but that's harder to consume in a script (no `jq` equivalent). We could always spit out both formats if we decided we wanted that down the line.