### PR TITLE
[#178898815] alertmanager deployment: wait for ecs service to be stable before proceeding

### DIFF
--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -344,10 +344,17 @@ jobs:
         timeout: 15m
         file: prometheus-aws-configuration-beta/ci/tasks/deploy-project.yml
         input_mapping: {src: prometheus-aws-configuration-beta}
+        output_mapping: {outputs: terraform-outputs}
         params:
           PROJECT: alertmanager-staging
           DEPLOYER_ARN: arn:aws:iam::027317422673:role/autom8-deployer
           GPG_PRIVATE_KEY: ((gpg_private_key))
+      - task: wait-ecs-services-stable
+        image: task-image
+        file: prometheus-aws-configuration-beta/ci/tasks/wait-ecs-services-stable.yml
+        params:
+          DEPLOYER_ARN: arn:aws:iam::027317422673:role/autom8-deployer
+          TERRAFORM_VAR: alertmanager_ecs_clusters_services
       - in_parallel:
         - task: smoke-test-alertmanager
           attempts: 4
@@ -392,10 +399,17 @@ jobs:
         timeout: 15m
         file: prometheus-aws-configuration-beta/ci/tasks/deploy-project.yml
         input_mapping: {src: prometheus-aws-configuration-beta}
+        output_mapping: {outputs: terraform-outputs}
         params:
           PROJECT: alertmanager-production
           DEPLOYER_ARN: arn:aws:iam::455214962221:role/autom8-deployer
           GPG_PRIVATE_KEY: ((gpg_private_key))
+      - task: wait-ecs-services-stable
+        image: task-image
+        file: prometheus-aws-configuration-beta/ci/tasks/wait-ecs-services-stable.yml
+        params:
+          DEPLOYER_ARN: arn:aws:iam::455214962221:role/autom8-deployer
+          TERRAFORM_VAR: alertmanager_ecs_clusters_services
       - in_parallel:
         - task: smoke-test-alertmanager
           attempts: 4

--- a/ci/tasks/wait-ecs-services-stable.yml
+++ b/ci/tasks/wait-ecs-services-stable.yml
@@ -1,0 +1,27 @@
+platform: linux
+inputs:
+  - name: terraform-outputs
+params:
+  DEPLOYER_ARN:
+  TERRAFORM_VAR:
+  AWS_REGION: 'eu-west-1'
+  AWS_DEFAULT_REGION: 'eu-west-1'
+run:
+  path: bash
+  args:
+    - -eu
+    - -c
+    - |
+      echo "configuring aws client..."
+      eval $(assume-role "${DEPLOYER_ARN}")
+
+      jq -c '.[env.TERRAFORM_VAR].value | to_entries | .[]' terraform-outputs/terraform-outputs.json | while read entry ; do
+        CLUSTER="$(echo ${entry} | jq -r '.key')"
+        SERVICES="$(echo ${entry} | jq -r '.value | join(" ")')"
+
+        echo "Waiting for services ${SERVICES} of cluster ${CLUSTER} to be stable..."
+
+        aws ecs wait services-stable \
+          --cluster "${CLUSTER}" \
+          --services ${SERVICES}
+      done

--- a/terraform/modules/alertmanager/main.tf
+++ b/terraform/modules/alertmanager/main.tf
@@ -111,3 +111,11 @@ resource "aws_cloudwatch_log_group" "task_logs" {
 }
 
 ## Outputs
+
+output "ecs_clusters_services" {
+  description = "Names of ECS services created, listed by ECS cluster name"
+  value = transpose({
+    for _, service in aws_ecs_service.alertmanager_alb:
+    service.name => [ service.cluster ]
+  })
+}

--- a/terraform/projects/alertmanager-production/main.tf
+++ b/terraform/projects/alertmanager-production/main.tf
@@ -91,3 +91,6 @@ module "alertmanager" {
   ]
 }
 
+output "alertmanager_ecs_clusters_services" {
+  value = module.alertmanager.ecs_clusters_services
+}

--- a/terraform/projects/alertmanager-staging/main.tf
+++ b/terraform/projects/alertmanager-staging/main.tf
@@ -53,3 +53,6 @@ module "alertmanager" {
   observe_cronitor    = data.pass_password.cronitor_staging_url.password
 }
 
+output "alertmanager_ecs_clusters_services" {
+  value = module.alertmanager.ecs_clusters_services
+}


### PR DESCRIPTION
The hope is that a broken deployment will be caught even if the current release doesn't cause an ECS deployment.

This does seem to have the desired effect in practise when the deployment is deliberately broken.