### PR TITLE
ci smoke tests: rename previous tests "config tests", add actual smoke tests of prometheus

### DIFF
--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -233,27 +233,48 @@ jobs:
         input_mapping: {input: terraform-outputs}
         output_mapping: {output: prometheus-test-jq}
       - in_parallel:
-        - task: smoke-test-prom-1
-          attempts: 8
-          timeout: 2m
-          file: ci-git/ci/tasks/http-ping.yml
-          input_mapping: {response-jq-test: prometheus-test-jq}
-          params:
-            URL: https://prom-1.monitoring-staging.gds-reliability.engineering/last-config
-        - task: smoke-test-prom-2
-          attempts: 8
-          timeout: 2m
-          file: ci-git/ci/tasks/http-ping.yml
-          input_mapping: {response-jq-test: prometheus-test-jq}
-          params:
-            URL: https://prom-2.monitoring-staging.gds-reliability.engineering/last-config
-        - task: smoke-test-prom-3
-          attempts: 8
-          timeout: 2m
-          file: ci-git/ci/tasks/http-ping.yml
-          input_mapping: {response-jq-test: prometheus-test-jq}
-          params:
-            URL: https://prom-3.monitoring-staging.gds-reliability.engineering/last-config
+        - do:
+          - task: conf-test-prom-1
+            attempts: 8
+            timeout: 2m
+            file: ci-git/ci/tasks/http-ping.yml
+            input_mapping: {response-jq-test: prometheus-test-jq}
+            params:
+              URL: https://prom-1.monitoring-staging.gds-reliability.engineering/last-config
+          - task: smoke-test-prom-1
+            attempts: 4
+            timeout: 2m
+            file: ci-git/ci/tasks/http-ping.yml
+            params:
+              URL: https://prom-1.monitoring-staging.gds-reliability.engineering/-/ready
+        - do:
+          - task: conf-test-prom-2
+            attempts: 8
+            timeout: 2m
+            file: ci-git/ci/tasks/http-ping.yml
+            input_mapping: {response-jq-test: prometheus-test-jq}
+            params:
+              URL: https://prom-2.monitoring-staging.gds-reliability.engineering/last-config
+          - task: smoke-test-prom-2
+            attempts: 4
+            timeout: 2m
+            file: ci-git/ci/tasks/http-ping.yml
+            params:
+              URL: https://prom-2.monitoring-staging.gds-reliability.engineering/-/ready
+        - do:
+          - task: conf-test-prom-3
+            attempts: 8
+            timeout: 2m
+            file: ci-git/ci/tasks/http-ping.yml
+            input_mapping: {response-jq-test: prometheus-test-jq}
+            params:
+              URL: https://prom-3.monitoring-staging.gds-reliability.engineering/last-config
+          - task: smoke-test-prom-3
+            attempts: 4
+            timeout: 2m
+            file: ci-git/ci/tasks/http-ping.yml
+            params:
+              URL: https://prom-3.monitoring-staging.gds-reliability.engineering/-/ready
 
   - name: deploy-prometheus-production
     serial: true
@@ -290,27 +311,48 @@ jobs:
         input_mapping: {input: terraform-outputs}
         output_mapping: {output: prometheus-test-jq}
       - in_parallel:
-        - task: smoke-test-prom-1
-          attempts: 8
-          timeout: 2m
-          file: ci-git/ci/tasks/http-ping.yml
-          input_mapping: {response-jq-test: prometheus-test-jq}
-          params:
-            URL: https://prom-1.monitoring.gds-reliability.engineering/last-config
-        - task: smoke-test-prom-2
-          attempts: 8
-          timeout: 2m
-          file: ci-git/ci/tasks/http-ping.yml
-          input_mapping: {response-jq-test: prometheus-test-jq}
-          params:
-            URL: https://prom-2.monitoring.gds-reliability.engineering/last-config
-        - task: smoke-test-prom-3
-          attempts: 8
-          timeout: 2m
-          file: ci-git/ci/tasks/http-ping.yml
-          input_mapping: {response-jq-test: prometheus-test-jq}
-          params:
-            URL: https://prom-3.monitoring.gds-reliability.engineering/last-config
+        - do:
+          - task: conf-test-prom-1
+            attempts: 8
+            timeout: 2m
+            file: ci-git/ci/tasks/http-ping.yml
+            input_mapping: {response-jq-test: prometheus-test-jq}
+            params:
+              URL: https://prom-1.monitoring.gds-reliability.engineering/last-config
+          - task: smoke-test-prom-1
+            attempts: 4
+            timeout: 2m
+            file: ci-git/ci/tasks/http-ping.yml
+            params:
+              URL: https://prom-1.monitoring.gds-reliability.engineering/-/ready
+        - do:
+          - task: conf-test-prom-2
+            attempts: 8
+            timeout: 2m
+            file: ci-git/ci/tasks/http-ping.yml
+            input_mapping: {response-jq-test: prometheus-test-jq}
+            params:
+              URL: https://prom-2.monitoring.gds-reliability.engineering/last-config
+          - task: smoke-test-prom-2
+            attempts: 4
+            timeout: 2m
+            file: ci-git/ci/tasks/http-ping.yml
+            params:
+              URL: https://prom-2.monitoring.gds-reliability.engineering/-/ready
+        - do:
+          - task: conf-test-prom-3
+            attempts: 8
+            timeout: 2m
+            file: ci-git/ci/tasks/http-ping.yml
+            input_mapping: {response-jq-test: prometheus-test-jq}
+            params:
+              URL: https://prom-3.monitoring.gds-reliability.engineering/last-config
+          - task: smoke-test-prom-3
+            attempts: 4
+            timeout: 2m
+            file: ci-git/ci/tasks/http-ping.yml
+            params:
+              URL: https://prom-3.monitoring.gds-reliability.engineering/-/ready
 
   - name: deploy-alertmanager-staging
     serial: true


### PR DESCRIPTION
https://trello.com/c/H5pjav8d

Previous tests only tested nginx and the config replacement system was happy, we should also check prometheus is happily running before we continue.