### PR TITLE
infra-networking terraform: pin terraform-aws-modules/vpc/aws to 3.5.0

### DIFF
--- a/terraform/modules/infra-networking/main.tf
+++ b/terraform/modules/infra-networking/main.tf
@@ -46,6 +46,7 @@ data "aws_availability_zones" "available" {}
 
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
+  version = "3.5.0"
 
   name = "observe-${var.environment}"
   cidr = "10.0.0.0/16"


### PR DESCRIPTION
This is the last version with a minimum aws provider version of 3.15 which is what we've used successfully for a long time. The "latest" version now mandates 3.38, which conflicts with our other provider pinning.