### PR TITLE
BAU: remove references to GSP in alertmanager config

### DIFF
--- a/terraform/modules/alertmanager/templates/alertmanager.tpl
+++ b/terraform/modules/alertmanager/templates/alertmanager.tpl
@@ -94,7 +94,7 @@ route:
       receiver: "dev-null"
     - match_re:
         layer: ".+"
-      receiver: "autom8-gsp-alerts-slack"
+      receiver: "autom8-alerts-slack"
   # Verify hub ECS
   - receiver: "verify-2ndline-slack"
     match:
@@ -195,9 +195,9 @@ receivers:
     - type: button
       text: Runbook
       url: '{{ .CommonAnnotations.runbook_url }}'
-- name: "autom8-gsp-alerts-slack"
+- name: "autom8-alerts-slack"
   slack_configs:
-  - &gsp-slack-config
+  - &slack-config
     send_resolved: true
     channel: '#re-autom8-alerts'
     icon_emoji: ':gsp:'
@@ -239,12 +239,12 @@ receivers:
       url: '{{ .CommonAnnotations.runbook_url }}'
 - name: "eidas-slack"
   slack_configs:
-    - <<: *gsp-slack-config
+    - <<: *slack-config
       channel: '#verify-eidas-alerts'
 - name: "dcs-slack"
   slack_configs:
-    - <<: *gsp-slack-config
-      channel: '#verify-dcs-gsp-alerts'
+    - <<: *slack-config
+      channel: '#verify-dcs-alerts'
 - name: "dcs-p2"
   pagerduty_configs:
     - service_key: "${dcs_p2_pagerduty_key}"

--- a/terraform/modules/alertmanager/templates/alertmanager.tpl
+++ b/terraform/modules/alertmanager/templates/alertmanager.tpl
@@ -244,7 +244,7 @@ receivers:
 - name: "dcs-slack"
   slack_configs:
     - <<: *slack-config
-      channel: '#verify-dcs-alerts'
+      channel: '#di-dcs-2ndline'
 - name: "dcs-p2"
   pagerduty_configs:
     - service_key: "${dcs_p2_pagerduty_key}"


### PR DESCRIPTION
## What

Remove references to GSP in alertmanager config.

## Why

So that the verify-dcs-gsp-alerts can be renamed to di-dcs-2ndline now that DCS has moved to PaaS.