### PR TITLE
ci http pings: add small sleep after failed ping

### DIFF
--- a/ci/tasks/http-ping.yml
+++ b/ci/tasks/http-ping.yml
@@ -30,6 +30,8 @@ run:
             cat curl_output
             echo 'Failed jq test:'
             cat response-jq-test/test.jq
+            # don't spin through attempts too fast
+            sleep 5
             exit 9
           fi
         fi


### PR DESCRIPTION
https://trello.com/c/H5pjav8d

Hopefully prevent us spinning through the attempts too quickly - it's either that or put the number of attempts up to something silly